### PR TITLE
fix(oauth): durable grant revocation on every bearer path and atomic token-artifact consumption (SEC-139, SEC-140)

### DIFF
--- a/apps/api/src/__tests__/integration/oauth-revocation-service.integration.test.ts
+++ b/apps/api/src/__tests__/integration/oauth-revocation-service.integration.test.ts
@@ -29,6 +29,8 @@ import {
   oauthSessions,
 } from '../../db/schema';
 import { revokeClientFamilies } from '../../oauth/revocationService';
+import { BreezeOidcAdapter } from '../../oauth/adapter';
+import { isOAuthGrantDurablyActive } from '../../oauth/grantStatus';
 import { isGrantRevoked } from '../../oauth/revocationCache';
 import { createOrganization, createPartner, createUser } from './db-utils';
 import { getTestDb } from './setup';
@@ -84,6 +86,15 @@ describe('revokeClientFamilies (integration)', () => {
     await getTestDb().insert(oauthClientPartnerGrants).values({ clientId, partnerId: partner.id });
     // Grant with NO refresh token — the auth-code access-token path.
     await seedGrant({ id: 'grant-code-only', clientId, accountId: user.id, partnerId: partner.id, orgId: org.id });
+    await getTestDb().insert(oauthAuthorizationCodes).values({
+      id: 'live-code-before-disconnect',
+      userId: user.id,
+      clientId,
+      partnerId: partner.id,
+      orgId: org.id,
+      payload: { accountId: user.id, clientId, grantId: 'grant-code-only' },
+      expiresAt: future(),
+    });
 
     const result = await revokeClientFamilies(clientId, { kind: 'partner', partnerId: partner.id });
 
@@ -91,6 +102,16 @@ describe('revokeClientFamilies (integration)', () => {
     expect((await grantRow('grant-code-only'))?.revokedAt).not.toBeNull();
     // Grant marker is live — bearer auth would reject an already-minted JWT.
     expect(await isGrantRevoked('grant-code-only')).toBe(true);
+    expect(await isOAuthGrantDurablyActive('grant-code-only')).toBe(false);
+    const [code] = await getTestDb()
+      .select({ consumedAt: oauthAuthorizationCodes.consumedAt })
+      .from(oauthAuthorizationCodes)
+      .where(eq(oauthAuthorizationCodes.id, 'live-code-before-disconnect'));
+    expect(code?.consumedAt).not.toBeNull();
+    await expect(
+      new BreezeOidcAdapter('AuthorizationCode').find('live-code-before-disconnect'),
+    ).resolves.toBeUndefined();
+    await expect(new BreezeOidcAdapter('Grant').find('grant-code-only')).resolves.toBeUndefined();
     // This partner's join row is gone; the shared client row stays.
     const join = await getTestDb().select().from(oauthClientPartnerGrants).where(eq(oauthClientPartnerGrants.clientId, clientId));
     expect(join).toHaveLength(0);
@@ -122,6 +143,8 @@ describe('revokeClientFamilies (integration)', () => {
     expect((await grantRow('grant-p2'))?.revokedAt).toBeNull();
     expect(await isGrantRevoked('grant-p1')).toBe(true);
     expect(await isGrantRevoked('grant-p2')).toBe(false);
+    expect(await isOAuthGrantDurablyActive('grant-p1')).toBe(false);
+    expect(await isOAuthGrantDurablyActive('grant-p2')).toBe(true);
     const joins = await getTestDb().select({ partnerId: oauthClientPartnerGrants.partnerId }).from(oauthClientPartnerGrants).where(eq(oauthClientPartnerGrants.clientId, clientId));
     expect(joins.map((j) => j.partnerId)).toEqual([p2.id]);
   });

--- a/apps/api/src/__tests__/integration/oauth-token-consume-race.integration.test.ts
+++ b/apps/api/src/__tests__/integration/oauth-token-consume-race.integration.test.ts
@@ -18,7 +18,7 @@ import type { HttpBindings } from '@hono/node-server';
 import postgres, { type Sql } from 'postgres';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
-import { oauthAuthorizationCodes, oauthRefreshTokens } from '../../db/schema';
+import { oauthAuthorizationCodes, oauthGrants, oauthRefreshTokens } from '../../db/schema';
 import { createAccessToken } from '../../services/jwt';
 import { assignUserToPartner, createPartner, createRole, createUser } from './db-utils';
 import { getTestDb } from './setup';
@@ -301,5 +301,61 @@ describe.skipIf(!SHOULD_RUN)('OAuth token consume is atomic across concurrent ex
       ));
     expect(allFamilyRows).toHaveLength(2);
     expect(activeFamilyRows).toHaveLength(1);
+  }, 30_000);
+
+  it('refresh-token reuse durably revokes the Grant and its whole family, not just a Redis marker', async () => {
+    // Steal-and-replay, sequentially (no lock needed): rotate once legitimately,
+    // then present the burned RT again. The eager Redis grant marker expires
+    // after GRANT_REVOCATION_TTL_SECONDS; if that is the only thing recording
+    // the compromise, the surviving sibling starts working again when it
+    // lapses. Assert the DURABLE half landed.
+    const issued = await issueAuthorizationCode(live.url, 'reuse');
+    const initial = await exchangeCode(live.url, issued);
+    expect(initial.status).toBe(200);
+    const first = await initial.json() as { refresh_token: string };
+
+    const rotated = await exchangeRefresh(live.url, issued.clientId, first.refresh_token);
+    expect(rotated.status).toBe(200);
+    const second = await rotated.json() as { refresh_token: string };
+
+    const rotatedRowId = createHash('sha256').update(second.refresh_token).digest('hex');
+    const [rotatedRow] = await getTestDb()
+      .select({ payload: oauthRefreshTokens.payload })
+      .from(oauthRefreshTokens)
+      .where(eq(oauthRefreshTokens.id, rotatedRowId));
+    const grantId = (rotatedRow?.payload as { grantId?: string } | null)?.grantId;
+    expect(grantId).toEqual(expect.any(String));
+
+    // Precondition: the surviving sibling is live right now.
+    const [beforeGrant] = await getTestDb()
+      .select({ revokedAt: oauthGrants.revokedAt })
+      .from(oauthGrants)
+      .where(eq(oauthGrants.id, grantId!));
+    expect(beforeGrant?.revokedAt).toBeNull();
+
+    // Replay the burned token.
+    const replay = await exchangeRefresh(live.url, issued.clientId, first.refresh_token);
+    expect(replay.status).toBe(400);
+    await expect(replay.json()).resolves.toMatchObject({ error: 'invalid_grant' });
+
+    const [afterGrant] = await getTestDb()
+      .select({ revokedAt: oauthGrants.revokedAt, revokedReason: oauthGrants.revokedReason })
+      .from(oauthGrants)
+      .where(eq(oauthGrants.id, grantId!));
+    expect(afterGrant?.revokedAt).toBeInstanceOf(Date);
+    expect(afterGrant?.revokedReason).toBe('refresh-token-reuse');
+
+    const activeSiblings = await getTestDb()
+      .select({ id: oauthRefreshTokens.id })
+      .from(oauthRefreshTokens)
+      .where(and(
+        eq(oauthRefreshTokens.clientId, issued.clientId),
+        isNull(oauthRefreshTokens.revokedAt),
+      ));
+    expect(activeSiblings).toHaveLength(0);
+
+    // And the surviving sibling is dead on the wire too, not merely flagged.
+    const siblingUse = await exchangeRefresh(live.url, issued.clientId, second.refresh_token);
+    expect(siblingUse.status).toBe(400);
   }, 30_000);
 });

--- a/apps/api/src/__tests__/integration/oauth-token-consume-race.integration.test.ts
+++ b/apps/api/src/__tests__/integration/oauth-token-consume-race.integration.test.ts
@@ -1,0 +1,305 @@
+/**
+ * OAuth single-use token consumption against the real provider and PostgreSQL.
+ *
+ * The holder transaction locks the exact token row before either request
+ * starts. Ordinary provider reads remain non-blocking under MVCC, so both
+ * exchanges reach their consume UPDATE and queue behind the holder. Observing
+ * both blocked backends makes the security interleaving deterministic: after
+ * release, exactly one compare-and-set may claim the artifact.
+ */
+import './setup';
+import './loadEnv';
+
+import { createHash, randomBytes, randomUUID } from 'node:crypto';
+import { serve, type ServerType } from '@hono/node-server';
+import { and, desc, eq, isNull, sql } from 'drizzle-orm';
+import { Hono } from 'hono';
+import type { HttpBindings } from '@hono/node-server';
+import postgres, { type Sql } from 'postgres';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { oauthAuthorizationCodes, oauthRefreshTokens } from '../../db/schema';
+import { createAccessToken } from '../../services/jwt';
+import { assignUserToPartner, createPartner, createRole, createUser } from './db-utils';
+import { getTestDb } from './setup';
+
+const SHOULD_RUN = Boolean(process.env.DATABASE_URL);
+const DATABASE_URL = process.env.DATABASE_URL
+  ?? 'postgresql://breeze_test:breeze_test@localhost:5433/breeze_test';
+
+type LiveServer = { server: ServerType; url: string };
+type IssuedCode = {
+  clientId: string;
+  code: string;
+  codeRowId: string;
+  verifier: string;
+  redirectUri: string;
+};
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => { resolve = done; });
+  return { promise, resolve };
+}
+
+function b64url(bytes: Buffer | Uint8Array): string {
+  return Buffer.from(bytes).toString('base64url');
+}
+
+async function startApi(port: number): Promise<LiveServer> {
+  const { oauthRoutes } = await import('../../routes/oauth');
+  const { oauthInteractionRoutes } = await import('../../routes/oauthInteraction');
+  const app = new Hono<{ Bindings: HttpBindings }>();
+  app.route('/oauth', oauthRoutes);
+  app.route('/api/v1/oauth', oauthInteractionRoutes);
+  return {
+    server: serve({ fetch: app.fetch, port, hostname: '127.0.0.1' }),
+    url: `http://127.0.0.1:${port}`,
+  };
+}
+
+async function stopApi(live: LiveServer): Promise<void> {
+  await new Promise<void>((resolve) => live.server.close(() => resolve()));
+}
+
+async function issueAuthorizationCode(baseUrl: string, label: string): Promise<IssuedCode> {
+  const partner = await createPartner({ name: `OAuth consume race ${label} ${randomUUID()}` });
+  const role = await createRole({ scope: 'partner', partnerId: partner.id });
+  const user = await createUser({
+    partnerId: partner.id,
+    email: `oauth-consume-${label}-${randomUUID()}@example.test`,
+  });
+  await assignUserToPartner(user.id, partner.id, role.id, 'all');
+  const dashboardJwt = await createAccessToken({
+    sub: user.id,
+    email: user.email,
+    roleId: role.id,
+    orgId: null,
+    partnerId: partner.id,
+    scope: 'partner',
+    mfa: false,
+    aep: 1,
+    mep: 1,
+    sid: `oauth-consume-${label}`,
+  });
+
+  const redirectUri = `https://example.com/oauth/${label}/callback`;
+  const registration = await fetch(`${baseUrl}/oauth/reg`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      client_name: `consume-race-${label}`,
+      redirect_uris: [redirectUri],
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+      token_endpoint_auth_method: 'none',
+      scope: 'openid offline_access mcp:read',
+      id_token_signed_response_alg: 'EdDSA',
+    }),
+  });
+  expect(registration.status).toBe(201);
+  const { client_id: clientId } = await registration.json() as { client_id: string };
+
+  const verifier = b64url(randomBytes(32));
+  const challenge = b64url(createHash('sha256').update(verifier).digest());
+  const auth = await fetch(`${baseUrl}/oauth/auth?${new URLSearchParams({
+    response_type: 'code',
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    scope: 'openid offline_access mcp:read',
+    code_challenge: challenge,
+    code_challenge_method: 'S256',
+    resource: process.env.OAUTH_RESOURCE_URL!,
+    state: `consume-${label}`,
+  })}`, { redirect: 'manual' });
+  expect([302, 303]).toContain(auth.status);
+  const interactionUrl = new URL(auth.headers.get('location') ?? '', baseUrl);
+  const uid = interactionUrl.searchParams.get('uid');
+  expect(uid).toBeTruthy();
+  const cookies = (auth.headers.getSetCookie?.() ?? []).map((value) => value.split(';')[0]).join('; ');
+
+  const consent = await fetch(`${baseUrl}/api/v1/oauth/interaction/${uid}/consent`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', authorization: `Bearer ${dashboardJwt}` },
+    body: JSON.stringify({ partner_id: partner.id, approve: true }),
+  });
+  expect(consent.status).toBe(200);
+  const { redirectTo } = await consent.json() as { redirectTo: string };
+  const resume = await fetch(redirectTo, { redirect: 'manual', headers: { cookie: cookies } });
+  expect([302, 303]).toContain(resume.status);
+  const code = new URL(resume.headers.get('location') ?? '').searchParams.get('code');
+  expect(code).toBeTruthy();
+
+  const [stored] = await getTestDb()
+    .select({ id: oauthAuthorizationCodes.id })
+    .from(oauthAuthorizationCodes)
+    .where(eq(oauthAuthorizationCodes.clientId, clientId))
+    .orderBy(desc(oauthAuthorizationCodes.createdAt))
+    .limit(1);
+  if (!stored) throw new Error('provider did not persist the authorization code');
+  return { clientId, code: code!, codeRowId: stored.id, verifier, redirectUri };
+}
+
+function exchangeCode(baseUrl: string, issued: IssuedCode): Promise<Response> {
+  return fetch(`${baseUrl}/oauth/token`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'authorization_code',
+      code: issued.code,
+      client_id: issued.clientId,
+      code_verifier: issued.verifier,
+      redirect_uri: issued.redirectUri,
+      resource: process.env.OAUTH_RESOURCE_URL!,
+    }),
+  });
+}
+
+function exchangeRefresh(baseUrl: string, clientId: string, refreshToken: string): Promise<Response> {
+  return fetch(`${baseUrl}/oauth/token`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken,
+      client_id: clientId,
+      resource: process.env.OAUTH_RESOURCE_URL!,
+    }),
+  });
+}
+
+async function waitForBlockedBackends(blockerPid: number, expected: number): Promise<void> {
+  const deadline = Date.now() + 10_000;
+  for (;;) {
+    // Recursive traversal includes the second exchange waiting behind the
+    // first exchange, which itself waits directly behind the holder.
+    const rows = await getTestDb().execute<{ waiting: number }>(sql`
+        WITH RECURSIVE wait_chain(pid) AS (
+          SELECT pid
+          FROM pg_catalog.pg_stat_activity
+          WHERE datname = current_database()
+            AND state = 'active'
+            AND ${blockerPid} = ANY(pg_catalog.pg_blocking_pids(pid))
+          UNION
+          SELECT activity.pid
+          FROM pg_catalog.pg_stat_activity activity
+          JOIN wait_chain blocker
+            ON blocker.pid = ANY(pg_catalog.pg_blocking_pids(activity.pid))
+          WHERE activity.datname = current_database()
+            AND activity.state = 'active'
+        )
+        SELECT count(*)::int AS waiting FROM wait_chain
+      `);
+    if ((rows[0]?.waiting ?? 0) >= expected) return;
+    if (Date.now() >= deadline) throw new Error('OAuth exchanges did not reach the consume-row barrier');
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+}
+
+async function raceBehindRowLock(
+  lock: (tx: Sql) => Promise<unknown>,
+  racers: () => [Promise<Response>, Promise<Response>],
+): Promise<Response[]> {
+  const holder = postgres(DATABASE_URL, { max: 1, onnotice: () => {} });
+  const held = deferred();
+  const release = deferred();
+  let holderPid = 0;
+  let holderWork: Promise<void> | undefined;
+  try {
+    holderWork = holder.begin(async (tx) => {
+      const [backend] = await tx<{ pid: number }[]>`SELECT pg_backend_pid()::int AS pid`;
+      holderPid = backend!.pid;
+      await lock(tx as unknown as Sql);
+      held.resolve();
+      await release.promise;
+    });
+    await held.promise;
+    const started = racers();
+    await waitForBlockedBackends(holderPid, 2);
+    release.resolve();
+    await holderWork;
+    return await Promise.all(started);
+  } finally {
+    release.resolve();
+    if (holderWork) await Promise.allSettled([holderWork]);
+    await holder.end({ timeout: 1 });
+  }
+}
+
+async function expectSingleWinner(responses: Response[]): Promise<Record<string, unknown>> {
+  const winners = responses.filter((response) => response.status === 200);
+  const losers = responses.filter((response) => response.status !== 200);
+  expect(winners).toHaveLength(1);
+  expect(losers).toHaveLength(1);
+  expect(losers[0]!.status).toBe(400);
+  await expect(losers[0]!.json()).resolves.toMatchObject({ error: 'invalid_grant' });
+  return await winners[0]!.json() as Record<string, unknown>;
+}
+
+describe.skipIf(!SHOULD_RUN)('OAuth token consume is atomic across concurrent exchanges', () => {
+  let live: LiveServer;
+
+  beforeAll(async () => {
+    const port = 35000 + Math.floor(Math.random() * 2000);
+    process.env.OAUTH_ISSUER = `http://127.0.0.1:${port}`;
+    process.env.OAUTH_RESOURCE_URL = `${process.env.OAUTH_ISSUER}/api/v1/mcp/message`;
+    process.env.OAUTH_CONSENT_URL_BASE = process.env.OAUTH_ISSUER;
+    vi.resetModules();
+    live = await startApi(port);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }, 30_000);
+
+  afterAll(async () => {
+    if (live) await stopApi(live);
+  });
+
+  it('allows exactly one authorization-code exchange after both requests read the fresh code', async () => {
+    const issued = await issueAuthorizationCode(live.url, 'code');
+    const responses = await raceBehindRowLock(
+      (tx) => tx`SELECT id FROM oauth_authorization_codes WHERE id = ${issued.codeRowId} FOR UPDATE`,
+      () => [exchangeCode(live.url, issued), exchangeCode(live.url, issued)],
+    );
+    const winner = await expectSingleWinner(responses);
+    expect(winner.access_token).toEqual(expect.any(String));
+    expect(winner.refresh_token).toEqual(expect.any(String));
+    const successors = await getTestDb().select({ id: oauthRefreshTokens.id })
+      .from(oauthRefreshTokens)
+      .where(eq(oauthRefreshTokens.clientId, issued.clientId));
+    expect(successors).toHaveLength(1);
+  }, 30_000);
+
+  it('allows exactly one rotating refresh exchange after both requests read the fresh token', async () => {
+    const issued = await issueAuthorizationCode(live.url, 'refresh');
+    const initial = await exchangeCode(live.url, issued);
+    expect(initial.status).toBe(200);
+    const initialBody = await initial.json() as { refresh_token: string };
+    const refreshRowId = createHash('sha256').update(initialBody.refresh_token).digest('hex');
+    const [stored] = await getTestDb().select({ id: oauthRefreshTokens.id })
+      .from(oauthRefreshTokens)
+      .where(eq(oauthRefreshTokens.id, refreshRowId));
+    expect(stored).toEqual({ id: refreshRowId });
+
+    const responses = await raceBehindRowLock(
+      (tx) => tx`SELECT id FROM oauth_refresh_tokens WHERE id = ${refreshRowId} FOR UPDATE`,
+      () => [
+        exchangeRefresh(live.url, issued.clientId, initialBody.refresh_token),
+        exchangeRefresh(live.url, issued.clientId, initialBody.refresh_token),
+      ],
+    );
+    const winner = await expectSingleWinner(responses);
+    expect(winner.access_token).toEqual(expect.any(String));
+    expect(winner.refresh_token).toEqual(expect.any(String));
+    expect(winner.refresh_token).not.toBe(initialBody.refresh_token);
+    const allFamilyRows = await getTestDb().select({ id: oauthRefreshTokens.id })
+      .from(oauthRefreshTokens)
+      .where(eq(oauthRefreshTokens.clientId, issued.clientId));
+    const activeFamilyRows = await getTestDb().select({ id: oauthRefreshTokens.id })
+      .from(oauthRefreshTokens)
+      .where(and(
+        eq(oauthRefreshTokens.clientId, issued.clientId),
+        isNull(oauthRefreshTokens.revokedAt),
+      ));
+    expect(allFamilyRows).toHaveLength(2);
+    expect(activeFamilyRows).toHaveLength(1);
+  }, 30_000);
+});

--- a/apps/api/src/middleware/bearerTokenAuth.test.ts
+++ b/apps/api/src/middleware/bearerTokenAuth.test.ts
@@ -34,6 +34,9 @@ const dbState = vi.hoisted(() => ({
   wherePredicates: [] as unknown[],
   liveUserRows: [] as unknown[],
   liveUserError: null as unknown,
+  // Every (table, on-condition) pair the live-user query joined. Bearer
+  // admission must resolve the Grant in THAT query, not a second round-trip.
+  liveUserJoins: [] as { table: unknown; on: unknown }[],
 }));
 
 vi.mock('../db', () => {
@@ -51,7 +54,11 @@ vi.mock('../db', () => {
       thenable.limit = limit;
       return thenable;
     });
-    const from = vi.fn(() => ({ where, limit }));
+    const leftJoin = vi.fn((table: unknown, on: unknown) => {
+      if (!collectPredicate) dbState.liveUserJoins.push({ table, on });
+      return { where, limit, leftJoin };
+    });
+    const from = vi.fn(() => ({ where, limit, leftJoin }));
     return { from };
   }
   return {
@@ -75,9 +82,13 @@ vi.mock('../oauth/revocationCache', () => ({
   isGrantRevoked: vi.fn().mockResolvedValue(false),
 }));
 
-vi.mock('../oauth/grantStatus', () => ({
-  isOAuthGrantDurablyActive: vi.fn().mockResolvedValue(true),
-}));
+vi.mock('../oauth/grantStatus', async () => {
+  // Keep the REAL predicate builder — the join-condition assertions below are
+  // only meaningful if the middleware composes the genuine active-Grant
+  // condition rather than a test double.
+  const actual = await vi.importActual<typeof import('../oauth/grantStatus')>('../oauth/grantStatus');
+  return { activeGrantCondition: actual.activeGrantCondition };
+});
 
 vi.mock('../services/tenantStatus', () => ({
   TenantInactiveError: class TenantInactiveError extends Error {},
@@ -107,8 +118,8 @@ vi.mock('jose', async () => {
 
 import { importJWK, jwtVerify, type JWK } from 'jose';
 import { db, withDbAccessContext, withSystemDbAccessContext } from '../db';
+import { oauthGrants } from '../db/schema';
 import { isGrantRevoked, isJtiRevoked } from '../oauth/revocationCache';
-import { isOAuthGrantDurablyActive } from '../oauth/grantStatus';
 import { assertActiveTenantContext, TenantInactiveError } from '../services/tenantStatus';
 import { generateTestKeypair, signTestJwt, type TestKeypair } from '../oauth/testHelpers';
 import {
@@ -120,6 +131,34 @@ import {
 type TestContext = Context & {
   get: (key: string) => unknown;
 };
+
+/**
+ * Reduce a drizzle clause to the columns it names and the literal SQL it
+ * renders, so the join condition can be asserted structurally instead of by a
+ * string match that would also see bound values.
+ */
+function inspectClause(clause: unknown): { columns: string[]; sql: string } {
+  const columns: string[] = [];
+  const fragments: string[] = [];
+  const visit = (node: unknown) => {
+    if (!node || typeof node !== 'object') return;
+    const chunks = (node as { queryChunks?: unknown[] }).queryChunks;
+    if (Array.isArray(chunks)) {
+      chunks.forEach(visit);
+      return;
+    }
+    const { name, table, value } = node as { name?: unknown; table?: unknown; value?: unknown };
+    if (typeof name === 'string' && table) {
+      columns.push(name);
+      return;
+    }
+    if (Array.isArray(value) && value.every((v) => typeof v === 'string')) {
+      fragments.push(...(value as string[]));
+    }
+  };
+  visit(clause);
+  return { columns, sql: fragments.join('').toLowerCase().replace(/\s+/g, ' ') };
+}
 
 const issuer = 'https://issuer.test';
 const audience = 'https://issuer.test/mcp/server';
@@ -199,7 +238,8 @@ describe('bearerTokenAuthMiddleware', () => {
     vi.clearAllMocks();
     dbState.rows = [];
     dbState.wherePredicates = [];
-    dbState.liveUserRows = [{ id: userId, status: 'active', authEpoch: 1 }];
+    dbState.liveUserJoins = [];
+    dbState.liveUserRows = [{ id: userId, status: 'active', authEpoch: 1, grantActive: true }];
     dbState.liveUserError = null;
     _resetJwksCacheForTests();
     envState.issuer = issuer;
@@ -308,7 +348,7 @@ describe('bearerTokenAuthMiddleware', () => {
   });
 
   it('authorizes a matching live auth epoch before consulting Redis', async () => {
-    dbState.liveUserRows = [{ id: userId, status: 'active', authEpoch: 6 }];
+    dbState.liveUserRows = [{ id: userId, status: 'active', authEpoch: 6, grantActive: true }];
     const token = await mintToken({
       sub: userId,
       partner_id: partnerId,
@@ -361,7 +401,7 @@ describe('bearerTokenAuthMiddleware', () => {
 
   it('accepts a claimless compatibility token before the deadline only after an active live lookup', async () => {
     envState.authEpochEnforceAfter = new Date('2099-01-01T00:00:00.000Z');
-    dbState.liveUserRows = [{ id: userId, status: 'active', authEpoch: 12 }];
+    dbState.liveUserRows = [{ id: userId, status: 'active', authEpoch: 12, grantActive: true }];
     const result = await assertLiveOAuthUser(
       { sub: userId },
       new Date('2098-12-31T23:59:59.999Z'),
@@ -372,13 +412,28 @@ describe('bearerTokenAuthMiddleware', () => {
       userId,
       authEpoch: 12,
       legacyClaim: true,
+      // No grant id was asked about, so the join answers nothing. `null` is
+      // "not asked" and must stay distinct from `false` ("asked, and dead").
+      grantActive: null,
     });
     expect(vi.mocked(db.select)).toHaveBeenCalled();
   });
 
+  it('reports grantActive from the joined row when a grant id is supplied', async () => {
+    dbState.liveUserRows = [{ id: userId, status: 'active', authEpoch: 3, grantActive: false }];
+    await expect(
+      assertLiveOAuthUser({ sub: userId, auth_epoch: 3 }, new Date(), { grantId: 'grant-dead' }),
+    ).resolves.toEqual(expect.objectContaining({ ok: true, grantActive: false }));
+
+    dbState.liveUserRows = [{ id: userId, status: 'active', authEpoch: 3, grantActive: true }];
+    await expect(
+      assertLiveOAuthUser({ sub: userId, auth_epoch: 3 }, new Date(), { grantId: 'grant-live' }),
+    ).resolves.toEqual(expect.objectContaining({ ok: true, grantActive: true }));
+  });
+
   it('rejects a claimless token exactly at and after the compatibility deadline', async () => {
     envState.authEpochEnforceAfter = new Date('2026-08-06T00:30:00.000Z');
-    dbState.liveUserRows = [{ id: userId, status: 'active', authEpoch: 12 }];
+    dbState.liveUserRows = [{ id: userId, status: 'active', authEpoch: 12, grantActive: true }];
 
     await expect(
       assertLiveOAuthUser({ sub: userId }, new Date('2026-08-06T00:30:00.000Z')),
@@ -642,7 +697,9 @@ describe('bearerTokenAuthMiddleware', () => {
   });
 
   it('rejects a bearer whose Redis marker expired but whose Grant is durably revoked', async () => {
-    vi.mocked(isOAuthGrantDurablyActive).mockResolvedValueOnce(false);
+    // Redis says nothing (marker lapsed); the durable join says the Grant is
+    // gone. The durable answer is the authority.
+    dbState.liveUserRows = [{ id: userId, status: 'active', authEpoch: 1, grantActive: false }];
     const token = await mintToken({
       sub: userId,
       partner_id: partnerId,
@@ -659,7 +716,35 @@ describe('bearerTokenAuthMiddleware', () => {
       next,
     );
     expect(isGrantRevoked).toHaveBeenCalledWith('durably-revoked-grant');
-    expect(isOAuthGrantDurablyActive).toHaveBeenCalledWith('durably-revoked-grant');
+  });
+
+  it('resolves the durable Grant in the SAME query as the live user (one round-trip)', async () => {
+    // Two sequential system-context queries per accepted bearer doubled pool
+    // pressure on the hottest OAuth path for no isolation benefit.
+    const token = await mintToken({
+      sub: userId,
+      partner_id: partnerId,
+      org_id: orgId,
+      scope: 'mcp:read',
+      jti: 'single-roundtrip-jti',
+      grant_id: 'grant-single-roundtrip',
+    });
+    const next = vi.fn();
+
+    await bearerTokenAuthMiddleware(createContext({ Authorization: `Bearer ${token}` }), next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(dbState.liveUserJoins).toHaveLength(1);
+    const join = dbState.liveUserJoins[0]!;
+    expect(join.table).toBe(oauthGrants);
+    const { columns, sql } = inspectClause(join.on);
+    expect(columns).toEqual(expect.arrayContaining([
+      oauthGrants.id.name,
+      oauthGrants.revokedAt.name,
+      oauthGrants.expiresAt.name,
+    ]));
+    expect(sql).toContain('is null');
+    expect(sql).toContain('>=');
   });
 
   it('rejects a bearer without a durable Grant identifier', async () => {
@@ -681,7 +766,9 @@ describe('bearerTokenAuthMiddleware', () => {
   });
 
   it('fails closed with 503 when durable Grant status cannot be read', async () => {
-    vi.mocked(isOAuthGrantDurablyActive).mockRejectedValueOnce(new Error('database unavailable'));
+    // The Grant now rides along in the live-user query, so a failure there is
+    // uncertainty about BOTH facts. It must never be admitted as "active".
+    dbState.liveUserError = new Error('database unavailable');
     const token = await mintToken({
       sub: userId,
       partner_id: partnerId,
@@ -696,7 +783,7 @@ describe('bearerTokenAuthMiddleware', () => {
       bearerTokenAuthMiddleware(createContext({ Authorization: `Bearer ${token}` }), next),
     ).rejects.toMatchObject({
       status: 503,
-      message: 'oauth authorization temporarily unavailable',
+      message: expect.stringContaining('temporarily unavailable'),
     });
     expect(next).not.toHaveBeenCalled();
   });

--- a/apps/api/src/middleware/bearerTokenAuth.test.ts
+++ b/apps/api/src/middleware/bearerTokenAuth.test.ts
@@ -75,6 +75,10 @@ vi.mock('../oauth/revocationCache', () => ({
   isGrantRevoked: vi.fn().mockResolvedValue(false),
 }));
 
+vi.mock('../oauth/grantStatus', () => ({
+  isOAuthGrantDurablyActive: vi.fn().mockResolvedValue(true),
+}));
+
 vi.mock('../services/tenantStatus', () => ({
   TenantInactiveError: class TenantInactiveError extends Error {},
   assertActiveTenantContext: vi.fn().mockResolvedValue(undefined),
@@ -104,6 +108,7 @@ vi.mock('jose', async () => {
 import { importJWK, jwtVerify, type JWK } from 'jose';
 import { db, withDbAccessContext, withSystemDbAccessContext } from '../db';
 import { isGrantRevoked, isJtiRevoked } from '../oauth/revocationCache';
+import { isOAuthGrantDurablyActive } from '../oauth/grantStatus';
 import { assertActiveTenantContext, TenantInactiveError } from '../services/tenantStatus';
 import { generateTestKeypair, signTestJwt, type TestKeypair } from '../oauth/testHelpers';
 import {
@@ -140,7 +145,7 @@ function createContext(headers: Record<string, string | undefined> = {}): TestCo
 }
 
 async function mintToken(claims: Record<string, unknown>, opts: { issuer?: string; audience?: string; ttlSeconds?: number } = {}) {
-  return signTestJwt(keypair.privateJwk, keypair.kid, claims, {
+  return signTestJwt(keypair.privateJwk, keypair.kid, { grant_id: 'grant-test-default', ...claims }, {
     issuer: opts.issuer ?? issuer,
     audience: opts.audience ?? audience,
     ttlSeconds: opts.ttlSeconds,
@@ -542,6 +547,7 @@ describe('bearerTokenAuthMiddleware', () => {
     // ai:execute is NOT granted — that now requires mcp:execute.
     expect(c.get('apiKey')).toEqual({
       id: 'oauth:org-token-jti',
+      oauthGrantId: 'grant-test-default',
       orgId,
       partnerId,
       name: 'OAuth bearer',
@@ -635,6 +641,66 @@ describe('bearerTokenAuthMiddleware', () => {
     expect(next).toHaveBeenCalledOnce();
   });
 
+  it('rejects a bearer whose Redis marker expired but whose Grant is durably revoked', async () => {
+    vi.mocked(isOAuthGrantDurablyActive).mockResolvedValueOnce(false);
+    const token = await mintToken({
+      sub: userId,
+      partner_id: partnerId,
+      org_id: orgId,
+      scope: 'mcp:read',
+      jti: 'durable-revocation-jti',
+      grant_id: 'durably-revoked-grant',
+    });
+    const next = vi.fn();
+
+    await expectUnauthorized(
+      createContext({ Authorization: `Bearer ${token}` }),
+      'token revoked',
+      next,
+    );
+    expect(isGrantRevoked).toHaveBeenCalledWith('durably-revoked-grant');
+    expect(isOAuthGrantDurablyActive).toHaveBeenCalledWith('durably-revoked-grant');
+  });
+
+  it('rejects a bearer without a durable Grant identifier', async () => {
+    const token = await mintToken({
+      sub: userId,
+      partner_id: partnerId,
+      org_id: orgId,
+      scope: 'mcp:read',
+      jti: 'missing-grant-jti',
+      grant_id: undefined,
+    });
+    const next = vi.fn();
+
+    await expectUnauthorized(
+      createContext({ Authorization: `Bearer ${token}` }),
+      'token missing required claims',
+      next,
+    );
+  });
+
+  it('fails closed with 503 when durable Grant status cannot be read', async () => {
+    vi.mocked(isOAuthGrantDurablyActive).mockRejectedValueOnce(new Error('database unavailable'));
+    const token = await mintToken({
+      sub: userId,
+      partner_id: partnerId,
+      org_id: orgId,
+      scope: 'mcp:read',
+      jti: 'grant-read-error-jti',
+      grant_id: 'grant-read-error',
+    });
+    const next = vi.fn();
+
+    await expect(
+      bearerTokenAuthMiddleware(createContext({ Authorization: `Bearer ${token}` }), next),
+    ).rejects.toMatchObject({
+      status: 503,
+      message: 'oauth authorization temporarily unavailable',
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
   it('sets partner-scope API key context when org_id is null and resolves the partner org allowlist (M-B1)', async () => {
     // Defense-in-depth: partner-scope tokens used to pass `accessibleOrgIds: null`
     // to withDbAccessContext, which downstream auth.orgCondition() interprets
@@ -663,6 +729,7 @@ describe('bearerTokenAuthMiddleware', () => {
 
     expect(c.get('apiKey')).toEqual({
       id: 'oauth:partner-token-jti',
+      oauthGrantId: 'grant-test-default',
       orgId: null,
       partnerId,
       name: 'OAuth bearer',

--- a/apps/api/src/middleware/bearerTokenAuth.ts
+++ b/apps/api/src/middleware/bearerTokenAuth.ts
@@ -16,6 +16,7 @@ import {
 } from '../db';
 import { oauthClientBlocks, organizations, partnerUsers, users } from '../db/schema';
 import { isGrantRevoked, isJtiRevoked } from '../oauth/revocationCache';
+import { isOAuthGrantDurablyActive } from '../oauth/grantStatus';
 import { assertActiveTenantContext, TenantInactiveError } from '../services/tenantStatus';
 
 interface OAuthApiKeyContext {
@@ -376,7 +377,19 @@ export async function bearerTokenAuthMiddleware(c: Context, next: Next) {
   // Grant-wide revocation: when a refresh token is revoked or a connected app
   // is deleted, every access JWT minted from the same Grant must die. The
   // grant_id claim is set by buildExtraTokenClaims (see oauth/provider.ts).
-  if (typeof payload.grant_id === 'string' && await isGrantRevoked(payload.grant_id)) {
+  if (typeof payload.grant_id !== 'string' || payload.grant_id.length === 0) {
+    throw new HTTPException(401, { message: 'token missing required claims' });
+  }
+  if (await isGrantRevoked(payload.grant_id)) {
+    throw new HTTPException(401, { message: 'token revoked' });
+  }
+  let durablyActive: boolean;
+  try {
+    durablyActive = await isOAuthGrantDurablyActive(payload.grant_id);
+  } catch {
+    throw new HTTPException(503, { message: 'oauth authorization temporarily unavailable' });
+  }
+  if (!durablyActive) {
     throw new HTTPException(401, { message: 'token revoked' });
   }
   const clientIdClaim = typeof (payload as { client_id?: unknown }).client_id === 'string'

--- a/apps/api/src/middleware/bearerTokenAuth.ts
+++ b/apps/api/src/middleware/bearerTokenAuth.ts
@@ -2,7 +2,7 @@ import type { Context, Next } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import * as Sentry from '@sentry/node';
 import { createRemoteJWKSet, jwtVerify, type JWTPayload, type JWTVerifyResult } from 'jose';
-import { and, eq, gt, inArray, isNull, or } from 'drizzle-orm';
+import { and, eq, gt, inArray, isNull, or, sql } from 'drizzle-orm';
 import {
   OAUTH_AUTH_EPOCH_ENFORCE_AFTER,
   OAUTH_ISSUER,
@@ -14,9 +14,9 @@ import {
   withDbAccessContext,
   withSystemDbAccessContext,
 } from '../db';
-import { oauthClientBlocks, organizations, partnerUsers, users } from '../db/schema';
+import { oauthClientBlocks, oauthGrants, organizations, partnerUsers, users } from '../db/schema';
 import { isGrantRevoked, isJtiRevoked } from '../oauth/revocationCache';
-import { isOAuthGrantDurablyActive } from '../oauth/grantStatus';
+import { activeGrantCondition } from '../oauth/grantStatus';
 import { assertActiveTenantContext, TenantInactiveError } from '../services/tenantStatus';
 
 interface OAuthApiKeyContext {
@@ -35,7 +35,19 @@ interface OAuthApiKeyContext {
 let cachedJwks: ReturnType<typeof createRemoteJWKSet> | null = null;
 
 export type LiveOAuthUserResult =
-  | { ok: true; userId: string; authEpoch: number; legacyClaim: boolean }
+  | {
+      ok: true;
+      userId: string;
+      authEpoch: number;
+      legacyClaim: boolean;
+      /**
+       * Whether the `grant_id` passed in resolves to a live `oauth_grants`
+       * row. `null` when no grant id was supplied (nothing was asked).
+       * Resolved in the SAME query as the user so bearer admission stays a
+       * single system-context round-trip.
+       */
+      grantActive: boolean | null;
+    }
   | {
       ok: false;
       status: 401 | 503;
@@ -65,6 +77,7 @@ function recordLiveOAuthAuthorization(
 export async function assertLiveOAuthUser(
   payload: JWTPayload,
   now: Date,
+  opts: { grantId?: string | null } = {},
 ): Promise<LiveOAuthUserResult> {
   const userId = typeof payload.sub === 'string' && payload.sub.length > 0
     ? payload.sub
@@ -73,7 +86,17 @@ export async function assertLiveOAuthUser(
     return { ok: false, status: 401, reason: 'user_missing' };
   }
 
-  let liveUser: { id: string; status: string; authEpoch: number } | undefined;
+  const grantId = typeof opts.grantId === 'string' && opts.grantId.length > 0 ? opts.grantId : null;
+
+  // ONE system-context round-trip proves both live facts bearer admission
+  // needs: the user is still active at the claimed auth epoch, and the Grant
+  // the token was minted under is still durably live. They were two
+  // sequential queries; on an OAuth-heavy tenant that doubled the per-request
+  // pool pressure on an already hot path for no isolation benefit — both reads
+  // are in the same system context anyway. The LEFT JOIN keeps a missing or
+  // revoked Grant as a row with a NULL join side rather than no row at all, so
+  // "user gone" stays distinguishable from "grant dead".
+  let liveUser: { id: string; status: string; authEpoch: number; grantActive: boolean } | undefined;
   try {
     [liveUser] = await runOutsideDbContext(() =>
       withSystemDbAccessContext(() =>
@@ -82,8 +105,13 @@ export async function assertLiveOAuthUser(
             id: users.id,
             status: users.status,
             authEpoch: users.authEpoch,
+            grantActive: sql<boolean>`${oauthGrants.id} IS NOT NULL`,
           })
           .from(users)
+          .leftJoin(
+            oauthGrants,
+            grantId ? activeGrantCondition(grantId, now) : sql`false`,
+          )
           .where(eq(users.id, userId))
           .limit(1),
       ),
@@ -112,6 +140,7 @@ export async function assertLiveOAuthUser(
       userId,
       authEpoch: liveUser.authEpoch,
       legacyClaim: true,
+      grantActive: grantId ? liveUser.grantActive : null,
     };
   }
 
@@ -128,6 +157,7 @@ export async function assertLiveOAuthUser(
     userId,
     authEpoch: liveUser.authEpoch,
     legacyClaim: false,
+    grantActive: grantId ? liveUser.grantActive : null,
   };
 }
 
@@ -361,7 +391,12 @@ export async function bearerTokenAuthMiddleware(c: Context, next: Next) {
     throw new HTTPException(401, { message: 'token missing required claims' });
   }
 
-  const liveUser = await assertLiveOAuthUser(payload, new Date());
+  // Read the claim now (not to reject on it yet — rejection order below is
+  // unchanged) so the Grant's durable state resolves in the same query.
+  const grantIdClaim = typeof payload.grant_id === 'string' && payload.grant_id.length > 0
+    ? payload.grant_id
+    : null;
+  const liveUser = await assertLiveOAuthUser(payload, new Date(), { grantId: grantIdClaim });
   if (!liveUser.ok) {
     recordLiveOAuthAuthorization(liveUser.reason, payload.auth_epoch === undefined);
     const message = liveUser.status === 503
@@ -377,19 +412,17 @@ export async function bearerTokenAuthMiddleware(c: Context, next: Next) {
   // Grant-wide revocation: when a refresh token is revoked or a connected app
   // is deleted, every access JWT minted from the same Grant must die. The
   // grant_id claim is set by buildExtraTokenClaims (see oauth/provider.ts).
-  if (typeof payload.grant_id !== 'string' || payload.grant_id.length === 0) {
+  if (!grantIdClaim) {
     throw new HTTPException(401, { message: 'token missing required claims' });
   }
-  if (await isGrantRevoked(payload.grant_id)) {
+  // Redis first (eager, cheap, covers the window before a durable sweep
+  // lands), then the durable answer already fetched alongside the user. A DB
+  // failure never reaches here as "active": assertLiveOAuthUser has already
+  // returned 503 for it, so uncertainty is fail-closed on both halves.
+  if (await isGrantRevoked(grantIdClaim)) {
     throw new HTTPException(401, { message: 'token revoked' });
   }
-  let durablyActive: boolean;
-  try {
-    durablyActive = await isOAuthGrantDurablyActive(payload.grant_id);
-  } catch {
-    throw new HTTPException(503, { message: 'oauth authorization temporarily unavailable' });
-  }
-  if (!durablyActive) {
+  if (!liveUser.grantActive) {
     throw new HTTPException(401, { message: 'token revoked' });
   }
   const clientIdClaim = typeof (payload as { client_id?: unknown }).client_id === 'string'

--- a/apps/api/src/oauth/adapter.test.ts
+++ b/apps/api/src/oauth/adapter.test.ts
@@ -10,7 +10,10 @@ import {
 } from './adapter';
 import { revokeGrant, revokeJti } from './revocationCache';
 import { assertActiveTenantContext, TenantInactiveError } from '../services/tenantStatus';
-import { isOAuthGrantActiveInCurrentDbContext } from './grantStatus';
+import {
+  isOAuthGrantActiveInCurrentDbContext,
+  revokeGrantsDurablyInCurrentDbContext,
+} from './grantStatus';
 
 vi.mock('../db', () => ({
   db: { insert: vi.fn(), update: vi.fn(), select: vi.fn() },
@@ -31,6 +34,7 @@ vi.mock('../services/tenantStatus', () => ({
 
 vi.mock('./grantStatus', () => ({
   isOAuthGrantActiveInCurrentDbContext: vi.fn(async () => true),
+  revokeGrantsDurablyInCurrentDbContext: vi.fn(async () => undefined),
 }));
 
 const insertMock = vi.mocked(db.insert);
@@ -259,16 +263,22 @@ describe('BreezeOidcAdapter', () => {
     expect(chain.where).toHaveBeenCalled();
   });
 
-  it('revokes refresh tokens by grantId with one JSON predicate update', async () => {
+  it('revokeByGrantId durably revokes the Grant, its codes and its refresh family', async () => {
+    // oidc-provider fires revokeGrant on authorization-code replay. Revoking
+    // only the refresh rows (what this used to do) left oauth_grants.revoked_at
+    // NULL, so once the 1800s Redis marker lapsed the replayed code's Grant
+    // read as live again and could restart the family.
     mockSelectRows([{ accountId: '00000000-0000-4000-8000-000000000001' }]);
-    const chain = mockUpdateChain();
 
     await new BreezeOidcAdapter('RefreshToken').revokeByGrantId('grant_abc');
 
-    expect(updateMock).toHaveBeenCalledTimes(1);
-    expect(updateMock).toHaveBeenCalledWith(oauthRefreshTokens);
-    expect(chain.set).toHaveBeenCalledWith({ revokedAt: expect.any(Date) });
-    expect(chain.where).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(revokeGrantsDurablyInCurrentDbContext)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        grantIds: ['grant_abc'],
+        reason: 'provider-revoke-grant',
+        cascadeRefreshTokens: true,
+      }),
+    );
   });
 
   it('persists Interaction rows so consent flows survive API restart', async () => {
@@ -411,6 +421,52 @@ describe('BreezeOidcAdapter', () => {
     // this, sibling access JWTs minted from the same grant would survive
     // until natural expiry. See finding #5.
     expect(vi.mocked(revokeGrant)).toHaveBeenCalledWith('grant_abc', expect.any(Number));
+    consoleError.mockRestore();
+  });
+
+  it('refresh-token reuse revokes the Grant durably, not just with an expiring Redis marker', async () => {
+    // The Redis grant marker lives GRANT_REVOCATION_TTL_SECONDS (1800s). If the
+    // durable half never runs, a stolen sibling refresh token starts passing
+    // the active-Grant predicate again the moment the marker lapses and the
+    // thief regains the whole family.
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    mockSelectRows([{
+      id: 'refresh_abc',
+      userId: '00000000-0000-4000-8000-000000000001',
+      clientId: 'client_abc',
+      partnerId: '00000000-0000-4000-8000-000000000002',
+      payload: { accountId: 'user_abc', grantId: 'grant_abc' },
+      revokedAt: new Date(),
+      expiresAt: new Date(Date.now() + 60_000),
+    }]);
+
+    await expect(new BreezeOidcAdapter('RefreshToken').find('refresh_abc')).resolves.toBeUndefined();
+
+    expect(vi.mocked(revokeGrantsDurablyInCurrentDbContext)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        grantIds: ['grant_abc'],
+        reason: 'refresh-token-reuse',
+        cascadeRefreshTokens: true,
+      }),
+    );
+    consoleError.mockRestore();
+  });
+
+  it('does not attempt a durable grant sweep when the reused token carries no grantId', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    mockSelectRows([{
+      id: 'refresh_abc',
+      userId: '00000000-0000-4000-8000-000000000001',
+      clientId: 'client_abc',
+      partnerId: '00000000-0000-4000-8000-000000000002',
+      payload: { accountId: 'user_abc' },
+      revokedAt: new Date(),
+      expiresAt: new Date(Date.now() + 60_000),
+    }]);
+
+    await expect(new BreezeOidcAdapter('RefreshToken').find('refresh_abc')).resolves.toBeUndefined();
+
+    expect(vi.mocked(revokeGrantsDurablyInCurrentDbContext)).not.toHaveBeenCalled();
     consoleError.mockRestore();
   });
 

--- a/apps/api/src/oauth/adapter.test.ts
+++ b/apps/api/src/oauth/adapter.test.ts
@@ -54,11 +54,12 @@ function mockRetryInsertChain(userId: string) {
   return { values, onConflictDoUpdate, returning };
 }
 
-function mockUpdateChain() {
-  const where = vi.fn();
+function mockUpdateChain(rows: unknown[] = [{ id: 'updated' }]) {
+  const returning = vi.fn(async () => rows);
+  const where = vi.fn(() => ({ returning }));
   const set = vi.fn(() => ({ where }));
   updateMock.mockReturnValue({ set } as unknown as ReturnType<typeof db.update>);
-  return { set, where };
+  return { set, where, returning };
 }
 
 function collectSqlStrings(value: unknown): string {
@@ -208,6 +209,16 @@ describe('BreezeOidcAdapter', () => {
     expect(payloadSql).toContain('jsonb_set');
     expect(payloadSql).toContain('{consumed}');
     expect(chain.where).toHaveBeenCalled();
+    expect(chain.returning).toHaveBeenCalled();
+  });
+
+  it('rejects an AuthorizationCode consume that loses the atomic single-use claim', async () => {
+    const chain = mockUpdateChain([]);
+
+    await expect(new BreezeOidcAdapter('AuthorizationCode').consume('code_abc'))
+      .rejects.toMatchObject({ error: 'invalid_grant' });
+
+    expect(chain.returning).toHaveBeenCalled();
   });
 
   it('consume() on RefreshToken only revokes (no payload.consumed stamp) — unchanged by the auth-code fix', async () => {
@@ -218,6 +229,16 @@ describe('BreezeOidcAdapter', () => {
     expect(updateMock).toHaveBeenCalledWith(oauthRefreshTokens);
     expect(chain.set).toHaveBeenCalledWith({ revokedAt: expect.any(Date) });
     expect(chain.where).toHaveBeenCalled();
+    expect(chain.returning).toHaveBeenCalled();
+  });
+
+  it('rejects a RefreshToken consume that loses the atomic single-use claim', async () => {
+    const chain = mockUpdateChain([]);
+
+    await expect(new BreezeOidcAdapter('RefreshToken').consume('refresh_abc'))
+      .rejects.toMatchObject({ error: 'invalid_grant' });
+
+    expect(chain.returning).toHaveBeenCalled();
   });
 
   it('consume() on AccessToken is a no-op DB-wise (in-memory model)', async () => {

--- a/apps/api/src/oauth/adapter.test.ts
+++ b/apps/api/src/oauth/adapter.test.ts
@@ -10,6 +10,7 @@ import {
 } from './adapter';
 import { revokeGrant, revokeJti } from './revocationCache';
 import { assertActiveTenantContext, TenantInactiveError } from '../services/tenantStatus';
+import { isOAuthGrantActiveInCurrentDbContext } from './grantStatus';
 
 vi.mock('../db', () => ({
   db: { insert: vi.fn(), update: vi.fn(), select: vi.fn() },
@@ -26,6 +27,10 @@ vi.mock('./revocationCache', () => ({
 vi.mock('../services/tenantStatus', () => ({
   TenantInactiveError: class TenantInactiveError extends Error {},
   assertActiveTenantContext: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('./grantStatus', () => ({
+  isOAuthGrantActiveInCurrentDbContext: vi.fn(async () => true),
 }));
 
 const insertMock = vi.mocked(db.insert);
@@ -100,6 +105,7 @@ describe('BreezeOidcAdapter', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(assertActiveTenantContext).mockResolvedValue(undefined);
+    vi.mocked(isOAuthGrantActiveInCurrentDbContext).mockResolvedValue(true);
   });
 
   it('upserts Client rows with null partner, metadata payload, and hashed secret', async () => {
@@ -314,6 +320,18 @@ describe('BreezeOidcAdapter', () => {
     await expect(new BreezeOidcAdapter('AuthorizationCode').find('code_abc')).resolves.toBe(payload);
   });
 
+  it('rejects a still-live AuthorizationCode after its durable Grant is revoked', async () => {
+    vi.mocked(isOAuthGrantActiveInCurrentDbContext).mockResolvedValueOnce(false);
+    mockSelectRows([{
+      payload: { accountId: 'user_abc', grantId: 'grant_revoked' },
+      consumedAt: null,
+      expiresAt: new Date(Date.now() + 60_000),
+    }]);
+
+    await expect(new BreezeOidcAdapter('AuthorizationCode').find('code_abc')).resolves.toBeUndefined();
+    expect(isOAuthGrantActiveInCurrentDbContext).toHaveBeenCalledWith('grant_revoked');
+  });
+
   it('surfaces a consumed AuthorizationCode payload on replay and logs OAUTH_AUTH_CODE_REUSE', async () => {
     // On replay the adapter MUST return the (consumed-stamped) payload rather
     // than undefined: oidc-provider calls find() with ignoreExpiration:true and
@@ -373,6 +391,23 @@ describe('BreezeOidcAdapter', () => {
     // until natural expiry. See finding #5.
     expect(vi.mocked(revokeGrant)).toHaveBeenCalledWith('grant_abc', expect.any(Number));
     consoleError.mockRestore();
+  });
+
+  it('rejects an otherwise-live RefreshToken after its durable Grant is revoked', async () => {
+    vi.mocked(isOAuthGrantActiveInCurrentDbContext).mockResolvedValueOnce(false);
+    mockSelectRows([{
+      id: 'refresh_abc',
+      userId: '00000000-0000-4000-8000-000000000001',
+      clientId: 'client_abc',
+      partnerId: '00000000-0000-4000-8000-000000000002',
+      orgId: null,
+      payload: { accountId: 'user_abc', grantId: 'grant_revoked' },
+      revokedAt: null,
+      expiresAt: new Date(Date.now() + 60_000),
+    }]);
+
+    await expect(new BreezeOidcAdapter('RefreshToken').find('refresh_abc')).resolves.toBeUndefined();
+    expect(assertActiveTenantContext).not.toHaveBeenCalled();
   });
 
   it('durably records refresh-token replay cleanup before returning the invalid-token result', async () => {

--- a/apps/api/src/oauth/adapter.ts
+++ b/apps/api/src/oauth/adapter.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { eq, sql } from 'drizzle-orm';
+import { and, eq, gte, isNull, sql } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import {
   oauthAuthorizationCodes,
@@ -16,6 +16,7 @@ import {
 import { revokeClientFamilies } from './revocationService';
 import { ERROR_IDS, logOauthDebug, logOauthError } from './log';
 import { assertActiveTenantContext, TenantInactiveError } from '../services/tenantStatus';
+import { isOAuthGrantActiveInCurrentDbContext } from './grantStatus';
 
 // Grant-revocation marker TTL must outlive the longest-lived access token
 // minted under the grant. Kept in sync with `ACCESS_TOKEN_TTL_SECONDS` in
@@ -337,6 +338,10 @@ export class BreezeOidcAdapter {
       if (this.model === 'AuthorizationCode') {
         const [row] = await db.select().from(oauthAuthorizationCodes).where(eq(oauthAuthorizationCodes.id, id));
         if (!row) return undefined;
+        const grantId = typeof (row.payload as { grantId?: unknown } | null)?.grantId === 'string'
+          ? (row.payload as { grantId: string }).grantId
+          : null;
+        if (!grantId || !(await isOAuthGrantActiveInCurrentDbContext(grantId))) return undefined;
         // Truly-expired non-consumed rows stay invisible via our own
         // `expiresAt >= new Date()` filter below — and that filter is the only
         // thing rejecting them: the grant calls find() with
@@ -372,6 +377,10 @@ export class BreezeOidcAdapter {
         const storageId = refreshTokenStorageId(id);
         const [row] = await db.select().from(oauthRefreshTokens).where(eq(oauthRefreshTokens.id, storageId));
         if (!row) return undefined;
+        const grantId = typeof (row.payload as { grantId?: unknown } | null)?.grantId === 'string'
+          ? (row.payload as { grantId: string }).grantId
+          : null;
+        if (!grantId || !(await isOAuthGrantActiveInCurrentDbContext(grantId))) return undefined;
         try {
           await assertActiveTenantContext({
             scope: row.orgId ? 'organization' : 'partner',
@@ -457,8 +466,12 @@ export class BreezeOidcAdapter {
         return row && row.expiresAt >= new Date() ? row.payload as OidcPayload : undefined;
       }
       if (this.model === 'Grant') {
-        const [row] = await db.select().from(oauthGrants).where(eq(oauthGrants.id, id));
-        return row && row.expiresAt >= new Date() ? row.payload as OidcPayload : undefined;
+        const [row] = await db.select().from(oauthGrants).where(and(
+          eq(oauthGrants.id, id),
+          isNull(oauthGrants.revokedAt),
+          gte(oauthGrants.expiresAt, new Date()),
+        ));
+        return row ? row.payload as OidcPayload : undefined;
       }
       if (this.model === 'Interaction') {
         const [row] = await db.select().from(oauthInteractions).where(eq(oauthInteractions.id, id));

--- a/apps/api/src/oauth/adapter.ts
+++ b/apps/api/src/oauth/adapter.ts
@@ -17,7 +17,7 @@ import {
 import { revokeClientFamilies } from './revocationService';
 import { ERROR_IDS, logOauthDebug, logOauthError } from './log';
 import { assertActiveTenantContext, TenantInactiveError } from '../services/tenantStatus';
-import { isOAuthGrantActiveInCurrentDbContext } from './grantStatus';
+import { isOAuthGrantActiveInCurrentDbContext, revokeGrantsDurablyInCurrentDbContext } from './grantStatus';
 
 // Grant-revocation marker TTL must outlive the longest-lived access token
 // minted under the grant. Kept in sync with `ACCESS_TOKEN_TTL_SECONDS` in
@@ -35,26 +35,21 @@ type StoredPayload = { payload: OidcPayload; expiresAt: Date | null };
 
 const inMemory = new Map<string, Map<string, StoredPayload>>();
 
-// Side cache for Breeze tenancy metadata attached to a Grant. oidc-provider's
+// Breeze tenancy metadata attached to a Grant. oidc-provider's
 // Grant.IN_PAYLOAD allowlist (lib/models/grant.js) drops unknown fields on
-// save, so we can't simply set `grant.breeze = ...`. Historically this map
-// was the only store; now that Grants are persisted to `oauth_grants`, the
-// map is just a fast process-local cache and `setGrantBreezeMeta` ALSO
-// writes the metadata to the DB row so it survives restart.
+// save, so we can't simply set `grant.breeze = ...`; it lives in the
+// `oauth_grants` row instead.
+//
+// There is deliberately NO process-local cache of this any more. A cached
+// entry outlives its Grant's `revoked_at` transition, which made stale
+// in-memory state answerable as tenancy — and therefore as authority — on
+// paths that should have re-read the row. The DB row is the only store.
 type GrantBreezeMeta = { partner_id: string; org_id: string | null };
-type StoredBreezeMeta = { meta: GrantBreezeMeta; expiresAt: Date | null };
-
-const grantBreezeMeta = new Map<string, StoredBreezeMeta>();
 
 export async function setGrantBreezeMeta(
   grantId: string,
   meta: GrantBreezeMeta,
-  ttlSeconds?: number,
 ): Promise<void> {
-  grantBreezeMeta.set(grantId, {
-    meta,
-    expiresAt: ttlSeconds === undefined ? null : new Date(Date.now() + ttlSeconds * 1000),
-  });
   // Persist to DB so a process restart between consent and the first
   // refresh-token grant doesn't orphan the partner_id. The Grant row is
   // INSERTed by `BreezeOidcAdapter.upsert` during `grant.save()`, which the
@@ -90,16 +85,13 @@ export async function getGrantBreezeMetaAsync(
   grantId: string | undefined | null,
 ): Promise<GrantBreezeMeta | undefined> {
   if (!grantId) return undefined;
-  const cached = getGrantBreezeMeta(grantId);
-  if (cached) return cached;
-  // Cache miss — possibly a different process / post-restart. Fall back to
-  // the DB row, populated by the consent route. We deliberately do NOT
-  // catch DB errors here: callers (`requiredPartnerId`, `buildExtraTokenClaims`)
+  // Always the DB row, populated by the consent route. We deliberately do NOT
+  // catch DB errors here: callers (`requiredPartnerId`, `resolvedOrgId`)
   // need to distinguish "no row" (DB returned undefined → grant has no
   // tenancy) from "lookup failed" (Postgres unavailable → we don't know).
-  // Silently degrading to "missing partner_id" would mint a JWT with
-  // `partner_id: null` that bearer middleware rejects with a confusing 401,
-  // and worse, mask infrastructure failures behind auth errors.
+  // Silently degrading to "missing partner_id" would persist a token row with
+  // a null tenant column, and worse, mask infrastructure failures behind
+  // auth errors.
   let row;
   try {
     row = await asSystem(async () => {
@@ -119,17 +111,6 @@ export async function getGrantBreezeMetaAsync(
   }
   if (!row || !row.partnerId) return undefined;
   return { partner_id: row.partnerId, org_id: row.orgId };
-}
-
-export function getGrantBreezeMeta(grantId: string | undefined | null): GrantBreezeMeta | undefined {
-  if (!grantId) return undefined;
-  const stored = grantBreezeMeta.get(grantId);
-  if (!stored) return undefined;
-  if (stored.expiresAt && stored.expiresAt < new Date()) {
-    grantBreezeMeta.delete(grantId);
-    return undefined;
-  }
-  return stored.meta;
 }
 
 function sha256(s: string): string {
@@ -179,18 +160,18 @@ function epochTime(): number {
 
 async function requiredPartnerId(payload: OidcPayload): Promise<string> {
   // First try extra.partner_id (kept for backward compatibility / tests). If
-  // not present, fall back to deriving it from the Grant via the cache, then
-  // the DB — the RefreshToken model's IN_PAYLOAD allowlist drops `extra`
+  // not present, derive it from the Grant's durable row — the RefreshToken
+  // model's IN_PAYLOAD allowlist drops `extra`
   // (only AccessToken/ClientCredentials carry it), so for tokens minted via
   // the authorization_code grant the only thing we have to key on is
-  // `grantId`. The DB fallback is critical post-restart: a refresh-token
-  // exchange a few minutes after an API redeploy lost the in-memory cache.
+  // `grantId`. Reaching here means find() already proved that Grant durably
+  // active, so the row exists.
   const partnerId = extraField(payload, 'partner_id');
   if (typeof partnerId === 'string' && partnerId.length > 0) {
     return partnerId;
   }
   const grantId = typeof payload.grantId === 'string' ? payload.grantId : undefined;
-  const meta = getGrantBreezeMeta(grantId) ?? (await getGrantBreezeMetaAsync(grantId));
+  const meta = await getGrantBreezeMetaAsync(grantId);
   if (meta && meta.partner_id) {
     return meta.partner_id;
   }
@@ -201,7 +182,7 @@ async function resolvedOrgId(payload: OidcPayload): Promise<string | null> {
   const fromExtra = extraField(payload, 'org_id');
   if (typeof fromExtra === 'string' && fromExtra.length > 0) return fromExtra;
   const grantId = typeof payload.grantId === 'string' ? payload.grantId : undefined;
-  const meta = getGrantBreezeMeta(grantId) ?? (await getGrantBreezeMetaAsync(grantId));
+  const meta = await getGrantBreezeMetaAsync(grantId);
   return meta?.org_id ?? null;
 }
 
@@ -439,6 +420,11 @@ export class BreezeOidcAdapter {
           // (all sibling access JWTs and refresh tokens) immediately —
           // logging alone leaves a window where the attacker continues
           // to use already-minted access tokens until natural expiry.
+          //
+          // The Redis marker is the EAGER half and it expires
+          // (GRANT_REVOCATION_TTL_SECONDS). It must be paired with the durable
+          // half, or a stolen sibling refresh token starts working again the
+          // moment the marker lapses and the thief regains the whole family.
           if (grantId) {
             const result = await writeOAuthRevocationMarkerDurably(db, {
               userId: row.userId,
@@ -453,6 +439,11 @@ export class BreezeOidcAdapter {
                 context: { markerType: 'grant', errorCode: result.errorCode },
               });
             }
+            await revokeGrantsDurablyInCurrentDbContext({
+              grantIds: [grantId],
+              reason: 'refresh-token-reuse',
+              cascadeRefreshTokens: true,
+            });
           }
           return undefined;
         }
@@ -506,6 +497,12 @@ export class BreezeOidcAdapter {
           isNull(oauthAuthorizationCodes.consumedAt),
         )).returning({ id: oauthAuthorizationCodes.id });
         if (consumed.length !== 1) {
+          // Losing the CAS aborts before oidc-provider's consumed-replay
+          // handler (which would call revokeGrant) can run. That is correct
+          // ONLY for the true-concurrent case this guards: the winner is a
+          // legitimate first use, not a replay. A genuine later replay still
+          // reaches find(), sees payload.consumed and fires revokeGrant
+          // normally.
           throw new errors.InvalidGrant('authorization code already consumed');
         }
       } else if (this.model === 'RefreshToken') {
@@ -675,10 +672,14 @@ export class BreezeOidcAdapter {
   }
 
   async revokeByGrantId(grantId: string): Promise<void> {
+    // oidc-provider calls this from its own replay handling (a re-presented
+    // authorization code) as well as from RP-initiated revocation.
+    //
     // Mark the grant revoked in the cache FIRST so any in-flight bearer
-    // checks immediately reject. Then mark every refresh token revoked in
-    // the DB (so the next refresh-token grant exchange fails with
-    // "invalid_grant" rather than minting a fresh access token).
+    // checks immediately reject, then do the durable sweep: consume every
+    // live authorization code, revoke every sibling refresh token and stamp
+    // `oauth_grants.revoked_at`. The cache marker alone expires, so without
+    // the durable half a replayed code could restart the family later.
     const retryQueued = await asSystem(async () => {
       const [grant] = await db
         .select({ accountId: oauthGrants.accountId })
@@ -693,7 +694,11 @@ export class BreezeOidcAdapter {
         markerId: grantId,
         expiresAt: new Date(Date.now() + GRANT_REVOCATION_TTL_SECONDS * 1000),
       });
-      await db.update(oauthRefreshTokens).set({ revokedAt: new Date() }).where(sql`payload->>'grantId' = ${grantId}`);
+      await revokeGrantsDurablyInCurrentDbContext({
+        grantIds: [grantId],
+        reason: 'provider-revoke-grant',
+        cascadeRefreshTokens: true,
+      });
       return marker.status === 'retry_queued';
     });
     if (retryQueued) {

--- a/apps/api/src/oauth/adapter.ts
+++ b/apps/api/src/oauth/adapter.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto';
+import { errors } from 'oidc-provider';
 import { and, eq, gte, isNull, sql } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import {
@@ -497,16 +498,28 @@ export class BreezeOidcAdapter {
         // the library reads `code.consumed` from that payload to fire its
         // grant-wide revoke on replay. jsonb_set keeps it a single atomic
         // write — no read-modify-write race on concurrent replays.
-        await db.update(oauthAuthorizationCodes).set({
+        const consumed = await db.update(oauthAuthorizationCodes).set({
           consumedAt: new Date(),
           payload: sql`jsonb_set(${oauthAuthorizationCodes.payload}, '{consumed}', ${epochTime()}::text::jsonb, true)`,
-        }).where(eq(oauthAuthorizationCodes.id, id));
+        }).where(and(
+          eq(oauthAuthorizationCodes.id, id),
+          isNull(oauthAuthorizationCodes.consumedAt),
+        )).returning({ id: oauthAuthorizationCodes.id });
+        if (consumed.length !== 1) {
+          throw new errors.InvalidGrant('authorization code already consumed');
+        }
       } else if (this.model === 'RefreshToken') {
         // oidc-provider rotates refresh tokens by minting a new one and
         // calling consume() on the previous. Mark it revoked so
         // `find()` (which filters on revokedAt IS NULL) returns undefined,
         // preventing replay of the old token after rotation.
-        await db.update(oauthRefreshTokens).set({ revokedAt: new Date() }).where(eq(oauthRefreshTokens.id, refreshTokenStorageId(id)));
+        const consumed = await db.update(oauthRefreshTokens).set({ revokedAt: new Date() }).where(and(
+          eq(oauthRefreshTokens.id, refreshTokenStorageId(id)),
+          isNull(oauthRefreshTokens.revokedAt),
+        )).returning({ id: oauthRefreshTokens.id });
+        if (consumed.length !== 1) {
+          throw new errors.InvalidGrant('refresh token already used');
+        }
       }
     });
   }

--- a/apps/api/src/oauth/adapter.ts
+++ b/apps/api/src/oauth/adapter.ts
@@ -397,11 +397,26 @@ export class BreezeOidcAdapter {
           // nukes the whole grant family. We deliberately KEEP the
           // grant-family revocation — genuine rotation replay is the
           // canonical token-theft signal and must stay fatal — and instead
-          // fix the known innocent trigger upstream (resource-alias
-          // normalization in routes/oauth.ts). The revoked_at / revoked_ms_ago
-          // context below lets on-call distinguish the two: an innocent
-          // post-failure retry presents within seconds of revocation, while
-          // theft replay typically surfaces much later.
+          // fix the known innocent trigger upstream: resource-alias
+          // normalization (`normalizeResourceParams` in
+          // oauth/resourceIndicators.ts, applied by routes/oauth.ts) stops an
+          // alias-only `resource` mismatch from failing the exchange in the
+          // first place.
+          //
+          // SUPPORT-VISIBLE CONSEQUENCE: that revocation is now DURABLE and
+          // IRREVERSIBLE. It used to be recorded only in the Redis grant
+          // marker, so a family effectively "recovered" once the marker
+          // expired (GRANT_REVOCATION_TTL_SECONDS). It now stamps
+          // oauth_grants.revoked_at and revokes every sibling refresh token,
+          // which is the whole point — a thief must not be able to wait the
+          // marker out — but it means an affected client CANNOT recover by
+          // retrying later. The user must re-consent. Runbooks should expect
+          // "re-authorize the connected app", not "wait and retry".
+          //
+          // The revoked_at / revoked_ms_ago context below lets on-call
+          // distinguish the two cases: an innocent post-failure retry presents
+          // within seconds of revocation, while theft replay typically
+          // surfaces much later.
           logOauthError({
             errorId: ERROR_IDS.OAUTH_REFRESH_TOKEN_REUSE,
             message: 'Revoked refresh token lookup detected',

--- a/apps/api/src/oauth/effectiveScopes.test.ts
+++ b/apps/api/src/oauth/effectiveScopes.test.ts
@@ -12,15 +12,6 @@ vi.mock('./partnerScopePolicy', () => ({
   getPartnerScopePolicy: vi.fn(),
 }));
 
-// Deliberately still mocked even though effectiveScopes.ts no longer imports it:
-// the point of the durable-grant fix is that a WARM process-local cache must not
-// be able to answer a tenancy question. If the fast path ever comes back, this
-// primed cache is what it would read.
-vi.mock('./adapter', () => ({
-  getGrantBreezeMeta: vi.fn(),
-}));
-
-import { getGrantBreezeMeta } from './adapter';
 import { getPartnerScopePolicy } from './partnerScopePolicy';
 import {
   ALL_MCP_SCOPES,
@@ -30,17 +21,23 @@ import {
 } from './effectiveScopes';
 
 const selectMock = vi.mocked(db.select);
-const getGrantBreezeMetaMock = vi.mocked(getGrantBreezeMeta);
 const getPartnerScopePolicyMock = vi.mocked(getPartnerScopePolicy);
 
 /**
- * Collect the qualified column names a drizzle `where` clause actually
- * references. Asserting on the columns (not on a stringified predicate) keeps
- * this independent of drizzle's SQL rendering and of any enum/param values that
- * a naive deep string search would false-positive on.
+ * Walk a drizzle `where` clause and report BOTH the columns it references and
+ * the raw operator fragments it renders. Asserting on the clause's own
+ * structure (rather than on a stringified predicate, or on the stubbed query
+ * result) keeps this independent of drizzle's SQL rendering and immune to the
+ * deep-search false positive where a bound enum's `enumValues` matches a
+ * literal you were looking for.
+ *
+ * Columns alone are not enough: `expires_at <= now` references the same column
+ * as `expires_at >= now` and inverts the security meaning. The operator
+ * fragments pin the direction.
  */
-function whereColumnNames(clause: unknown): string[] {
-  const names: string[] = [];
+function inspectWhere(clause: unknown): { columns: string[]; sql: string } {
+  const columns: string[] = [];
+  const fragments: string[] = [];
   const visit = (node: unknown) => {
     if (!node || typeof node !== 'object') return;
     const chunks = (node as { queryChunks?: unknown[] }).queryChunks;
@@ -48,11 +45,18 @@ function whereColumnNames(clause: unknown): string[] {
       chunks.forEach(visit);
       return;
     }
-    const { name, table } = node as { name?: unknown; table?: unknown };
-    if (typeof name === 'string' && table) names.push(name);
+    const { name, table, value } = node as { name?: unknown; table?: unknown; value?: unknown };
+    if (typeof name === 'string' && table) {
+      columns.push(name);
+      return;
+    }
+    // StringChunk holds the literal SQL between interpolations.
+    if (Array.isArray(value) && value.every((v) => typeof v === 'string')) {
+      fragments.push(...(value as string[]));
+    }
   };
   visit(clause);
-  return names;
+  return { columns, sql: fragments.join('').toLowerCase().replace(/\s+/g, ' ') };
 }
 
 function mockSelectRow(row: unknown) {
@@ -74,7 +78,6 @@ function mockSelectError(err: unknown) {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  getGrantBreezeMetaMock.mockReturnValue(undefined);
   getPartnerScopePolicyMock.mockResolvedValue({});
 });
 
@@ -83,11 +86,10 @@ afterEach(() => {
 });
 
 describe('resolveGrantContext', () => {
-  it('ignores warm process-local tenancy metadata and answers from the durable row', async () => {
-    // A stale in-memory entry survives its Grant's revoked_at transition, so it
-    // must never short-circuit the lookup. Prime it with DIFFERENT tenancy than
-    // the DB row: whichever one comes back tells us which path ran.
-    getGrantBreezeMetaMock.mockReturnValue({ partner_id: 'stale-cached-partner', org_id: 'stale-cached-org' });
+  it('always reads the durable row — there is no process-local tenancy fast path', async () => {
+    // Any cached answer outlives its Grant's revoked_at transition, so tenancy
+    // may only come from the row. The in-memory side cache this used to consult
+    // has been deleted outright; this pins that the lookup still happens.
     mockSelectRow({ partnerId: 'partner-1', orgId: 'org-1' });
 
     const context = await resolveGrantContext('grant-1');
@@ -118,10 +120,16 @@ describe('resolveGrantContext', () => {
 
     await expect(resolveGrantContext('grant-revoked')).resolves.toBeNull();
 
-    const columns = whereColumnNames((where.mock.calls as unknown as unknown[][])[0]?.[0]);
+    const { columns, sql } = inspectWhere((where.mock.calls as unknown as unknown[][])[0]?.[0]);
     expect(columns).toContain(oauthGrants.id.name);
     expect(columns).toContain(oauthGrants.revokedAt.name);
     expect(columns).toContain(oauthGrants.expiresAt.name);
+    // Direction matters as much as the column: `revoked_at IS NOT NULL` or
+    // `expires_at <= now` would reference the same two columns and mean the
+    // opposite thing.
+    expect(sql).toContain('is null');
+    expect(sql).toContain('>=');
+    expect(sql).not.toContain('is not null');
   });
 
   it('cache miss + row exists with NULL partnerId: throws GrantTenancyError (fail closed — the -02 bug)', async () => {

--- a/apps/api/src/oauth/effectiveScopes.test.ts
+++ b/apps/api/src/oauth/effectiveScopes.test.ts
@@ -8,12 +8,16 @@ vi.mock('../db', () => ({
   withSystemDbAccessContext: vi.fn(async (fn: () => unknown) => fn()),
 }));
 
-vi.mock('./adapter', () => ({
-  getGrantBreezeMeta: vi.fn(),
-}));
-
 vi.mock('./partnerScopePolicy', () => ({
   getPartnerScopePolicy: vi.fn(),
+}));
+
+// Deliberately still mocked even though effectiveScopes.ts no longer imports it:
+// the point of the durable-grant fix is that a WARM process-local cache must not
+// be able to answer a tenancy question. If the fast path ever comes back, this
+// primed cache is what it would read.
+vi.mock('./adapter', () => ({
+  getGrantBreezeMeta: vi.fn(),
 }));
 
 import { getGrantBreezeMeta } from './adapter';
@@ -28,6 +32,28 @@ import {
 const selectMock = vi.mocked(db.select);
 const getGrantBreezeMetaMock = vi.mocked(getGrantBreezeMeta);
 const getPartnerScopePolicyMock = vi.mocked(getPartnerScopePolicy);
+
+/**
+ * Collect the qualified column names a drizzle `where` clause actually
+ * references. Asserting on the columns (not on a stringified predicate) keeps
+ * this independent of drizzle's SQL rendering and of any enum/param values that
+ * a naive deep string search would false-positive on.
+ */
+function whereColumnNames(clause: unknown): string[] {
+  const names: string[] = [];
+  const visit = (node: unknown) => {
+    if (!node || typeof node !== 'object') return;
+    const chunks = (node as { queryChunks?: unknown[] }).queryChunks;
+    if (Array.isArray(chunks)) {
+      chunks.forEach(visit);
+      return;
+    }
+    const { name, table } = node as { name?: unknown; table?: unknown };
+    if (typeof name === 'string' && table) names.push(name);
+  };
+  visit(clause);
+  return names;
+}
 
 function mockSelectRow(row: unknown) {
   const limit = vi.fn(async () => (row === undefined ? [] : [row]));
@@ -57,17 +83,20 @@ afterEach(() => {
 });
 
 describe('resolveGrantContext', () => {
-  it('returns context from the in-memory cache without touching the DB (fast path)', async () => {
-    getGrantBreezeMetaMock.mockReturnValue({ partner_id: 'partner-1', org_id: 'org-1' });
+  it('ignores warm process-local tenancy metadata and answers from the durable row', async () => {
+    // A stale in-memory entry survives its Grant's revoked_at transition, so it
+    // must never short-circuit the lookup. Prime it with DIFFERENT tenancy than
+    // the DB row: whichever one comes back tells us which path ran.
+    getGrantBreezeMetaMock.mockReturnValue({ partner_id: 'stale-cached-partner', org_id: 'stale-cached-org' });
+    mockSelectRow({ partnerId: 'partner-1', orgId: 'org-1' });
 
     const context = await resolveGrantContext('grant-1');
 
     expect(context).toEqual({ grantId: 'grant-1', partnerId: 'partner-1', orgId: 'org-1' });
-    expect(selectMock).not.toHaveBeenCalled();
+    expect(selectMock).toHaveBeenCalledOnce();
   });
 
   it('cache miss: loads the oauth_grants row and returns its durable tenancy', async () => {
-    getGrantBreezeMetaMock.mockReturnValue(undefined);
     mockSelectRow({ partnerId: 'partner-2', orgId: null });
 
     const context = await resolveGrantContext('grant-2');
@@ -77,7 +106,6 @@ describe('resolveGrantContext', () => {
   });
 
   it('cache miss + grant row does not exist: returns null (not a tenancy failure)', async () => {
-    getGrantBreezeMetaMock.mockReturnValue(undefined);
     mockSelectRow(undefined);
 
     const context = await resolveGrantContext('grant-missing');
@@ -85,15 +113,24 @@ describe('resolveGrantContext', () => {
     expect(context).toBeNull();
   });
 
+  it('constrains the lookup to unrevoked, unexpired Grants (revoked rows never match)', async () => {
+    const { where } = mockSelectRow(undefined);
+
+    await expect(resolveGrantContext('grant-revoked')).resolves.toBeNull();
+
+    const columns = whereColumnNames((where.mock.calls as unknown as unknown[][])[0]?.[0]);
+    expect(columns).toContain(oauthGrants.id.name);
+    expect(columns).toContain(oauthGrants.revokedAt.name);
+    expect(columns).toContain(oauthGrants.expiresAt.name);
+  });
+
   it('cache miss + row exists with NULL partnerId: throws GrantTenancyError (fail closed — the -02 bug)', async () => {
-    getGrantBreezeMetaMock.mockReturnValue(undefined);
     mockSelectRow({ partnerId: null, orgId: null });
 
     await expect(resolveGrantContext('grant-orphaned')).rejects.toThrow(GrantTenancyError);
   });
 
   it('propagates a DB lookup failure rather than falling back to null (fail closed)', async () => {
-    getGrantBreezeMetaMock.mockReturnValue(undefined);
     const dbErr = new Error('connection refused');
     mockSelectError(dbErr);
 
@@ -101,7 +138,6 @@ describe('resolveGrantContext', () => {
   });
 
   it('exits request DB context before opening system DB context (mirrors adapter.ts convention)', async () => {
-    getGrantBreezeMetaMock.mockReturnValue(undefined);
     mockSelectRow({ partnerId: 'partner-4', orgId: null });
 
     await resolveGrantContext('grant-4');

--- a/apps/api/src/oauth/effectiveScopes.ts
+++ b/apps/api/src/oauth/effectiveScopes.ts
@@ -1,6 +1,6 @@
-import { and, eq, gte, isNull } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { oauthGrants } from '../db/schema';
+import { activeGrantCondition } from './grantStatus';
 import { getPartnerScopePolicy } from './partnerScopePolicy';
 import { ERROR_IDS, logOauthError } from './log';
 
@@ -58,11 +58,7 @@ export async function resolveGrantContext(grantId: string): Promise<OAuthGrantCo
       const [r] = await db
         .select({ partnerId: oauthGrants.partnerId, orgId: oauthGrants.orgId })
         .from(oauthGrants)
-        .where(and(
-          eq(oauthGrants.id, grantId),
-          isNull(oauthGrants.revokedAt),
-          gte(oauthGrants.expiresAt, new Date()),
-        ))
+        .where(activeGrantCondition(grantId, new Date()))
         .limit(1);
       return r;
     });

--- a/apps/api/src/oauth/effectiveScopes.ts
+++ b/apps/api/src/oauth/effectiveScopes.ts
@@ -1,7 +1,6 @@
-import { eq } from 'drizzle-orm';
+import { and, eq, gte, isNull } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { oauthGrants } from '../db/schema';
-import { getGrantBreezeMeta } from './adapter';
 import { getPartnerScopePolicy } from './partnerScopePolicy';
 import { ERROR_IDS, logOauthError } from './log';
 
@@ -39,12 +38,10 @@ export class GrantTenancyError extends Error {
 /**
  * The single authoritative source of a Grant's durable tenancy.
  *
- * Fast path: the in-memory `grantBreezeMeta` cache populated by the consent
- * route (same-process, warm). On a cache miss (e.g. a different process, or
- * an API restart between consent and the next token/refresh exchange) this
- * loads the `oauth_grants` row directly — that row is written durably by
- * `setGrantBreezeMeta` before the consent route ever resumes the
- * interaction, so it is authoritative regardless of process lifetime.
+ * Always loads `oauth_grants` durably. Process-local tenancy metadata is not
+ * an authorization source: it can outlive a Grant's revoked_at transition.
+ * The row is written by `setGrantBreezeMeta` before the consent route resumes
+ * and the query also requires the Grant to be unrevoked and unexpired.
  *
  * Returns `null` only when the grant row itself does not exist (e.g. it was
  * cleaned up / never created — not a tenancy failure). Throws
@@ -55,18 +52,17 @@ export class GrantTenancyError extends Error {
  * MCP scope after a restart cleared the process-local cache).
  */
 export async function resolveGrantContext(grantId: string): Promise<OAuthGrantContext | null> {
-  const cached = getGrantBreezeMeta(grantId);
-  if (cached) {
-    return { grantId, partnerId: cached.partner_id, orgId: cached.org_id };
-  }
-
   let row: { partnerId: string | null; orgId: string | null } | undefined;
   try {
     row = await asSystem(async () => {
       const [r] = await db
         .select({ partnerId: oauthGrants.partnerId, orgId: oauthGrants.orgId })
         .from(oauthGrants)
-        .where(eq(oauthGrants.id, grantId))
+        .where(and(
+          eq(oauthGrants.id, grantId),
+          isNull(oauthGrants.revokedAt),
+          gte(oauthGrants.expiresAt, new Date()),
+        ))
         .limit(1);
       return r;
     });

--- a/apps/api/src/oauth/grantRevocation.test.ts
+++ b/apps/api/src/oauth/grantRevocation.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
-import { oauthGrants, oauthRefreshTokens } from '../db/schema';
+import { oauthAuthorizationCodes, oauthGrants, oauthRefreshTokens } from '../db/schema';
 import { revokeGrant, revokeJti } from './revocationCache';
 import { revokeAllOrgOauthArtifacts, revokeAllPartnerOauthArtifacts, revokeAllUserOauthArtifacts } from './grantRevocation';
 
@@ -77,6 +77,7 @@ describe('revokeAllUserOauthArtifacts', () => {
     expect(grantCalls.sort()).toEqual(['grant-A', 'grant-B', 'grant-C']);
 
     expect(updateMock).toHaveBeenCalledWith(oauthRefreshTokens);
+    expect(updateMock).toHaveBeenCalledWith(oauthAuthorizationCodes);
     // Durability: revoked_at is also stamped on the grant rows themselves so
     // revocation survives Redis-marker expiry (parity with revocationService).
     expect(updateMock).toHaveBeenCalledWith(oauthGrants);

--- a/apps/api/src/oauth/grantRevocation.ts
+++ b/apps/api/src/oauth/grantRevocation.ts
@@ -1,6 +1,7 @@
-import { and, eq, gt, inArray, isNull, sql } from 'drizzle-orm';
+import { and, eq, inArray, isNull } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
-import { oauthAuthorizationCodes, oauthGrants, oauthRefreshTokens } from '../db/schema';
+import { oauthGrants, oauthRefreshTokens } from '../db/schema';
+import { revokeGrantsDurablyInCurrentDbContext } from './grantStatus';
 import { writeOAuthRevocationMarkerDurably } from './revocationRetry';
 import { ACCESS_TOKEN_TTL_SECONDS } from './provider';
 import { ERROR_IDS, logOauthError } from './log';
@@ -103,22 +104,11 @@ async function revokeOauthArtifactsByColumn(
   // ordering as revocationService.ts): a stamped-but-unmarked grant would look
   // revoked in the DB while its in-flight access JWTs kept working.
   if (seenGrants.size > 0) {
-    const grantIds = [...seenGrants];
-    await db
-      .update(oauthAuthorizationCodes)
-      .set({
-        consumedAt: now,
-        payload: sql`jsonb_set(${oauthAuthorizationCodes.payload}, '{consumed}', ${Math.floor(now.getTime() / 1000)}::text::jsonb, true)`,
-      })
-      .where(and(
-        inArray(sql<string>`${oauthAuthorizationCodes.payload}->>'grantId'`, grantIds),
-        isNull(oauthAuthorizationCodes.consumedAt),
-        gt(oauthAuthorizationCodes.expiresAt, now),
-      ));
-    await db
-      .update(oauthGrants)
-      .set({ revokedAt: now, revokedReason: `tenant-lifecycle:${target}` })
-      .where(inArray(oauthGrants.id, grantIds));
+    await revokeGrantsDurablyInCurrentDbContext({
+      grantIds: [...seenGrants],
+      reason: `tenant-lifecycle:${target}`,
+      now,
+    });
   }
 
   return {

--- a/apps/api/src/oauth/grantRevocation.ts
+++ b/apps/api/src/oauth/grantRevocation.ts
@@ -1,6 +1,6 @@
-import { and, eq, inArray, isNull } from 'drizzle-orm';
+import { and, eq, gt, inArray, isNull, sql } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
-import { oauthGrants, oauthRefreshTokens } from '../db/schema';
+import { oauthAuthorizationCodes, oauthGrants, oauthRefreshTokens } from '../db/schema';
 import { writeOAuthRevocationMarkerDurably } from './revocationRetry';
 import { ACCESS_TOKEN_TTL_SECONDS } from './provider';
 import { ERROR_IDS, logOauthError } from './log';
@@ -103,10 +103,22 @@ async function revokeOauthArtifactsByColumn(
   // ordering as revocationService.ts): a stamped-but-unmarked grant would look
   // revoked in the DB while its in-flight access JWTs kept working.
   if (seenGrants.size > 0) {
+    const grantIds = [...seenGrants];
+    await db
+      .update(oauthAuthorizationCodes)
+      .set({
+        consumedAt: now,
+        payload: sql`jsonb_set(${oauthAuthorizationCodes.payload}, '{consumed}', ${Math.floor(now.getTime() / 1000)}::text::jsonb, true)`,
+      })
+      .where(and(
+        inArray(sql<string>`${oauthAuthorizationCodes.payload}->>'grantId'`, grantIds),
+        isNull(oauthAuthorizationCodes.consumedAt),
+        gt(oauthAuthorizationCodes.expiresAt, now),
+      ));
     await db
       .update(oauthGrants)
       .set({ revokedAt: now, revokedReason: `tenant-lifecycle:${target}` })
-      .where(inArray(oauthGrants.id, [...seenGrants]));
+      .where(inArray(oauthGrants.id, grantIds));
   }
 
   return {

--- a/apps/api/src/oauth/grantStatus.test.ts
+++ b/apps/api/src/oauth/grantStatus.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { db } from '../db';
+import { oauthAuthorizationCodes, oauthGrants, oauthRefreshTokens } from '../db/schema';
+import {
+  activeGrantCondition,
+  isOAuthGrantActiveInCurrentDbContext,
+  revokeGrantsDurablyInCurrentDbContext,
+} from './grantStatus';
+
+vi.mock('../db', () => ({
+  db: { select: vi.fn(), update: vi.fn() },
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => unknown) => fn()),
+}));
+
+const selectMock = vi.mocked(db.select);
+const updateMock = vi.mocked(db.update);
+
+/** Every `db.update(...)` issued, in order, with its table and set/where args. */
+function captureUpdates() {
+  const calls: { table: unknown; set: unknown; where: unknown }[] = [];
+  updateMock.mockImplementation(((table: unknown) => {
+    const entry: { table: unknown; set: unknown; where: unknown } = { table, set: undefined, where: undefined };
+    calls.push(entry);
+    return {
+      set: (value: unknown) => {
+        entry.set = value;
+        return {
+          where: async (clause: unknown) => {
+            entry.where = clause;
+            return [];
+          },
+        };
+      },
+    };
+  }) as unknown as typeof db.update);
+  return calls;
+}
+
+function mockSelectRow(row: unknown) {
+  const where = vi.fn(async () => (row === undefined ? [] : [row]));
+  const from = vi.fn(() => ({ where }));
+  selectMock.mockReturnValueOnce({ from } as unknown as ReturnType<typeof db.select>);
+  return { from, where };
+}
+
+/**
+ * Reduce a drizzle clause to the columns it names and the literal SQL it
+ * renders, so a predicate can be asserted structurally rather than by a
+ * string match on the whole statement (which would also match bound values).
+ */
+function inspectClause(clause: unknown): { columns: string[]; sql: string } {
+  const columns: string[] = [];
+  const fragments: string[] = [];
+  const visit = (node: unknown) => {
+    if (!node || typeof node !== 'object') return;
+    const chunks = (node as { queryChunks?: unknown[] }).queryChunks;
+    if (Array.isArray(chunks)) {
+      chunks.forEach(visit);
+      return;
+    }
+    const { name, table, value } = node as { name?: unknown; table?: unknown; value?: unknown };
+    if (typeof name === 'string' && table) {
+      columns.push(name);
+      return;
+    }
+    if (Array.isArray(value) && value.every((v) => typeof v === 'string')) {
+      fragments.push(...(value as string[]));
+    }
+  };
+  visit(clause);
+  return { columns, sql: fragments.join('').toLowerCase().replace(/\s+/g, ' ') };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('activeGrantCondition', () => {
+  it('requires the exact id, an unrevoked row and an unexpired row', () => {
+    const { columns, sql } = inspectClause(activeGrantCondition('grant-1', new Date()));
+
+    expect(columns).toEqual(expect.arrayContaining([
+      oauthGrants.id.name,
+      oauthGrants.revokedAt.name,
+      oauthGrants.expiresAt.name,
+    ]));
+    expect(sql).toContain('is null');
+    expect(sql).toContain('>=');
+    // `revoked_at IS NOT NULL` / `expires_at <= now` would touch the same
+    // columns and invert the meaning, so pin the direction too.
+    expect(sql).not.toContain('is not null');
+    expect(sql).not.toContain('<=');
+  });
+});
+
+describe('isOAuthGrantActiveInCurrentDbContext', () => {
+  it('is true only when the active predicate returns the row', async () => {
+    mockSelectRow({ id: 'grant-1' });
+    await expect(isOAuthGrantActiveInCurrentDbContext('grant-1')).resolves.toBe(true);
+
+    mockSelectRow(undefined);
+    await expect(isOAuthGrantActiveInCurrentDbContext('grant-1')).resolves.toBe(false);
+  });
+});
+
+describe('revokeGrantsDurablyInCurrentDbContext', () => {
+  it('is a no-op on an empty grant list', async () => {
+    const updates = captureUpdates();
+
+    await revokeGrantsDurablyInCurrentDbContext({ grantIds: [], reason: 'noop' });
+
+    expect(updates).toHaveLength(0);
+  });
+
+  it('consumes live authorization codes BEFORE stamping revoked_at', async () => {
+    // Order is the whole point: a Grant stamped revoked while a live code is
+    // still unconsumed reads as dead in the DB but can still mint a successor
+    // family through the code-exchange path.
+    const updates = captureUpdates();
+
+    await revokeGrantsDurablyInCurrentDbContext({ grantIds: ['g1', 'g2'], reason: 'disconnect' });
+
+    expect(updates.map((u) => u.table)).toEqual([oauthAuthorizationCodes, oauthGrants]);
+
+    const codes = updates[0]!;
+    expect(codes.set).toEqual(expect.objectContaining({ consumedAt: expect.any(Date) }));
+    // The provider reads `payload.consumed` to fire its own replay handling,
+    // so the canonical payload stamp must travel with consumed_at.
+    expect(inspectClause((codes.set as { payload?: unknown }).payload).sql).toContain('jsonb_set');
+    const codeWhere = inspectClause(codes.where);
+    expect(codeWhere.columns).toEqual(expect.arrayContaining([
+      oauthAuthorizationCodes.consumedAt.name,
+      oauthAuthorizationCodes.expiresAt.name,
+    ]));
+    expect(codeWhere.sql).toContain('is null');
+  });
+
+  it('stamps revoked_at only on Grants that are not already revoked', async () => {
+    const updates = captureUpdates();
+
+    await revokeGrantsDurablyInCurrentDbContext({ grantIds: ['g1'], reason: 'refresh-token-reuse' });
+
+    const grantUpdate = updates.find((u) => u.table === oauthGrants);
+    expect(grantUpdate?.set).toEqual({ revokedAt: expect.any(Date), revokedReason: 'refresh-token-reuse' });
+    const where = inspectClause(grantUpdate?.where);
+    expect(where.columns).toEqual(expect.arrayContaining([oauthGrants.id.name, oauthGrants.revokedAt.name]));
+    // Re-stamping would overwrite the first revocation's reason and timestamp.
+    expect(where.sql).toContain('is null');
+  });
+
+  it('records revoked_by_user_id only when the caller supplies an actor', async () => {
+    const withActor = captureUpdates();
+    await revokeGrantsDurablyInCurrentDbContext({ grantIds: ['g1'], reason: 'r', revokedByUserId: 'user-1' });
+    expect(withActor.find((u) => u.table === oauthGrants)?.set).toEqual(
+      expect.objectContaining({ revokedByUserId: 'user-1' }),
+    );
+
+    vi.clearAllMocks();
+    const withoutActor = captureUpdates();
+    await revokeGrantsDurablyInCurrentDbContext({ grantIds: ['g1'], reason: 'r' });
+    expect(withoutActor.find((u) => u.table === oauthGrants)?.set).not.toHaveProperty('revokedByUserId');
+  });
+
+  it('cascades to sibling refresh tokens by payload grantId when asked', async () => {
+    const updates = captureUpdates();
+
+    await revokeGrantsDurablyInCurrentDbContext({
+      grantIds: ['g1'],
+      reason: 'refresh-token-reuse',
+      cascadeRefreshTokens: true,
+    });
+
+    expect(updates.map((u) => u.table)).toEqual([
+      oauthAuthorizationCodes,
+      oauthRefreshTokens,
+      oauthGrants,
+    ]);
+    const refresh = updates[1]!;
+    expect(refresh.set).toEqual({ revokedAt: expect.any(Date) });
+    const where = inspectClause(refresh.where);
+    expect(where.columns).toContain(oauthRefreshTokens.revokedAt.name);
+    expect(where.sql).toContain("->>'grantid'");
+    expect(where.sql).toContain('is null');
+  });
+
+  it('leaves sibling refresh tokens alone when the caller revokes explicit ids itself', async () => {
+    const updates = captureUpdates();
+
+    await revokeGrantsDurablyInCurrentDbContext({ grantIds: ['g1'], reason: 'scoped-disconnect' });
+
+    expect(updates.map((u) => u.table)).not.toContain(oauthRefreshTokens);
+  });
+});

--- a/apps/api/src/oauth/grantStatus.ts
+++ b/apps/api/src/oauth/grantStatus.ts
@@ -1,0 +1,29 @@
+import { and, eq, gte, isNull } from 'drizzle-orm';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
+import { oauthGrants } from '../db/schema';
+
+/**
+ * Durable Grant activity is the authority for every OAuth mint and use path.
+ * Redis remains the eager revocation signal for already-issued access tokens,
+ * but it is deliberately not the source of truth: its marker expires.
+ */
+export async function isOAuthGrantActiveInCurrentDbContext(
+  grantId: string,
+  now = new Date(),
+): Promise<boolean> {
+  const [row] = await db
+    .select({ id: oauthGrants.id })
+    .from(oauthGrants)
+    .where(and(
+      eq(oauthGrants.id, grantId),
+      isNull(oauthGrants.revokedAt),
+      gte(oauthGrants.expiresAt, now),
+    ));
+  return !!row;
+}
+
+export function isOAuthGrantDurablyActive(grantId: string, now = new Date()): Promise<boolean> {
+  return runOutsideDbContext(() =>
+    withSystemDbAccessContext(() => isOAuthGrantActiveInCurrentDbContext(grantId, now)),
+  );
+}

--- a/apps/api/src/oauth/grantStatus.ts
+++ b/apps/api/src/oauth/grantStatus.ts
@@ -1,12 +1,25 @@
-import { and, eq, gte, isNull } from 'drizzle-orm';
+import { and, eq, gt, gte, inArray, isNull, sql, type SQL } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
-import { oauthGrants } from '../db/schema';
+import { oauthAuthorizationCodes, oauthGrants, oauthRefreshTokens } from '../db/schema';
 
 /**
  * Durable Grant activity is the authority for every OAuth mint and use path.
  * Redis remains the eager revocation signal for already-issued access tokens,
  * but it is deliberately not the source of truth: its marker expires.
+ *
+ * This is the ONE definition of "this Grant is still live". Every caller —
+ * adapter lookups, scope resolution, the bearer-admission join — composes this
+ * condition rather than re-spelling the predicate, so a future change to what
+ * "active" means cannot land on some paths and miss others.
  */
+export function activeGrantCondition(grantId: string, now: Date): SQL {
+  return and(
+    eq(oauthGrants.id, grantId),
+    isNull(oauthGrants.revokedAt),
+    gte(oauthGrants.expiresAt, now),
+  ) as SQL;
+}
+
 export async function isOAuthGrantActiveInCurrentDbContext(
   grantId: string,
   now = new Date(),
@@ -14,11 +27,7 @@ export async function isOAuthGrantActiveInCurrentDbContext(
   const [row] = await db
     .select({ id: oauthGrants.id })
     .from(oauthGrants)
-    .where(and(
-      eq(oauthGrants.id, grantId),
-      isNull(oauthGrants.revokedAt),
-      gte(oauthGrants.expiresAt, now),
-    ));
+    .where(activeGrantCondition(grantId, now));
   return !!row;
 }
 
@@ -26,4 +35,85 @@ export function isOAuthGrantDurablyActive(grantId: string, now = new Date()): Pr
   return runOutsideDbContext(() =>
     withSystemDbAccessContext(() => isOAuthGrantActiveInCurrentDbContext(grantId, now)),
   );
+}
+
+export interface DurableGrantRevocationOptions {
+  grantIds: string[];
+  /** Written to `oauth_grants.revoked_reason`. */
+  reason: string | null;
+  /** Written to `oauth_grants.revoked_by_user_id` when the caller knows the actor. */
+  revokedByUserId?: string | null;
+  /**
+   * Also revoke every unrevoked refresh token whose payload `grantId` matches.
+   * Callers that already hold the exact refresh-token ids they mean to revoke
+   * (scoped disconnects) leave this off and revoke those rows themselves.
+   */
+  cascadeRefreshTokens?: boolean;
+  now?: Date;
+}
+
+/**
+ * The single durable "this Grant is dead" write, shared by every revocation
+ * path: connected-app disconnect, tenant lifecycle, oidc-provider's own
+ * `revokeGrant` (authorization-code replay) and refresh-token reuse detection.
+ *
+ * Order is load-bearing and mirrors the marker-then-stamp discipline in
+ * `revocationService.ts`: live capabilities (authorization codes, sibling
+ * refresh tokens) die BEFORE `revoked_at` is stamped. A stamped-but-unswept
+ * Grant would read as revoked in the DB while its in-flight artifacts still
+ * minted successors.
+ *
+ * Runs in the caller's DB context — every caller already holds a system
+ * context (and usually a transaction), so the whole sweep is atomic with
+ * whatever else that caller is doing.
+ */
+export async function revokeGrantsDurablyInCurrentDbContext(
+  opts: DurableGrantRevocationOptions,
+): Promise<void> {
+  const { grantIds } = opts;
+  if (grantIds.length === 0) return;
+  const now = opts.now ?? new Date();
+
+  // A pre-revocation authorization code is itself a live capability. Mark it
+  // consumed with the provider's canonical payload shape so a later exchange
+  // follows the normal invalid_grant path instead of minting a fresh family
+  // once the eager Redis marker has expired.
+  await db
+    .update(oauthAuthorizationCodes)
+    .set({
+      consumedAt: now,
+      payload: sql`jsonb_set(${oauthAuthorizationCodes.payload}, '{consumed}', ${Math.floor(now.getTime() / 1000)}::text::jsonb, true)`,
+    })
+    .where(and(
+      inArray(sql<string>`${oauthAuthorizationCodes.payload}->>'grantId'`, grantIds),
+      isNull(oauthAuthorizationCodes.consumedAt),
+      gt(oauthAuthorizationCodes.expiresAt, now),
+    ));
+
+  if (opts.cascadeRefreshTokens) {
+    await db
+      .update(oauthRefreshTokens)
+      .set({ revokedAt: now })
+      .where(and(
+        inArray(sql<string>`${oauthRefreshTokens.payload}->>'grantId'`, grantIds),
+        isNull(oauthRefreshTokens.revokedAt),
+      ));
+  }
+
+  // `revoked_at IS NULL` keeps the FIRST revocation's timestamp and reason:
+  // a later sweep must not overwrite the forensic record of why a Grant died.
+  const stamp: { revokedAt: Date; revokedReason: string | null; revokedByUserId?: string | null } = {
+    revokedAt: now,
+    revokedReason: opts.reason,
+  };
+  if (opts.revokedByUserId !== undefined) {
+    stamp.revokedByUserId = opts.revokedByUserId;
+  }
+  await db
+    .update(oauthGrants)
+    .set(stamp)
+    .where(and(
+      inArray(oauthGrants.id, grantIds),
+      isNull(oauthGrants.revokedAt),
+    ));
 }

--- a/apps/api/src/oauth/provider.test.ts
+++ b/apps/api/src/oauth/provider.test.ts
@@ -79,6 +79,7 @@ function mockSelectError(error: unknown) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  resolveGrantContextMock.mockResolvedValue({ grantId: 'grant-default', partnerId: 'p1', orgId: null });
 });
 
 afterEach(() => {
@@ -127,7 +128,18 @@ describe('buildExtraTokenClaims', () => {
     expect(selectMock).not.toHaveBeenCalled();
   });
 
+  it('denies minting when the durable Grant is revoked or expired', async () => {
+    resolveGrantContextMock.mockResolvedValueOnce(null);
+
+    await expect(buildExtraTokenClaims(
+      { oidc: { entities: { Grant: { jti: 'grant-revoked', accountId: 'user-1' } } } },
+      { accountId: 'user-1' },
+    )).rejects.toThrow(/grant meta missing/i);
+    expect(selectMock).not.toHaveBeenCalled();
+  });
+
   it('includes the active user auth epoch and preserves partner, org, and grant claims', async () => {
+    resolveGrantContextMock.mockResolvedValue({ grantId: 'grant-1', partnerId: 'p1', orgId: 'o1' });
     const query = mockSelectRows([{ id: 'user-1', status: 'active', authEpoch: 7 }]);
 
     await expect(
@@ -162,6 +174,7 @@ describe('buildExtraTokenClaims', () => {
   });
 
   it('preserves a null organization claim for a partner-scoped grant', async () => {
+    resolveGrantContextMock.mockResolvedValue({ grantId: 'grant-2', partnerId: 'p1', orgId: null });
     mockSelectRows([{ id: 'user-1', status: 'active', authEpoch: 3 }]);
 
     await expect(
@@ -255,6 +268,7 @@ describe('buildExtraTokenClaims', () => {
   });
 
   it('does not project any other grant fields beyond the canonical access claims', async () => {
+    resolveGrantContextMock.mockResolvedValue({ grantId: 'grant-3', partnerId: 'p1', orgId: 'o1' });
     // grant_id is now also surfaced (added 2026-04-24 so bearer middleware can
     // check the grant-revocation cache and reject every access JWT minted
     // under a revoked grant). Aside from that the projection stays narrow.

--- a/apps/api/src/oauth/provider.ts
+++ b/apps/api/src/oauth/provider.ts
@@ -8,7 +8,7 @@ import {
   OAUTH_ISSUER,
   OAUTH_RESOURCE_URL,
 } from '../config/env';
-import { BreezeOidcAdapter, getGrantBreezeMeta, getGrantBreezeMetaAsync } from './adapter';
+import { BreezeOidcAdapter } from './adapter';
 import { findAccount } from './findAccount';
 import { loadJwks } from './keys';
 import {
@@ -220,8 +220,10 @@ export async function buildExtraTokenClaims(
     throw new Error('OAuth Grant and access token account mismatch');
   }
 
-  const cached = getGrantBreezeMeta(grantId);
-  const meta = cached ?? grant.breeze ?? (await getGrantBreezeMetaAsync(grantId));
+  const durableGrant = grantId ? await resolveGrantContext(grantId) : null;
+  const meta = durableGrant
+    ? { partner_id: durableGrant.partnerId, org_id: durableGrant.orgId }
+    : undefined;
   // Invariant: no null-claim JWT EVER leaves the server. If a grant_id is
   // present (the only case that produces a real access token), we must be
   // able to resolve its tenancy — otherwise bearer middleware would later

--- a/apps/api/src/oauth/revocationService.test.ts
+++ b/apps/api/src/oauth/revocationService.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
+import { oauthAuthorizationCodes } from '../db/schema';
 import { revokeGrant, revokeJti } from './revocationCache';
 import { revokeClientFamilies } from './revocationService';
 
@@ -64,6 +65,18 @@ const PARTNER = '22222222-2222-2222-2222-222222222222';
 const USER = '11111111-1111-1111-1111-111111111111';
 
 describe('revokeClientFamilies', () => {
+  it('invalidates every still-live authorization code for a revoked grant before it can restart authority', async () => {
+    mockSelectRows([{ id: 'grant-with-live-code', accountId: USER }]);
+    mockSelectRows([]);
+
+    await revokeClientFamilies(CLIENT, { kind: 'partner', partnerId: PARTNER });
+
+    expect(updateMock).toHaveBeenCalledWith(oauthAuthorizationCodes);
+    expect(updateSetCalls).toContainEqual(expect.objectContaining({
+      consumedAt: expect.any(Date),
+    }));
+  });
+
   it('revokes a code-only grant (no refresh row) under partner scope and deletes only the join row', async () => {
     mockSelectRows([{ id: 'grant-code-only', accountId: USER }]); // grants
     mockSelectRows([]); // refresh rows (none — code-only)

--- a/apps/api/src/oauth/revocationService.ts
+++ b/apps/api/src/oauth/revocationService.ts
@@ -1,6 +1,7 @@
-import { and, eq, gt, inArray, isNull, sql, type SQL } from 'drizzle-orm';
+import { and, eq, inArray, isNull, sql, type SQL } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
-import { oauthAuthorizationCodes, oauthClients, oauthClientPartnerGrants, oauthGrants, oauthRefreshTokens } from '../db/schema';
+import { oauthClients, oauthClientPartnerGrants, oauthGrants, oauthRefreshTokens } from '../db/schema';
+import { revokeGrantsDurablyInCurrentDbContext } from './grantStatus';
 import { writeOAuthRevocationMarkerDurably } from './revocationRetry';
 import { ERROR_IDS, logOauthError } from './log';
 
@@ -172,33 +173,16 @@ async function revokeClientFamiliesInSystemContext(
   const grantIds = grants.map((g) => g.id);
   const refreshIds = refreshRows.map((r) => r.id);
 
-  if (grantIds.length > 0) {
-    // A pre-revocation code is itself a live capability. Mark it consumed in
-    // the same transaction as its Grant so a later code exchange cannot mint
-    // a fresh refresh family after the eager Redis marker expires. Reuse the
-    // provider's canonical consumed payload shape so any racing/sequential
-    // lookup follows the normal invalid_grant path.
-    await db
-      .update(oauthAuthorizationCodes)
-      .set({
-        consumedAt: now,
-        payload: sql`jsonb_set(${oauthAuthorizationCodes.payload}, '{consumed}', ${Math.floor(now.getTime() / 1000)}::text::jsonb, true)`,
-      })
-      .where(and(
-        inArray(sql<string>`${oauthAuthorizationCodes.payload}->>'grantId'`, grantIds),
-        isNull(oauthAuthorizationCodes.consumedAt),
-        gt(oauthAuthorizationCodes.expiresAt, now),
-      ));
-
-    await db
-      .update(oauthGrants)
-      .set({
-        revokedAt: now,
-        revokedByUserId: opts.revokedByUserId ?? null,
-        revokedReason: opts.reason ?? null,
-      })
-      .where(inArray(oauthGrants.id, grantIds));
-  }
+  // Consumes every live authorization code for these Grants, then stamps
+  // revoked_at — see revokeGrantsDurablyInCurrentDbContext for why that order.
+  // The explicit refresh rows are revoked separately below because a partner
+  // disconnect revokes only the ids its scope query selected.
+  await revokeGrantsDurablyInCurrentDbContext({
+    grantIds,
+    reason: opts.reason ?? null,
+    revokedByUserId: opts.revokedByUserId ?? null,
+    now,
+  });
 
   if (refreshIds.length > 0) {
     await db

--- a/apps/api/src/oauth/revocationService.ts
+++ b/apps/api/src/oauth/revocationService.ts
@@ -1,6 +1,6 @@
-import { and, eq, inArray, isNull, type SQL } from 'drizzle-orm';
+import { and, eq, gt, inArray, isNull, sql, type SQL } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
-import { oauthClients, oauthClientPartnerGrants, oauthGrants, oauthRefreshTokens } from '../db/schema';
+import { oauthAuthorizationCodes, oauthClients, oauthClientPartnerGrants, oauthGrants, oauthRefreshTokens } from '../db/schema';
 import { writeOAuthRevocationMarkerDurably } from './revocationRetry';
 import { ERROR_IDS, logOauthError } from './log';
 
@@ -173,6 +173,23 @@ async function revokeClientFamiliesInSystemContext(
   const refreshIds = refreshRows.map((r) => r.id);
 
   if (grantIds.length > 0) {
+    // A pre-revocation code is itself a live capability. Mark it consumed in
+    // the same transaction as its Grant so a later code exchange cannot mint
+    // a fresh refresh family after the eager Redis marker expires. Reuse the
+    // provider's canonical consumed payload shape so any racing/sequential
+    // lookup follows the normal invalid_grant path.
+    await db
+      .update(oauthAuthorizationCodes)
+      .set({
+        consumedAt: now,
+        payload: sql`jsonb_set(${oauthAuthorizationCodes.payload}, '{consumed}', ${Math.floor(now.getTime() / 1000)}::text::jsonb, true)`,
+      })
+      .where(and(
+        inArray(sql<string>`${oauthAuthorizationCodes.payload}->>'grantId'`, grantIds),
+        isNull(oauthAuthorizationCodes.consumedAt),
+        gt(oauthAuthorizationCodes.expiresAt, now),
+      ));
+
     await db
       .update(oauthGrants)
       .set({

--- a/apps/api/src/routes/oauth.ts
+++ b/apps/api/src/routes/oauth.ts
@@ -6,6 +6,7 @@ import { getProvider } from '../oauth/provider';
 import { MCP_OAUTH_ENABLED, OAUTH_DCR_ENABLED, OAUTH_ISSUER, OAUTH_RESOURCE_URL } from '../config/env';
 import { loadPublicJwks } from '../oauth/keys';
 import { db, withDbAccessContext } from '../db';
+import { GRANT_REVOCATION_TTL_SECONDS } from '../oauth/adapter';
 import { writeOAuthRevocationMarkerDurably } from '../oauth/revocationRetry';
 import { normalizeFormEncodedResource, normalizeResourceParams } from '../oauth/resourceIndicators';
 import { ERROR_IDS, logOauthDebug, logOauthError } from '../oauth/log';
@@ -623,6 +624,13 @@ if (MCP_OAUTH_ENABLED) {
     }
     const ttl = Math.max(exp - Math.floor(Date.now() / 1000), 1);
     const expiresAt = new Date((Math.floor(Date.now() / 1000) + ttl) * 1000);
+    // The jti marker only has to outlive the ONE token being revoked, so its
+    // own `exp` is the right TTL. The grant marker has to outlive every access
+    // token minted under that Grant — including ones issued after this
+    // request — so it takes the grant-wide TTL instead. Using the presented
+    // token's remaining lifetime here left a sibling JWT usable after the
+    // marker lapsed and before the durable sweep was consulted.
+    const grantMarkerExpiresAt = new Date(Date.now() + GRANT_REVOCATION_TTL_SECONDS * 1000);
     let retryQueued = false;
     try {
       await withDbAccessContext({
@@ -648,7 +656,7 @@ if (MCP_OAUTH_ENABLED) {
             userId,
             markerType: 'grant',
             markerId: grantId,
-            expiresAt,
+            expiresAt: grantMarkerExpiresAt,
           });
           retryQueued ||= grantResult.status === 'retry_queued';
         }

--- a/apps/api/src/routes/oauthInteraction.ts
+++ b/apps/api/src/routes/oauthInteraction.ts
@@ -13,9 +13,6 @@ import { BILLING_URL, MCP_OAUTH_ENABLED, OAUTH_ISSUER } from '../config/env';
 import { ERROR_IDS, logOauthError } from '../oauth/log';
 import { writeRouteAudit } from '../services/auditEvents';
 
-// Grant TTL in seconds — must match `ttl.Grant` in oauth/provider.ts so the
-// breeze metadata side-table entry expires no later than the Grant itself.
-const GRANT_TTL_SECONDS = 14 * 24 * 60 * 60;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 const asSystem = <T>(fn: () => Promise<T>): Promise<T> =>
@@ -433,7 +430,7 @@ if (MCP_OAUTH_ENABLED) {
     // null` that bearer middleware rejects. The Grant.save() above is
     // recoverable on a retry click since the auth code is short-lived.
     try {
-      await setGrantBreezeMeta(grantId, { partner_id: body.partner_id, org_id: orgId }, GRANT_TTL_SECONDS);
+      await setGrantBreezeMeta(grantId, { partner_id: body.partner_id, org_id: orgId });
     } catch {
       // setGrantBreezeMeta already logs with errorId. Surface a generic 500
       // to the consent client; they can retry.


### PR DESCRIPTION
## Summary

Two related OAuth findings on the `MCP_OAUTH_ENABLED` route groups (flag defaults to `false`, so deployments that never turned MCP OAuth on are not exposed), plus a third commit closing three more paths that review found were still non-durable.

### SEC-139 — grant revocation was not durable at the boundaries that matter (Medium)

Revoking a public OAuth client (user self-revoke, or an operator disconnecting the connected app) wrote an **eager Redis marker** and stamped `oauth_grants.revoked_at` plus the refresh rows — but it left any still-live authorization code + PKCE verifier usable, and none of the read paths treated the durable `oauth_grants` row as the continuing authority:

- adapter `find()` for `AuthorizationCode` / `RefreshToken` returned the persisted capability without looking at its Grant;
- `resolveGrantContext` answered from a **process-local metadata cache** that outlives a `revoked_at` transition, so scope computation and access-token claim construction could be served entirely from stale in-memory state;
- bearer admission treated `grant_id` as optional and consulted only the Redis marker.

The Redis marker expires. After it did, a code holder could exchange the old code and **restore the entire consented credential family** — a fresh refresh token and fresh access tokens under a Grant the user had already revoked.

The invariant enforced: the exact Grant row must **exist, be unrevoked and be unexpired** at every exchange, mint, scope and bearer-use boundary. A cache marker may accelerate denial but never replace the database predicate, and database uncertainty fails closed.

- New `apps/api/src/oauth/grantStatus.ts` owns the one active-Grant predicate (`activeGrantCondition`: exact id, `revoked_at IS NULL`, `expires_at >= now`). Every reader composes it rather than re-spelling it.
- Adapter `find()` for `AuthorizationCode` and `RefreshToken` rejects a missing, malformed, revoked or expired Grant before returning the capability; `find()` for `Grant` gains the same predicate.
- `resolveGrantContext` always reads the durable row and propagates DB failure instead of degrading. `buildExtraTokenClaims` resolves tenancy through it.
- Bearer admission **requires** a `grant_id` claim, checks the Redis marker, then the durable Grant state. Uncertainty → retryable **503**; inactive Grant → **401**.
- Every revocation path consumes still-live authorization codes — stamping oidc-provider's canonical `payload.consumed` epoch — **before** stamping `revoked_at`. (Ordering matters: a stamped-but-unswept Grant reads as revoked in the DB while its in-flight artifacts still mint successors.)

### SEC-140 — token-artifact consumption was not single-use under concurrency (Medium)

`oidc-provider@9.8.4` does find → validate → in-memory consumed check → `await adapter.consume()` → save successors. Breeze's adapter issued an unconditional `UPDATE` and never checked the affected-row count, so two concurrent exchanges of the same authorization code (with its PKCE verifier), or of the same rotating refresh token, could both read the fresh artifact, both report a successful consume, and both mint live successors.

Consumption is now a single database compare-and-set:

- `AuthorizationCode`: update the exact id only `WHERE consumed_at IS NULL`, stamping `consumed_at` **and** the canonical `payload.consumed` epoch in the same statement, `RETURNING id`, require cardinality exactly 1.
- `RefreshToken`: update the sha256 storage id only `WHERE revoked_at IS NULL`, `RETURNING id`, require cardinality exactly 1.
- A zero-row result throws `errors.InvalidGrant` → HTTP 400 `invalid_grant`, non-oracular for missing, already-consumed and already-revoked artifacts alike. Because the provider awaits `consume()` before any successor save, a thrown CAS loser cannot reach a successor sink.

### Review round — three paths the invariant did not yet reach (`788fc76529`)

Review of the first two commits was SHIP-WITH-FIXES. All three findings are the same bug class the port set out to fix — an eager Redis marker standing in for a durable record that expires out from under it — so the third commit finishes the job rather than deferring it.

1. **Refresh-token reuse detection wrote only the Redis marker.** `adapter.find()` on a replayed rotation logged `OAUTH_REFRESH_TOKEN_REUSE` and wrote the grant marker (TTL 1800s), but never stamped `oauth_grants.revoked_at` and never revoked the sibling refresh tokens — while the comment above it claimed it revoked "the entire grant family". With SEC-139's predicate now gating every read, that gap became sharper, not softer: after the marker lapsed a stolen sibling passed `activeGrantCondition` and the thief regained the family. Now does the full durable sweep.
2. **`revokeByGrantId` — oidc-provider's own `revokeGrant`, fired on authorization-code replay — revoked refresh rows only**, leaving `revoked_at` NULL and live authorization codes untouched. Same sweep applied.
3. **Bearer admission had become two sequential system-context round-trips** (`assertLiveOAuthUser`, then the durable Grant check). Given this repo's pool-starvation history that is a real cost on the hottest OAuth path. The Grant is now a `LEFT JOIN` inside the existing live-user query — one round-trip, as before the port. No positive cache was added. 503-on-uncertainty is unchanged and now covers *both* facts: a failure of the combined query can never be read as "grant active".

Plus the cheap ones:

4. `/oauth/revoke` (RFC 7009) sized the **grant-wide** marker from the presented token's remaining lifetime; a sibling JWT could outlive it. It now uses `GRANT_REVOCATION_TTL_SECONDS`, like every other grant marker. (The `jti` marker correctly keeps the token's own `exp` — it only has to outlive the one token.)
5. **The process-local Grant tenancy cache is deleted outright.** `requiredPartnerId` / `resolvedOrgId` were its last readers; they now read the durable row, which `find()` has already proven active by the time they run. With no reader left, the map, its TTL bookkeeping and the sync accessor are gone rather than left as a trap. This is the "known limitation" the previous PR body flagged — it is now closed, not documented.
6. The predicate tests assert the rendered operator tokens (`is null`, `>=`, and the absence of `is not null` / `<=`), not just the column references — `expires_at <= now` touches the same columns and inverts the meaning.
7. A comment where `consume()` throws `InvalidGrant` on a lost CAS notes that it skips oidc-provider's replay `revokeGrant` handler **in the true-concurrent case only** (the winner there is a legitimate first use). A genuine later replay still reaches `find()`, sees `payload.consumed` and fires `revokeGrant` normally — which, after fix 2, is itself now durable.

All four revocation paths — connected-app disconnect, tenant lifecycle, provider `revokeGrant`, reuse detection — share one `revokeGrantsDurablyInCurrentDbContext`. It consumes live codes, optionally cascades to sibling refresh tokens, then stamps `revoked_at`/`revoked_reason` only on rows not already revoked, so the first revocation's forensic record survives a later sweep.

## Ported from

Two locally-tested commits from the private security-remediation program, cherry-picked with `-x`:

| Local commit | Finding | Landed as |
|---|---|---|
| `14b261d848ba88a785173d93b3bbeb9a8b6ae4f2` | SEC-2026-09-05-139 | `4c08cda18e` |
| `43fd22aab79a239ae63d2708c13d6f8bcffdf6e6` | SEC-2026-09-05-140 | `b11ac3a0b2` |
| — (review round, authored here) | SEC-139 follow-through | `788fc76529` |
| — (re-review, comment-only) | `#2363` block accuracy | `9a54fa0bef` |

The originals were authored against `f429b5cf1d` (2026-09-06). **All six touched source files were byte-identical between that base and current `main`** (verified: `git rev-parse <base>:<file>` vs `origin/main:<file>` for `bearerTokenAuth.ts` and `oauth/{adapter,effectiveScopes,grantRevocation,provider,revocationService}.ts` — six `SAME`), so nothing was dropped as already-on-main and no security intent was re-derived. Nothing was superseded by PR #5475's auth family.

Changed vs. the originals:

1. **One conflict, imports only.** Both commits edit `adapter.ts`'s import block; resolved as the union. No logic hunk conflicted.
2. **Two `effectiveScopes.test.ts` tests were rewritten because the ported versions were vacuous** — both passed against `main`'s unfixed source. The originals deleted the `vi.mock('./adapter')` stub, so the "no fast path" test only proved an *empty* real cache misses, and the "revoked row" test stubbed the query result without asserting the predicate. They now assert the clause's own columns **and** operator fragments, walking `queryChunks` and inspecting column objects (`.name` + `.table`) rather than a stringified predicate — which avoids the known false positive where a deep string search matches a bound pg enum's `enumValues`.
3. **The third commit is new work**, not part of either original patch.

No migrations, no schema columns, no new tables — so no RLS/cascade/export-policy registration applies.

## Verification

All commands from `apps/api` on the pushed tree (`788fc76529`; the head commit `9a54fa0bef` on top of it is comment-only — verified `git diff --numstat` = one file, +20/-5, no code) unless a red-first step says otherwise. Every count is **verified** (observed output), not inferred.

**Unit** — `npx vitest run --pool=threads --maxWorkers=2 src/oauth src/middleware/bearerTokenAuth src/routes/mcpServer src/routes/oauth`
→ **40 files, 478 passed / 3 skipped (481)**.

**Integration** — `npx vitest run --config vitest.integration.config.ts --pool=threads --maxWorkers=2 src/__tests__/integration/oauth src/__tests__/integration/mcpOrgAxisSeparation src/__tests__/integration/mobileDeviceRevocation src/__tests__/integration/mtlsCertificateRevocationLifecycle src/__tests__/integration/remoteRevocationLease`
→ **11 files, 42 passed**, against a fresh disposable Postgres+Redis (`pnpm test-stack up`). That is the whole `oauth` / `mcp` / `revocation` family, not just the diff.

**Integration-suite coverage contract** — `npx vitest run --config vitest.config.integration-suite-coverage.ts` → **1 file, 5 passed**. Run explicitly because this suite is *excluded* from `vitest.integration.config.ts`; it proves the new `oauth-token-consume-race.integration.test.ts` is picked up by a CI shard rather than silently running nowhere.

**Site-scope coverage contract** — `npx vitest run --config vitest.config.site-scope-coverage.ts` → **1 file, 7 passed** (also excluded from the integration config). No `routes/` handler behaviour changed, so this is a no-change control.

**Typecheck** — `NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit` → **exit 0**.

**Lint** — `npx eslint` over every changed `apps/api` file → **exit 0**.

### New tests

| Test | Guards |
|---|---|
| `grantStatus.test.ts` › `activeGrantCondition` requires the exact id, an unrevoked row and an unexpired row | the shared predicate, incl. operator direction |
| `grantStatus.test.ts` › `isOAuthGrantActiveInCurrentDbContext` is true only when the active predicate returns the row | the read path |
| `grantStatus.test.ts` › is a no-op on an empty grant list | no stray writes |
| `grantStatus.test.ts` › consumes live authorization codes BEFORE stamping `revoked_at` | sweep ordering + `jsonb_set` payload stamp |
| `grantStatus.test.ts` › stamps `revoked_at` only on Grants that are not already revoked | forensic record survives a later sweep |
| `grantStatus.test.ts` › records `revoked_by_user_id` only when the caller supplies an actor | no null-clobbering the actor |
| `grantStatus.test.ts` › cascades to sibling refresh tokens by payload `grantId` when asked | fix 1 / fix 2 sweep shape |
| `grantStatus.test.ts` › leaves sibling refresh tokens alone when the caller revokes explicit ids itself | scoped partner disconnect unchanged |
| `adapter.test.ts` › refresh-token reuse revokes the Grant durably, not just with an expiring Redis marker | **fix 1** |
| `adapter.test.ts` › does not attempt a durable grant sweep when the reused token carries no grantId | fix 1 negative control |
| `adapter.test.ts` › `revokeByGrantId` durably revokes the Grant, its codes and its refresh family | **fix 2** |
| `bearerTokenAuth.test.ts` › resolves the durable Grant in the SAME query as the live user (one round-trip) | **fix 3** |
| `bearerTokenAuth.test.ts` › reports `grantActive` from the joined row when a grant id is supplied | fix 3 both polarities |
| `oauth-token-consume-race.integration.test.ts` › refresh-token reuse durably revokes the Grant and its whole family, not just a Redis marker | **fix 1, real Postgres + real provider** |

### Red-first evidence

Ported and new tests must discriminate, so each was re-run against source with the fix removed.

**Ported unit (commits 1–2).** `git checkout origin/main -- apps/api/src/middleware/bearerTokenAuth.ts apps/api/src/oauth/{adapter,effectiveScopes,grantRevocation,provider,revocationService}.ts` (leaving the new `grantStatus.ts`, which has no `main` version):
→ **5 files failed, 13 tests failed / 371 passed**, naming the boundaries directly: `rejects a bearer whose Redis marker expired but whose Grant is durably revoked`, `fails closed with 503 when durable Grant status cannot be read`, `rejects an AuthorizationCode consume that loses the atomic single-use claim`, `rejects a still-live AuthorizationCode after its durable Grant is revoked`, `invalidates every still-live authorization code for a revoked grant before it can restart authority`, `denies minting when the durable Grant is revoked or expired`, and others. Restored → green.

`effectiveScopes.test.ts` was **0 of those 13** on the first pass — that is what exposed the two vacuous tests. After the rewrite, `git checkout origin/main -- apps/api/src/oauth/effectiveScopes.ts` gives **7 failed / 8 passed (15)** with both rewritten tests among them. (The other 5 are collateral: `main`'s cache fast path never consumes its `mockReturnValueOnce` select stub, which leaks into later cases. Pre-existing test-isolation behaviour — `beforeEach` uses `vi.clearAllMocks()`, which does not drain `*Once` queues — and it only manifests on unfixed source.)

**Ported integration (commit 2).** `git checkout origin/main -- apps/api/src/oauth/{adapter,revocationService}.ts` → **3 failed / 3 passed (6)**: both real-Postgres race tests plus `revokes a code-only grant (no refresh row) under partner scope and removes only the join row`. Restored → 6 passed.

**Review fixes (commit 3)** were red-checked *surgically* — one hunk removed at a time, so the red is attributable rather than a whole-file revert:

- Removed only the `revokeGrantsDurablyInCurrentDbContext` call in the reuse branch → real-Postgres run: **1 failed / 2 passed**, the failure being exactly `refresh-token reuse durably revokes the Grant and its whole family, not just a Redis marker`.
- Removed both new adapter sweeps (reuse branch + `revokeByGrantId`, the latter restored to its old refresh-only `UPDATE`) → **2 failed / 34 passed**, exactly the two new adapter tests, nothing else.
- Removed only the `.leftJoin(oauthGrants, …)` (pinning `grantActive` to `true`) → **1 failed / 42 passed**, exactly `resolves the durable Grant in the SAME query as the live user (one round-trip)`.
- Removed only the `if (!liveUser.grantActive) throw` gate → **1 failed / 42 passed**, exactly `rejects a bearer whose Redis marker expired but whose Grant is durably revoked`.

The `bearerTokenAuth.test.ts` grant-status mock deliberately keeps the **real** `activeGrantCondition` (`vi.importActual`), so the join-condition assertions test the production predicate, not a double.

### Not checked

- Full API unit corpus (only the OAuth/bearer/MCP/oauth-routes family above); CI covers it.
- Browser / multi-replica / soak behaviour.
- Anything gated behind actually enabling `MCP_OAUTH_ENABLED` in a deployed environment.

## Operator impact

- **`MCP_OAUTH_ENABLED=false` deployments see no behaviour change.** The affected route groups are not mounted.
- **A `grant_id` claim is now mandatory on OAuth bearers.** Any legacy access JWT lacking it gets `401 token missing required claims`. Intentional fail-closed. Current issuance has always set the claim (`buildExtraTokenClaims` throws outright when it cannot resolve a Grant), access tokens are short-lived, and grep confirms nothing outside the oidc-provider mints tokens for `OAUTH_RESOURCE_URL` — so the practical window is one token lifetime. Reviewer independently verified there are no first-party OAuth bearer holders.
- **Bearer admission costs the same round-trip it did before this PR.** The durable Grant check is a `LEFT JOIN` on the existing live-user query, not a second query. Adapter `find()` for codes/refresh tokens does do one extra indexed PK read on the exchange path (not the per-request path).
- **Database uncertainty on that query is availability-failing**: `503` rather than admitting the request. Deliberate — a Postgres blip surfaces as OAuth 503s instead of silent authorization on stale cache.
- **Redis being unreachable still hard-401s every OAuth bearer.** That is pre-existing fail-closed behaviour in `isGrantRevoked`, unchanged by this PR and called out here only because this PR makes the durable check available as an alternative. A follow-up could degrade a Redis outage to "durable check + 503" instead of a blanket 401; deliberately out of scope here.
- **Revocation now sweeps more.** Disconnecting a connected app, a tenant-lifecycle revoke, an authorization-code replay and a refresh-token reuse all now consume live authorization codes and (for the latter two) revoke every sibling refresh token, then stamp `revoked_at`. A client mid-flow at revoke time gets `invalid_grant` instead of a working token — the intended outcome, but it changes the observed error for that race.
- **Refresh-token reuse is now permanently fatal to the family, not fatal-for-1800s — support runbooks must expect re-consent.** Previously the compromise was recorded only in the Redis grant marker, so an affected family effectively recovered once the marker expired (`GRANT_REVOCATION_TTL_SECONDS`). It now stamps `oauth_grants.revoked_at` and revokes every sibling refresh token, which is the point (a thief must not be able to wait the marker out) — but it means an affected client **cannot** recover by retrying later. The correct remediation is "re-authorize the connected app", not "wait and retry". The `#2363` comment block in `adapter.ts` has been updated to say so at the call site.
  The *trigger* is unchanged: this fires on any presentation of a consumed/revoked RT, including an innocent spec-correct retry after a failed exchange, because oidc-provider rotates the token before it finishes validating. Genuine rotation replay is the canonical token-theft signal and deliberately stays fatal; the known innocent trigger is fixed upstream instead, by resource-alias normalization (`normalizeResourceParams` in `oauth/resourceIndicators.ts`, applied by `routes/oauth.ts`), so an alias-only `resource` mismatch no longer fails the exchange in the first place. The `revoked_at` / `revoked_ms_ago` fields on the `OAUTH_REFRESH_TOKEN_REUSE` log let on-call separate the two: an innocent retry presents within seconds of revocation, theft replay typically much later.
- **Concurrent duplicate exchanges now lose deterministically** with `400 invalid_grant`. A client that fires the same code or refresh token twice in parallel used to sometimes get two working token sets; it now gets one success and one `invalid_grant`.
- **`bearerTokenAuthMiddleware` is OAuth-JWT-only** (issuer + audience verified against `OAUTH_ISSUER` / `OAUTH_RESOURCE_URL`); plain API-key bearers are handled elsewhere and are unaffected by the new `grant_id` requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Tugfg88kFiowD7E5xQFpU
