### PR TITLE
fix(backup): minimize verification listings, bind vault mutations to current site, bind local vaults to the device tenant (SEC-021, SEC-024, SEC-026)

### DIFF
--- a/apps/api/migrations/2026-10-15-160110-local-vault-device-org-fk.sql
+++ b/apps/api/migrations/2026-10-15-160110-local-vault-device-org-fk.sql
@@ -1,0 +1,46 @@
+-- SEC-2026-09-05-026: bind each local vault's tenant axis to its device.
+--
+-- Older application code admitted caller-org rows that named another org's
+-- device. Delete those unusable configurations before enforcing the invariant;
+-- report both the parent and cascaded inventory counts for forensic follow-up.
+SELECT set_config('breeze.scope', 'system', true);
+
+DO $$
+DECLARE
+  mismatch_vault_count bigint;
+  mismatch_inventory_count bigint;
+BEGIN
+  SELECT count(*) INTO mismatch_inventory_count
+  FROM vault_snapshot_inventory AS inventory
+  JOIN local_vaults AS vault ON vault.id = inventory.vault_id
+  JOIN devices AS device ON device.id = vault.device_id
+  WHERE vault.org_id <> device.org_id;
+
+  DELETE FROM local_vaults AS vault
+  WHERE EXISTS (
+    SELECT 1
+    FROM devices AS device
+    WHERE device.id = vault.device_id
+      AND device.org_id <> vault.org_id
+  );
+  GET DIAGNOSTICS mismatch_vault_count = ROW_COUNT;
+
+  RAISE WARNING
+    'SEC-026 cleanup removed % mismatched local vault(s) and cascaded % snapshot inventory row(s)',
+    mismatch_vault_count,
+    mismatch_inventory_count;
+END $$;
+
+DO $$
+BEGIN
+  ALTER TABLE local_vaults
+    ADD CONSTRAINT local_vaults_device_org_fkey
+    FOREIGN KEY (device_id, org_id)
+    REFERENCES devices(id, org_id)
+    DEFERRABLE INITIALLY DEFERRED
+    NOT VALID;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+ALTER TABLE local_vaults
+  VALIDATE CONSTRAINT local_vaults_device_org_fkey;

--- a/apps/api/migrations/2026-10-15-160110-local-vault-device-org-fk.sql
+++ b/apps/api/migrations/2026-10-15-160110-local-vault-device-org-fk.sql
@@ -1,34 +1,74 @@
 -- SEC-2026-09-05-026: bind each local vault's tenant axis to its device.
 --
 -- Older application code admitted caller-org rows that named another org's
--- device. Delete those unusable configurations before enforcing the invariant;
--- report both the parent and cascaded inventory counts for forensic follow-up.
+-- device. Repair those rows the way the rest of the repo repairs this shape:
+-- restamp org_id FROM THE DEVICE, which is exactly what the dynamic
+-- breeze_cascade_device_org_id() trigger has done on every device move since
+-- 2026-05-18 (2026-05-18-device-child-orgid-cascade.sql). Two reasons not to
+-- delete:
+--
+--   1. A mismatch here is indistinguishable from a benign pre-2026-05-18
+--      device move that predates that trigger's backfill window. The migration
+--      cannot tell that apart from the SEC-026 abuse path, so it must not pick
+--      the destructive reading.
+--   2. Deleting a local_vault cascades vault_snapshot_inventory
+--      (ON DELETE CASCADE), which is recovery metadata describing backups of
+--      data that lives on the VICTIM org's device. Destroying it to repair an
+--      attacker-created pointer would compound the harm.
+--
+-- The vault is deactivated as well: an attacker-chosen vault_path must not
+-- start syncing under the victim's org just because the tenant axis got
+-- corrected. A human re-enables it after confirming the path.
+--
+-- vault_snapshot_inventory keys on vault_id, not device_id, so the device
+-- trigger never covers it — it is restamped here explicitly, after the parent.
 SELECT set_config('breeze.scope', 'system', true);
 
 DO $$
 DECLARE
-  mismatch_vault_count bigint;
-  mismatch_inventory_count bigint;
+  restamped_vault_count bigint;
+  restamped_inventory_count bigint;
+  restamped_vault_ids uuid[];
+  restamped_inventory_ids uuid[];
 BEGIN
-  SELECT count(*) INTO mismatch_inventory_count
-  FROM vault_snapshot_inventory AS inventory
-  JOIN local_vaults AS vault ON vault.id = inventory.vault_id
+  -- Capture the affected ids BEFORE each repair; the predicates stop matching
+  -- once the rows are corrected. Capped at 200 so a large historical drift
+  -- cannot flood the server log; the counts are always exact and uncapped.
+  SELECT (array_agg(vault.id ORDER BY vault.id))[1:200]
+  INTO restamped_vault_ids
+  FROM local_vaults AS vault
   JOIN devices AS device ON device.id = vault.device_id
   WHERE vault.org_id <> device.org_id;
 
-  DELETE FROM local_vaults AS vault
-  WHERE EXISTS (
-    SELECT 1
-    FROM devices AS device
-    WHERE device.id = vault.device_id
-      AND device.org_id <> vault.org_id
-  );
-  GET DIAGNOSTICS mismatch_vault_count = ROW_COUNT;
+  UPDATE local_vaults AS vault
+  SET org_id = device.org_id,
+      is_active = false,
+      updated_at = now()
+  FROM devices AS device
+  WHERE device.id = vault.device_id
+    AND device.org_id <> vault.org_id;
+  GET DIAGNOSTICS restamped_vault_count = ROW_COUNT;
+
+  -- Runs after the parent restamp so it observes the corrected vault org.
+  SELECT (array_agg(inventory.id ORDER BY inventory.id))[1:200]
+  INTO restamped_inventory_ids
+  FROM vault_snapshot_inventory AS inventory
+  JOIN local_vaults AS vault ON vault.id = inventory.vault_id
+  WHERE inventory.org_id <> vault.org_id;
+
+  UPDATE vault_snapshot_inventory AS inventory
+  SET org_id = vault.org_id
+  FROM local_vaults AS vault
+  WHERE vault.id = inventory.vault_id
+    AND inventory.org_id <> vault.org_id;
+  GET DIAGNOSTICS restamped_inventory_count = ROW_COUNT;
 
   RAISE WARNING
-    'SEC-026 cleanup removed % mismatched local vault(s) and cascaded % snapshot inventory row(s)',
-    mismatch_vault_count,
-    mismatch_inventory_count;
+    'SEC-026 cleanup restamped and deactivated % mismatched local vault(s) (ids, first 200: %) and restamped % vault_snapshot_inventory row(s) (ids, first 200: %)',
+    restamped_vault_count,
+    coalesce(restamped_vault_ids, ARRAY[]::uuid[]),
+    restamped_inventory_count,
+    coalesce(restamped_inventory_ids, ARRAY[]::uuid[]);
 END $$;
 
 DO $$

--- a/apps/api/src/__tests__/integration/backupVaultMutationSiteScope.integration.test.ts
+++ b/apps/api/src/__tests__/integration/backupVaultMutationSiteScope.integration.test.ts
@@ -1,0 +1,196 @@
+import './setup';
+
+import { randomUUID } from 'node:crypto';
+
+import { eq } from 'drizzle-orm';
+import { Hono } from 'hono';
+import { describe, expect, it } from 'vitest';
+
+import { devices, localVaults, organizationUsers } from '../../db/schema';
+import { authMiddleware } from '../../middleware/auth';
+import { vaultRoutes } from '../../routes/backup/vault';
+import { createAccessToken } from '../../services/jwt';
+import { createSite, setupTestEnvironment } from './db-utils';
+import { getTestDb } from './setup';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+const JSON_HEADERS = { 'Content-Type': 'application/json' };
+
+function buildApp(): Hono {
+  const app = new Hono();
+  app.use('*', authMiddleware);
+  app.route('/backup/vault', vaultRoutes);
+  return app;
+}
+
+async function mfaToken(
+  env: Awaited<ReturnType<typeof setupTestEnvironment>>,
+  scope: 'organization' | 'partner' = 'organization',
+): Promise<string> {
+  return createAccessToken({
+    sub: env.user.id,
+    email: env.user.email,
+    roleId: env.role.id,
+    orgId: scope === 'organization' ? env.organization.id : null,
+    partnerId: env.partner.id,
+    scope,
+    mfa: true,
+    aep: 1,
+    mep: 1,
+    sid: randomUUID(),
+  });
+}
+
+async function seedDevice(orgId: string, siteId: string, label: string): Promise<string> {
+  const [row] = await getTestDb().insert(devices).values({
+    orgId,
+    siteId,
+    agentId: `vault-site-${label}-${randomUUID()}`,
+    hostname: `vault-${label}`,
+    osType: 'linux',
+    osVersion: 'test',
+    architecture: 'x64',
+    agentVersion: 'test',
+    status: 'online',
+  }).returning({ id: devices.id });
+  if (!row) throw new Error('device fixture insert failed');
+  return row.id;
+}
+
+async function seedVault(orgId: string, deviceId: string, path: string): Promise<string> {
+  const [row] = await getTestDb().insert(localVaults).values({
+    orgId,
+    deviceId,
+    vaultPath: path,
+    vaultType: 'local',
+    retentionCount: 3,
+  }).returning({ id: localVaults.id });
+  if (!row) throw new Error('vault fixture insert failed');
+  return row.id;
+}
+
+async function loadVault(id: string) {
+  const [row] = await getTestDb().select({
+    vaultPath: localVaults.vaultPath,
+    isActive: localVaults.isActive,
+  }).from(localVaults).where(eq(localVaults.id, id)).limit(1);
+  return row;
+}
+
+describe('local-vault mutations enforce the current device site', () => {
+  runDb('allows the selected site and opaquely denies a hidden site before effects', async () => {
+    const env = await setupTestEnvironment({
+      scope: 'organization',
+      rolePermissions: [{ resource: 'organizations', action: 'write' }],
+    });
+    const hiddenSite = await createSite({ orgId: env.organization.id });
+    await getTestDb().update(organizationUsers)
+      .set({ siteIds: [env.site.id] })
+      .where(eq(organizationUsers.userId, env.user.id));
+
+    const allowedDevice = await seedDevice(env.organization.id, env.site.id, 'allowed');
+    const hiddenDevice = await seedDevice(env.organization.id, hiddenSite.id, 'hidden');
+    const allowedVault = await seedVault(env.organization.id, allowedDevice, '/allowed');
+    const hiddenVault = await seedVault(env.organization.id, hiddenDevice, '/hidden');
+    const token = await mfaToken(env);
+    const app = buildApp();
+
+    const allowed = await app.request(`/backup/vault/${allowedVault}`, {
+      method: 'PATCH',
+      headers: { Authorization: `Bearer ${token}`, ...JSON_HEADERS },
+      body: JSON.stringify({ vaultPath: '/allowed-updated' }),
+    });
+    expect(allowed.status).toBe(200);
+
+    const hiddenPatch = await app.request(`/backup/vault/${hiddenVault}`, {
+      method: 'PATCH',
+      headers: { Authorization: `Bearer ${token}`, ...JSON_HEADERS },
+      body: JSON.stringify({ vaultPath: '/hidden-mutated' }),
+    });
+    expect(hiddenPatch.status).toBe(404);
+    expect(await hiddenPatch.json()).toEqual({ error: 'Vault not found' });
+
+    const hiddenDelete = await app.request(`/backup/vault/${hiddenVault}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(hiddenDelete.status).toBe(404);
+    expect(await hiddenDelete.json()).toEqual({ error: 'Vault not found' });
+
+    expect(await loadVault(allowedVault)).toEqual({ vaultPath: '/allowed-updated', isActive: true });
+    expect(await loadVault(hiddenVault)).toEqual({ vaultPath: '/hidden', isActive: true });
+
+    const foreign = await setupTestEnvironment({ scope: 'organization' });
+    const foreignDevice = await seedDevice(foreign.organization.id, foreign.site.id, 'foreign');
+    const foreignVault = await seedVault(foreign.organization.id, foreignDevice, '/foreign');
+    const crossOrg = await app.request(`/backup/vault/${foreignVault}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(crossOrg.status).toBe(404);
+    expect(await loadVault(foreignVault)).toEqual({ vaultPath: '/foreign', isActive: true });
+  });
+
+  runDb('denies an empty site ceiling without changing the vault', async () => {
+    const env = await setupTestEnvironment({
+      scope: 'organization',
+      rolePermissions: [{ resource: 'organizations', action: 'write' }],
+    });
+    await getTestDb().update(organizationUsers)
+      .set({ siteIds: [] })
+      .where(eq(organizationUsers.userId, env.user.id));
+    const deviceId = await seedDevice(env.organization.id, env.site.id, 'empty');
+    const vaultId = await seedVault(env.organization.id, deviceId, '/empty');
+    const token = await mfaToken(env);
+    const app = buildApp();
+
+    const response = await app.request(`/backup/vault/${vaultId}`, {
+      method: 'PATCH',
+      headers: { Authorization: `Bearer ${token}`, ...JSON_HEADERS },
+      body: JSON.stringify({ vaultPath: '/must-not-write' }),
+    });
+
+    expect(response.status).toBe(404);
+    expect(await loadVault(vaultId)).toEqual({ vaultPath: '/empty', isActive: true });
+  });
+
+  runDb('preserves unrestricted organization mutation behavior', async () => {
+    const env = await setupTestEnvironment({
+      scope: 'organization',
+      rolePermissions: [{ resource: 'organizations', action: 'write' }],
+    });
+    const otherSite = await createSite({ orgId: env.organization.id });
+    const deviceId = await seedDevice(env.organization.id, otherSite.id, 'unrestricted');
+    const vaultId = await seedVault(env.organization.id, deviceId, '/unrestricted');
+    const token = await mfaToken(env);
+    const app = buildApp();
+
+    const response = await app.request(`/backup/vault/${vaultId}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(response.status).toBe(200);
+    expect(await loadVault(vaultId)).toEqual({ vaultPath: '/unrestricted', isActive: false });
+  });
+
+  runDb('preserves unrestricted partner mutation behavior for an accessible organization', async () => {
+    const env = await setupTestEnvironment({
+      scope: 'partner',
+      rolePermissions: [{ resource: 'organizations', action: 'write' }],
+    });
+    const deviceId = await seedDevice(env.organization.id, env.site.id, 'partner');
+    const vaultId = await seedVault(env.organization.id, deviceId, '/partner');
+    const token = await mfaToken(env, 'partner');
+    const app = buildApp();
+
+    const response = await app.request(`/backup/vault/${vaultId}?orgId=${env.organization.id}`, {
+      method: 'PATCH',
+      headers: { Authorization: `Bearer ${token}`, ...JSON_HEADERS },
+      body: JSON.stringify({ retentionCount: 9 }),
+    });
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).retentionCount).toBe(9);
+  });
+});

--- a/apps/api/src/__tests__/integration/backupVerificationSiteScope.integration.test.ts
+++ b/apps/api/src/__tests__/integration/backupVerificationSiteScope.integration.test.ts
@@ -1,0 +1,71 @@
+import './setup';
+
+import { randomUUID } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { getTestDb } from './setup';
+import { createOrganization, createPartner } from './db-utils';
+import { listBackupVerifications } from '../../routes/backup/verificationService';
+import { listRecoveryReadiness } from '../../routes/backup/readinessCalculator';
+
+describe('backup verification current-site visibility', () => {
+  it('filters verification and readiness rows before limit and follows a current site move', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const siteA = randomUUID();
+    const siteB = randomUUID();
+    const visibleDevice = randomUUID();
+    const hiddenDevice = randomUUID();
+    const configId = randomUUID();
+    const visibleJob = randomUUID();
+    const hiddenJob = randomUUID();
+
+    await getTestDb().execute(sql`
+      INSERT INTO sites (id, org_id, name) VALUES
+        (${siteA}, ${org.id}, 'Visible'),
+        (${siteB}, ${org.id}, 'Hidden')
+    `);
+    await getTestDb().execute(sql`
+      INSERT INTO devices (id, org_id, site_id, agent_id, hostname, os_type, os_version, architecture, agent_version) VALUES
+        (${visibleDevice}, ${org.id}, ${siteA}, ${`agent-${randomUUID()}`}, 'visible-host', 'windows', '11', 'amd64', '2.0.0'),
+        (${hiddenDevice}, ${org.id}, ${siteB}, ${`agent-${randomUUID()}`}, 'hidden-host', 'windows', '11', 'amd64', '2.0.0')
+    `);
+    await getTestDb().execute(sql`
+      INSERT INTO backup_configs (id, org_id, name, type, provider, provider_config)
+        VALUES (${configId}, ${org.id}, 'Site scope', 'file', 'local', '{}'::jsonb)
+    `);
+    await getTestDb().execute(sql`
+      INSERT INTO backup_jobs (id, org_id, config_id, device_id, status, type) VALUES
+        (${visibleJob}, ${org.id}, ${configId}, ${visibleDevice}, 'completed', 'manual'),
+        (${hiddenJob}, ${org.id}, ${configId}, ${hiddenDevice}, 'completed', 'manual')
+    `);
+    await getTestDb().execute(sql`
+      INSERT INTO backup_verifications (
+        org_id, device_id, backup_job_id, verification_type, status, started_at, completed_at, details
+      ) VALUES
+        (${org.id}, ${visibleDevice}, ${visibleJob}, 'integrity', 'passed', now() - interval '1 hour', now() - interval '1 hour', '{"simulated":true,"restorePath":"/private/visible","failedFiles":["secret.txt"],"commandId":"internal-command"}'::jsonb),
+        (${org.id}, ${hiddenDevice}, ${hiddenJob}, 'integrity', 'failed', now(), now(), '{"path":"hidden"}'::jsonb)
+    `);
+    await getTestDb().execute(sql`
+      INSERT INTO recovery_readiness (org_id, device_id, readiness_score, risk_factors, calculated_at) VALUES
+        (${org.id}, ${visibleDevice}, 90, '[]'::jsonb, now()),
+        (${org.id}, ${hiddenDevice}, 10, '[{"code":"hidden-risk","severity":"high","message":"hidden"}]'::jsonb, now())
+    `);
+
+    const visible = await listBackupVerifications(org.id, { allowedSiteIds: [siteA], limit: 1 });
+    expect(visible).toHaveLength(1);
+    expect(visible[0]?.deviceId).toBe(visibleDevice);
+    expect(visible[0]?.details).toEqual({ simulated: true });
+    expect(JSON.stringify(visible[0])).not.toContain('restorePath');
+    expect(JSON.stringify(visible[0])).not.toContain('failedFiles');
+    expect(JSON.stringify(visible[0])).not.toContain('internal-command');
+    expect(await listBackupVerifications(org.id, { allowedSiteIds: [] })).toEqual([]);
+
+    const readiness = await listRecoveryReadiness(org.id, [siteA]);
+    expect(readiness.map((row) => row.deviceId)).toEqual([visibleDevice]);
+
+    await getTestDb().execute(sql`UPDATE devices SET site_id = ${siteB} WHERE id = ${visibleDevice}`);
+    expect(await listBackupVerifications(org.id, { allowedSiteIds: [siteA], limit: 1 })).toEqual([]);
+    expect(await listRecoveryReadiness(org.id, [siteA])).toEqual([]);
+  });
+});

--- a/apps/api/src/__tests__/integration/localVaultDeviceOrgFk.integration.test.ts
+++ b/apps/api/src/__tests__/integration/localVaultDeviceOrgFk.integration.test.ts
@@ -5,10 +5,16 @@
  */
 import './setup';
 import { randomUUID } from 'crypto';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import postgres from 'postgres';
 import { afterAll, describe, expect, it } from 'vitest';
 import { eq, sql } from 'drizzle-orm';
 import { db, withDbAccessContext, type DbAccessContext } from '../../db';
-import { devices, localVaults, organizations, partners, sites } from '../../db/schema';
+import {
+  backupConfigs, backupJobs, backupSnapshots, devices, localVaults,
+  organizations, partners, sites, vaultSnapshotInventory,
+} from '../../db/schema';
 import { createOrganization, createPartner, createSite } from './db-utils';
 import { getTestDb } from './setup';
 
@@ -48,8 +54,17 @@ afterAll(async () => {
   }
   if (partnerIds.length > 0) {
     const ids = sql.join(partnerIds.map((id) => sql`${id}`), sql`, `);
-    await admin.delete(devices).where(sql`${devices.orgId} IN (SELECT id FROM organizations WHERE partner_id IN (${ids}))`);
-    await admin.delete(sites).where(sql`${sites.orgId} IN (SELECT id FROM organizations WHERE partner_id IN (${ids}))`);
+    // Children first: the backup chain (config -> job -> snapshot) references
+    // both devices and organizations, and vault_snapshot_inventory references
+    // the snapshot, so an org-first delete would raise an FK violation.
+    const orgScope = sql`(SELECT id FROM organizations WHERE partner_id IN (${ids}))`;
+    await admin.delete(vaultSnapshotInventory).where(sql`${vaultSnapshotInventory.orgId} IN ${orgScope}`);
+    await admin.delete(localVaults).where(sql`${localVaults.orgId} IN ${orgScope}`);
+    await admin.delete(backupSnapshots).where(sql`${backupSnapshots.orgId} IN ${orgScope}`);
+    await admin.delete(backupJobs).where(sql`${backupJobs.orgId} IN ${orgScope}`);
+    await admin.delete(backupConfigs).where(sql`${backupConfigs.orgId} IN ${orgScope}`);
+    await admin.delete(devices).where(sql`${devices.orgId} IN ${orgScope}`);
+    await admin.delete(sites).where(sql`${sites.orgId} IN ${orgScope}`);
     await admin.delete(organizations).where(sql`${organizations.partnerId} IN (${ids})`);
     await admin.delete(partners).where(sql`${partners.id} IN (${ids})`);
   }
@@ -101,5 +116,129 @@ describe('local_vaults device/org composite FK (SEC-026)', () => {
       .from(localVaults)
       .where(eq(localVaults.id, allowed!.id));
     expect(movedVault?.orgId).toBe(orgB.id);
+  });
+});
+
+/**
+ * Forward-migration behaviour (SEC-026 review BLOCKER 1). The repair for a
+ * historical mismatched row is RESTAMP-AND-DEACTIVATE, never DELETE:
+ *
+ *  - restamping from the device is what breeze_cascade_device_org_id() has
+ *    done on every device move since 2026-05-18, so a pre-trigger benign move
+ *    and the SEC-026 abuse path are indistinguishable here;
+ *  - deleting would cascade vault_snapshot_inventory, which is recovery
+ *    metadata for data on the VICTIM org's device;
+ *  - deactivating stops an attacker-chosen vault_path from syncing under the
+ *    corrected org until a human re-enables it.
+ *
+ * vault_snapshot_inventory keys on vault_id (not device_id), so the device
+ * trigger never covers it — the migration restamps it explicitly.
+ */
+describe('local_vaults device/org migration repair (SEC-026)', () => {
+  const MIGRATION = '2026-10-15-160110-local-vault-device-org-fk.sql';
+  const migrationSql = readFileSync(join(__dirname, '../../../migrations', MIGRATION), 'utf8');
+
+  const notices: string[] = [];
+  const replaySql = postgres(process.env.DATABASE_URL ?? '', {
+    max: 1,
+    onnotice: (n) => { notices.push(String(n.message)); },
+  });
+  afterAll(async () => { await replaySql.end({ timeout: 5 }); });
+
+  async function replay(): Promise<string> {
+    notices.length = 0;
+    await replaySql.unsafe(migrationSql);
+    return notices.find((m) => m.includes('SEC-026 cleanup')) ?? '';
+  }
+
+  it('restamps and deactivates a mismatched vault, restamps its inventory, and re-applies as a no-op', async () => {
+    const admin = getTestDb() as any;
+    const { orgA, orgB, deviceA, deviceB } = await seed();
+
+    // Snapshot chain lives with the device's REAL owner (orgB / deviceB).
+    const [config] = await admin.insert(backupConfigs).values({
+      orgId: orgB.id, name: 'sec026-cfg', type: 'file', provider: 'local', providerConfig: {},
+    }).returning({ id: backupConfigs.id });
+    const [job] = await admin.insert(backupJobs).values({
+      orgId: orgB.id, configId: config!.id, deviceId: deviceB.id, status: 'completed', type: 'manual',
+    }).returning({ id: backupJobs.id });
+    const [snapshot] = await admin.insert(backupSnapshots).values({
+      orgId: orgB.id, jobId: job!.id, deviceId: deviceB.id,
+      snapshotId: `sec026-${randomUUID()}`, timestamp: new Date(), size: 1024,
+    }).returning({ id: backupSnapshots.id });
+
+    // Forge the pre-fix row shape: caller org A, victim device B. Only
+    // possible with the constraint off — which is exactly the historical state
+    // this migration repairs.
+    await admin.execute(sql`ALTER TABLE local_vaults DROP CONSTRAINT IF EXISTS local_vaults_device_org_fkey`);
+    let badVaultId: string;
+    let inventoryId: string;
+    try {
+      const [badVault] = await admin.insert(localVaults).values({
+        orgId: orgA.id, deviceId: deviceB.id, vaultPath: '/attacker/chosen/path', isActive: true,
+      }).returning({ id: localVaults.id });
+      badVaultId = badVault!.id;
+      vaultIds.push(badVaultId);
+
+      const [inventory] = await admin.insert(vaultSnapshotInventory).values({
+        orgId: orgA.id, vaultId: badVaultId, snapshotDbId: snapshot!.id,
+        externalSnapshotId: `ext-${randomUUID()}`,
+      }).returning({ id: vaultSnapshotInventory.id });
+      inventoryId = inventory!.id;
+
+      // A same-org control that the migration must leave completely alone.
+      const [goodVault] = await admin.insert(localVaults).values({
+        orgId: orgA.id, deviceId: deviceA.id, vaultPath: '/legit/path', isActive: true,
+      }).returning({ id: localVaults.id });
+      vaultIds.push(goodVault!.id);
+
+      const firstWarning = await replay();
+
+      const [repaired] = await admin
+        .select({ orgId: localVaults.orgId, isActive: localVaults.isActive, vaultPath: localVaults.vaultPath })
+        .from(localVaults).where(eq(localVaults.id, badVaultId));
+      // Restamped to the DEVICE's org, not deleted.
+      expect(repaired?.orgId).toBe(orgB.id);
+      // Deactivated: the attacker-chosen path must not sync under org B.
+      expect(repaired?.isActive).toBe(false);
+      expect(repaired?.vaultPath).toBe('/attacker/chosen/path');
+
+      // The inventory row survived and followed its parent.
+      const [inv] = await admin
+        .select({ orgId: vaultSnapshotInventory.orgId })
+        .from(vaultSnapshotInventory).where(eq(vaultSnapshotInventory.id, inventoryId));
+      expect(inv?.orgId).toBe(orgB.id);
+
+      // The same-org control is untouched.
+      const [untouched] = await admin
+        .select({ orgId: localVaults.orgId, isActive: localVaults.isActive })
+        .from(localVaults).where(eq(localVaults.id, goodVault!.id));
+      expect(untouched).toEqual({ orgId: orgA.id, isActive: true });
+
+      // Counts are reported for BOTH tables, and the ids are printed.
+      expect(firstWarning).toContain('restamped and deactivated 1 mismatched local vault(s)');
+      expect(firstWarning).toContain('restamped 1 vault_snapshot_inventory row(s)');
+      expect(firstWarning).toContain(badVaultId);
+      expect(firstWarning).toContain(inventoryId);
+
+      // Re-apply is a true no-op with zero counts.
+      const secondWarning = await replay();
+      expect(secondWarning).toContain('restamped and deactivated 0 mismatched local vault(s)');
+      expect(secondWarning).toContain('restamped 0 vault_snapshot_inventory row(s)');
+
+      const [afterSecond] = await admin
+        .select({ orgId: localVaults.orgId, isActive: localVaults.isActive })
+        .from(localVaults).where(eq(localVaults.id, badVaultId));
+      expect(afterSecond).toEqual({ orgId: orgB.id, isActive: false });
+    } finally {
+      // The migration re-adds the constraint itself; assert it is back rather
+      // than restoring it by hand, so a migration that forgot would fail here.
+      const constraints = (await admin.execute(sql`
+        SELECT condeferrable, condeferred, convalidated
+        FROM pg_constraint
+        WHERE conname = 'local_vaults_device_org_fkey' AND conrelid = 'local_vaults'::regclass
+      `)) as unknown as Array<{ condeferrable: boolean; condeferred: boolean; convalidated: boolean }>;
+      expect(constraints).toEqual([{ condeferrable: true, condeferred: true, convalidated: true }]);
+    }
   });
 });

--- a/apps/api/src/__tests__/integration/localVaultDeviceOrgFk.integration.test.ts
+++ b/apps/api/src/__tests__/integration/localVaultDeviceOrgFk.integration.test.ts
@@ -1,0 +1,105 @@
+/**
+ * SEC-2026-09-05-026 — local_vaults must not pair one tenant's org_id with
+ * another tenant's device_id. Org-axis RLS checks only the row's org_id, so a
+ * composite FK is the database backstop for every present and future writer.
+ */
+import './setup';
+import { randomUUID } from 'crypto';
+import { afterAll, describe, expect, it } from 'vitest';
+import { eq, sql } from 'drizzle-orm';
+import { db, withDbAccessContext, type DbAccessContext } from '../../db';
+import { devices, localVaults, organizations, partners, sites } from '../../db/schema';
+import { createOrganization, createPartner, createSite } from './db-utils';
+import { getTestDb } from './setup';
+
+const partnerIds: string[] = [];
+const vaultIds: string[] = [];
+
+function orgCtx(orgId: string): DbAccessContext {
+  return { scope: 'organization', orgId, accessibleOrgIds: [orgId], accessiblePartnerIds: [], userId: null };
+}
+
+async function seed() {
+  const partnerA = await createPartner();
+  const partnerB = await createPartner();
+  partnerIds.push(partnerA.id, partnerB.id);
+  const orgA = await createOrganization({ partnerId: partnerA.id });
+  const orgB = await createOrganization({ partnerId: partnerB.id });
+  const siteA = await createSite({ orgId: orgA.id });
+  const siteB = await createSite({ orgId: orgB.id });
+  const [deviceA, deviceB] = await (getTestDb() as any).insert(devices).values([
+    {
+      orgId: orgA.id, siteId: siteA.id, agentId: `sec026-a-${randomUUID()}`,
+      hostname: 'sec026-a', osType: 'linux', osVersion: '1', architecture: 'amd64', agentVersion: '1.0.0',
+    },
+    {
+      orgId: orgB.id, siteId: siteB.id, agentId: `sec026-b-${randomUUID()}`,
+      hostname: 'sec026-b', osType: 'linux', osVersion: '1', architecture: 'amd64', agentVersion: '1.0.0',
+    },
+  ]).returning({ id: devices.id });
+  return { orgA, orgB, siteB, deviceA: deviceA!, deviceB: deviceB! };
+}
+
+afterAll(async () => {
+  const admin = getTestDb() as any;
+  if (vaultIds.length > 0) {
+    const ids = sql.join(vaultIds.map((id) => sql`${id}`), sql`, `);
+    await admin.delete(localVaults).where(sql`${localVaults.id} IN (${ids})`);
+  }
+  if (partnerIds.length > 0) {
+    const ids = sql.join(partnerIds.map((id) => sql`${id}`), sql`, `);
+    await admin.delete(devices).where(sql`${devices.orgId} IN (SELECT id FROM organizations WHERE partner_id IN (${ids}))`);
+    await admin.delete(sites).where(sql`${sites.orgId} IN (SELECT id FROM organizations WHERE partner_id IN (${ids}))`);
+    await admin.delete(organizations).where(sql`${organizations.partnerId} IN (${ids})`);
+    await admin.delete(partners).where(sql`${partners.id} IN (${ids})`);
+  }
+});
+
+describe('local_vaults device/org composite FK (SEC-026)', () => {
+  it('rejects a caller-org row that references another tenant device while allowing the matching pair', async () => {
+    const { orgA, orgB, siteB, deviceA, deviceB } = await seed();
+    let mismatchError: unknown;
+    let mismatchedId: string | undefined;
+    try {
+      const [row] = await withDbAccessContext(orgCtx(orgA.id), () =>
+        db.insert(localVaults).values({ orgId: orgA.id, deviceId: deviceB.id, vaultPath: '/synthetic/foreign' }).returning({ id: localVaults.id }),
+      );
+      mismatchedId = row?.id;
+    } catch (error) {
+      mismatchError = error;
+    } finally {
+      if (mismatchedId) await (getTestDb() as any).delete(localVaults).where(eq(localVaults.id, mismatchedId));
+    }
+
+    expect(mismatchError).toMatchObject({
+      code: '23503', constraint_name: 'local_vaults_device_org_fkey',
+    });
+
+    const [allowed] = await withDbAccessContext(orgCtx(orgA.id), () =>
+      db.insert(localVaults).values({ orgId: orgA.id, deviceId: deviceA.id, vaultPath: '/synthetic/own' }).returning({ id: localVaults.id }),
+    );
+    expect(allowed?.id).toBeTypeOf('string');
+    vaultIds.push(allowed!.id);
+
+    const constraints = (await (getTestDb() as any).execute(sql`
+      SELECT condeferrable, condeferred
+      FROM pg_constraint
+      WHERE conname = 'local_vaults_device_org_fkey'
+        AND conrelid = 'local_vaults'::regclass
+    `)) as unknown as Array<{ condeferrable: boolean; condeferred: boolean }>;
+    expect(constraints).toEqual([{ condeferrable: true, condeferred: true }]);
+
+    // Device moves are a sibling path: the existing SECURITY DEFINER device
+    // cascade re-stamps local_vaults in the same transaction. The deferred FK
+    // must permit that repair while still being valid at commit.
+    await (getTestDb() as any)
+      .update(devices)
+      .set({ orgId: orgB.id, siteId: siteB.id })
+      .where(eq(devices.id, deviceA.id));
+    const [movedVault] = await (getTestDb() as any)
+      .select({ orgId: localVaults.orgId })
+      .from(localVaults)
+      .where(eq(localVaults.id, allowed!.id));
+    expect(movedVault?.orgId).toBe(orgB.id);
+  });
+});

--- a/apps/api/src/db/schema/localVault.ts
+++ b/apps/api/src/db/schema/localVault.ts
@@ -9,6 +9,7 @@ import {
   bigint,
   index,
   uniqueIndex,
+  foreignKey,
 } from 'drizzle-orm/pg-core';
 import { organizations } from './orgs';
 import { devices } from './devices';
@@ -37,6 +38,11 @@ export const localVaults = pgTable(
     updatedAt: timestamp('updated_at').defaultNow().notNull(),
   },
   (table) => ({
+    deviceOrgFk: foreignKey({
+      columns: [table.deviceId, table.orgId],
+      foreignColumns: [devices.id, devices.orgId],
+      name: 'local_vaults_device_org_fkey',
+    }),
     orgIdx: index('local_vaults_org_idx').on(table.orgId),
     deviceIdx: index('local_vaults_device_idx').on(table.deviceId),
   })

--- a/apps/api/src/routes/backup/readinessCalculator.ts
+++ b/apps/api/src/routes/backup/readinessCalculator.ts
@@ -117,7 +117,10 @@ async function addMissingAssignedDevicesToReadiness(
       const visibleIds = new Set(visible.map((row) => row.id));
       assignedDevices = assignedDevices.filter((device) => visibleIds.has(device.deviceId));
     } catch (error) {
-      console.warn('[backupVerification] Site-scoped assigned-device lookup failed closed:', error);
+      // `rows` is already site-scoped by listRecoveryReadinessFromDb. Returning
+      // it unaugmented drops the synthetic assigned-device rows rather than
+      // adding ones we could not confirm are visible — no unscoped row escapes.
+      console.warn('[backupVerification] Site-scoped assigned-device lookup failed; skipping synthetic readiness rows:', error);
       return rows;
     }
   }

--- a/apps/api/src/routes/backup/readinessCalculator.ts
+++ b/apps/api/src/routes/backup/readinessCalculator.ts
@@ -1,6 +1,6 @@
-import { and, desc, eq, inArray } from 'drizzle-orm';
+import { and, desc, eq, inArray, sql } from 'drizzle-orm';
 import * as dbModule from '../../db';
-import { backupJobs as backupJobsTable, recoveryReadiness as recoveryReadinessTable, RESTORABLE_BACKUP_JOB_STATUSES } from '../../db/schema';
+import { backupJobs as backupJobsTable, devices, recoveryReadiness as recoveryReadinessTable, RESTORABLE_BACKUP_JOB_STATUSES } from '../../db/schema';
 import { publishEvent } from '../../services/eventBus';
 import {
   backupJobs,
@@ -87,7 +87,8 @@ function createNoHistoryReadiness(orgId: string, deviceId: string): RecoveryRead
 
 async function addMissingAssignedDevicesToReadiness(
   orgId: string,
-  rows: RecoveryReadiness[]
+  rows: RecoveryReadiness[],
+  allowedSiteIds?: readonly string[],
 ): Promise<RecoveryReadiness[]> {
   let assignedDevices: BackupAssignedDevice[] = [];
 
@@ -100,6 +101,25 @@ async function addMissingAssignedDevicesToReadiness(
 
   if (assignedDevices.length === 0) {
     return rows;
+  }
+
+  if (allowedSiteIds) {
+    if (allowedSiteIds.length === 0) return [];
+    try {
+      const visible = await runWithSystemDbAccess(() => db
+        .select({ id: devices.id })
+        .from(devices)
+        .where(and(
+          eq(devices.orgId, orgId),
+          inArray(devices.siteId, [...allowedSiteIds]),
+          inArray(devices.id, assignedDevices.map((device) => device.deviceId)),
+        )));
+      const visibleIds = new Set(visible.map((row) => row.id));
+      assignedDevices = assignedDevices.filter((device) => visibleIds.has(device.deviceId));
+    } catch (error) {
+      console.warn('[backupVerification] Site-scoped assigned-device lookup failed closed:', error);
+      return rows;
+    }
   }
 
   const existingDeviceIds = new Set(rows.map((row) => row.deviceId));
@@ -210,14 +230,23 @@ async function getLatestCompletedBackup(
   return latestBackup ? { completedAt: latestBackup.completedAt ?? null } : null;
 }
 
-async function listRecoveryReadinessFromDb(orgId: string): Promise<RecoveryReadiness[] | null> {
+async function listRecoveryReadinessFromDb(orgId: string, allowedSiteIds?: readonly string[]): Promise<RecoveryReadiness[] | null> {
   if (!supportsDbOrg(orgId)) return null;
+  if (allowedSiteIds?.length === 0) return [];
 
   try {
     const rows = await runWithSystemDbAccess(() => db
       .select()
       .from(recoveryReadinessTable)
-      .where(eq(recoveryReadinessTable.orgId, orgId))
+      .where(and(
+        eq(recoveryReadinessTable.orgId, orgId),
+        allowedSiteIds ? sql`exists (
+          select 1 from ${devices}
+          where ${devices.id} = ${recoveryReadinessTable.deviceId}
+            and ${devices.orgId} = ${recoveryReadinessTable.orgId}
+            and ${inArray(devices.siteId, [...allowedSiteIds])}
+        )` : undefined,
+      ))
       .orderBy(recoveryReadinessTable.readinessScore));
 
     return rows.map((row) => normalizeDbReadinessRow({
@@ -226,6 +255,7 @@ async function listRecoveryReadinessFromDb(orgId: string): Promise<RecoveryReadi
     }));
   } catch (error) {
     console.warn('[backupVerification] DB readiness read failed; falling back to memory:', error);
+    if (allowedSiteIds) return [];
     return null;
   }
 }
@@ -310,10 +340,11 @@ async function safePublish(
 
 // ---- Public readiness listing ----
 
-export async function listRecoveryReadiness(orgId: string): Promise<RecoveryReadiness[]> {
-  const dbRows = await listRecoveryReadinessFromDb(orgId);
-  const rows = dbRows ?? listRecoveryReadinessFromMemory(orgId);
-  return addMissingAssignedDevicesToReadiness(orgId, rows);
+export async function listRecoveryReadiness(orgId: string, allowedSiteIds?: readonly string[]): Promise<RecoveryReadiness[]> {
+  if (allowedSiteIds?.length === 0) return [];
+  const dbRows = await listRecoveryReadinessFromDb(orgId, allowedSiteIds);
+  const rows = dbRows ?? (allowedSiteIds ? [] : listRecoveryReadinessFromMemory(orgId));
+  return addMissingAssignedDevicesToReadiness(orgId, rows, allowedSiteIds);
 }
 
 // ---- Main readiness computation ----
@@ -461,7 +492,7 @@ export async function recomputeRecoveryReadinessForDevice(
 
 // ---- Health summary ----
 
-export async function getBackupHealthSummary(orgId: string): Promise<{
+export async function getBackupHealthSummary(orgId: string, allowedSiteIds?: readonly string[]): Promise<{
   verification: {
     total: number;
     passedLast24h: number;
@@ -480,8 +511,8 @@ export async function getBackupHealthSummary(orgId: string): Promise<{
   };
 }> {
   const [rows, readiness, assignedResult] = await Promise.all([
-    listBackupVerifications(orgId, { excludeSimulated: true }),
-    listRecoveryReadiness(orgId),
+    listBackupVerifications(orgId, { excludeSimulated: true, allowedSiteIds }),
+    listRecoveryReadiness(orgId, allowedSiteIds),
     resolveAllBackupAssignedDevices(orgId)
       .then((assigned) => ({ assigned, failed: false as const }))
       .catch((err) => {
@@ -493,7 +524,28 @@ export async function getBackupHealthSummary(orgId: string): Promise<{
   const dayAgo = now - DAY_MS;
 
   const last24h = rows.filter((row) => toEpoch(row.completedAt ?? row.startedAt) >= dayAgo);
-  const protectedDeviceIds = assignedResult.assigned.map((a) => a.deviceId);
+  let assigned = assignedResult.assigned;
+  if (allowedSiteIds) {
+    if (allowedSiteIds.length === 0) assigned = [];
+    else {
+      try {
+        const visible = await runWithSystemDbAccess(() => db
+          .select({ id: devices.id })
+          .from(devices)
+          .where(and(
+            eq(devices.orgId, orgId),
+            inArray(devices.siteId, [...allowedSiteIds]),
+            inArray(devices.id, assigned.map((device) => device.deviceId)),
+          )));
+        const visibleIds = new Set(visible.map((row) => row.id));
+        assigned = assigned.filter((device) => visibleIds.has(device.deviceId));
+      } catch (error) {
+        console.warn('[BackupReadiness] Site-scoped assigned-device lookup failed closed:', error);
+        assigned = [];
+      }
+    }
+  }
+  const protectedDeviceIds = assigned.map((a) => a.deviceId);
   const protectedDevices = new Set(protectedDeviceIds);
   const coveredRecently = new Set(
     rows

--- a/apps/api/src/routes/backup/sla.test.ts
+++ b/apps/api/src/routes/backup/sla.test.ts
@@ -83,6 +83,7 @@ vi.mock('../../db/schema', () => ({
   },
   recoveryReadiness: {
     orgId: 'recovery_readiness.org_id',
+    deviceId: 'recovery_readiness.device_id',
     estimatedRpoMinutes: 'recovery_readiness.estimated_rpo_minutes',
     estimatedRtoMinutes: 'recovery_readiness.estimated_rto_minutes',
   },
@@ -280,6 +281,99 @@ describe('sla routes', () => {
     expect(body.data.compliancePercent).toBe(67);
     expect(body.data.avgRpoMinutes).toBe(15);
     expect(body.data.avgRtoMinutes).toBe(45);
+  });
+
+  it('narrows the SLA dashboard to allowed device sites (SEC-021 sibling)', async () => {
+    permissionsState = { allowedSiteIds: [SITE_A] };
+    const breachesChain = chainMock([{ count: 1 }]);
+    const eventsChain = chainMock([{ count: 4 }]);
+    const readinessChain = chainMock([{ avgRpo: 15, avgRto: 45 }]);
+    selectMock
+      // 1. resolveSiteAllowedDeviceIds
+      .mockReturnValueOnce(chainMock([
+        { id: DEVICE_ID, siteId: SITE_A },
+        { id: OTHER_DEVICE_ID, siteId: SITE_B },
+      ]))
+      .mockReturnValueOnce(chainMock([{ count: 3 }]))
+      .mockReturnValueOnce(breachesChain)
+      .mockReturnValueOnce(eventsChain)
+      .mockReturnValueOnce(readinessChain)
+      .mockReturnValueOnce(chainMock([{ count: 1 }]));
+
+    const res = await app.request('/backup/sla/dashboard', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(200);
+    // Events keep unattributed rows (device_id NULL), matching GET /events.
+    const eventScoped = expect.objectContaining({
+      op: 'or',
+      conditions: expect.arrayContaining([
+        expect.objectContaining({ op: 'isNull', column: 'backup_sla_events.device_id' }),
+        expect.objectContaining({ op: 'inArray', column: 'backup_sla_events.device_id', values: [DEVICE_ID] }),
+      ]),
+    });
+    for (const chain of [breachesChain, eventsChain]) {
+      expect(chain.where).toHaveBeenCalledWith(expect.objectContaining({
+        op: 'and',
+        conditions: expect.arrayContaining([eventScoped]),
+      }));
+    }
+    // recovery_readiness is always per-device: plain membership, no NULL arm.
+    expect(readinessChain.where).toHaveBeenCalledWith(expect.objectContaining({
+      op: 'and',
+      conditions: expect.arrayContaining([
+        expect.objectContaining({ op: 'inArray', column: 'recovery_readiness.device_id', values: [DEVICE_ID] }),
+      ]),
+    }));
+  });
+
+  it('fails the SLA dashboard closed for an empty site ceiling', async () => {
+    permissionsState = { allowedSiteIds: [] };
+
+    const res = await app.request('/backup/sla/dashboard', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      data: {
+        activeConfigs: 0,
+        compliancePercent: null,
+        compliantConfigs: 0,
+        activeBreaches: 0,
+        totalEventsLast30d: 0,
+        avgRpoMinutes: null,
+        avgRtoMinutes: null,
+      },
+    });
+    // No aggregate ran: nothing was queried at all.
+    expect(selectMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps unrestricted SLA dashboard behavior unchanged', async () => {
+    const breachesChain = chainMock([{ count: 1 }]);
+    selectMock
+      .mockReturnValueOnce(chainMock([{ count: 3 }]))
+      .mockReturnValueOnce(breachesChain)
+      .mockReturnValueOnce(chainMock([{ count: 4 }]))
+      .mockReturnValueOnce(chainMock([{ avgRpo: 15, avgRto: 45 }]))
+      .mockReturnValueOnce(chainMock([{ count: 1 }]));
+
+    const res = await app.request('/backup/sla/dashboard', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(200);
+    // No device resolution query, and no device predicate on the aggregates.
+    expect(selectMock).toHaveBeenCalledTimes(5);
+    expect(breachesChain.where).toHaveBeenCalledWith(expect.objectContaining({
+      op: 'and',
+      conditions: expect.not.arrayContaining([expect.objectContaining({ op: 'inArray' })]),
+    }));
   });
 });
 

--- a/apps/api/src/routes/backup/sla.ts
+++ b/apps/api/src/routes/backup/sla.ts
@@ -256,12 +256,57 @@ slaRoutes.get(
 
 // ── GET /dashboard — compliance dashboard ────────────────────────────────────
 
+/**
+ * Dashboard payload for a caller who can see no device. `null` rather than
+ * `100`/`0` for the derived figures: a reader with an empty site ceiling has
+ * not observed a compliant fleet, and a hard number would be a false
+ * assurance about devices they cannot see.
+ */
+function emptySlaDashboard() {
+  return {
+    activeConfigs: 0,
+    compliancePercent: null,
+    compliantConfigs: 0,
+    activeBreaches: 0,
+    totalEventsLast30d: 0,
+    avgRpoMinutes: null,
+    avgRtoMinutes: null,
+  };
+}
+
 slaRoutes.get('/dashboard', requirePermission(PERMISSIONS.ORGS_READ.resource, PERMISSIONS.ORGS_READ.action), async (c) => {
   const auth = c.get('auth');
   const orgId = resolveScopedOrgId(auth, c.req.query('orgId'));
   if (!orgId) {
     return c.json({ error: 'orgId is required for this scope' }, 400);
   }
+
+  // Site axis. Without this the device-scoped aggregates below (breach count,
+  // 30-day event count, RPO/RTO averages) report org-wide figures to a
+  // site-restricted tech — the same leak SEC-021 closed on /backup/health.
+  // `auth.allowedSiteIds` is the primary source because the auth middleware
+  // always populates it; `permissions` is only set by requirePermission.
+  const perms = c.get('permissions') as UserPermissions | undefined;
+  const siteCeiling = auth?.allowedSiteIds ?? perms?.allowedSiteIds;
+  if (siteCeiling?.length === 0) {
+    return c.json({ data: emptySlaDashboard() });
+  }
+  const allowedDeviceIds = siteCeiling
+    ? await resolveSiteAllowedDeviceIds(orgId, { ...(perms ?? {}), allowedSiteIds: siteCeiling } as UserPermissions)
+    : null;
+  if (allowedDeviceIds && allowedDeviceIds.length === 0) {
+    return c.json({ data: emptySlaDashboard() });
+  }
+
+  // Events may be unattributed (device_id NULL); those stay visible, matching
+  // GET /events above. recovery_readiness is always per-device, so it takes a
+  // plain membership test.
+  const eventSiteCondition = allowedDeviceIds
+    ? or(isNull(backupSlaEvents.deviceId), inArray(backupSlaEvents.deviceId, allowedDeviceIds))
+    : undefined;
+  const readinessSiteCondition = allowedDeviceIds
+    ? inArray(recoveryReadiness.deviceId, allowedDeviceIds)
+    : undefined;
 
   const [configs, activeBreaches, totalEvents, avgReadiness] = await Promise.all([
     // Total active SLA configs
@@ -275,7 +320,7 @@ slaRoutes.get('/dashboard', requirePermission(PERMISSIONS.ORGS_READ.resource, PE
     db
       .select({ count: sql<number>`count(*)::int` })
       .from(backupSlaEvents)
-      .where(and(eq(backupSlaEvents.orgId, orgId), isNull(backupSlaEvents.resolvedAt)))
+      .where(and(eq(backupSlaEvents.orgId, orgId), isNull(backupSlaEvents.resolvedAt), eventSiteCondition))
       .then((r) => r[0]?.count ?? 0),
 
     // Total events in last 30 days
@@ -285,7 +330,8 @@ slaRoutes.get('/dashboard', requirePermission(PERMISSIONS.ORGS_READ.resource, PE
       .where(
         and(
           eq(backupSlaEvents.orgId, orgId),
-          gte(backupSlaEvents.detectedAt, new Date(Date.now() - 30 * 24 * 60 * 60 * 1000))
+          gte(backupSlaEvents.detectedAt, new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)),
+          eventSiteCondition
         )
       )
       .then((r) => r[0]?.count ?? 0),
@@ -297,7 +343,7 @@ slaRoutes.get('/dashboard', requirePermission(PERMISSIONS.ORGS_READ.resource, PE
         avgRto: sql<number>`coalesce(avg(${recoveryReadiness.estimatedRtoMinutes}), 0)::int`,
       })
       .from(recoveryReadiness)
-      .where(eq(recoveryReadiness.orgId, orgId))
+      .where(and(eq(recoveryReadiness.orgId, orgId), readinessSiteCondition))
       .then((r) => r[0] ?? { avgRpo: 0, avgRto: 0 }),
   ]);
 
@@ -306,7 +352,7 @@ slaRoutes.get('/dashboard', requirePermission(PERMISSIONS.ORGS_READ.resource, PE
     ? await db
         .select({ count: sql<number>`count(distinct ${backupSlaEvents.slaConfigId})::int` })
         .from(backupSlaEvents)
-        .where(and(eq(backupSlaEvents.orgId, orgId), isNull(backupSlaEvents.resolvedAt)))
+        .where(and(eq(backupSlaEvents.orgId, orgId), isNull(backupSlaEvents.resolvedAt), eventSiteCondition))
         .then((r) => r[0]?.count ?? 0)
     : 0;
 

--- a/apps/api/src/routes/backup/vault.test.ts
+++ b/apps/api/src/routes/backup/vault.test.ts
@@ -14,6 +14,23 @@ vi.mock('../../services', () => ({}));
 const queueCommandForExecutionMock = vi.fn();
 const writeRouteAuditMock = vi.fn();
 
+/**
+ * The string operands drizzle placed into a SQL predicate — column names (the
+ * schema is stubbed with strings in this file) and the values compared against
+ * them. Walks ONLY `queryChunks`, never the whole object graph, so it cannot
+ * pick up unrelated metadata and quietly pass against unfixed code.
+ */
+function predicateOperands(node: unknown, acc: string[] = []): string[] {
+  if (typeof node === 'string') {
+    acc.push(node);
+    return acc;
+  }
+  if (node === null || typeof node !== 'object') return acc;
+  const chunks = (node as { queryChunks?: unknown[] }).queryChunks;
+  if (Array.isArray(chunks)) for (const chunk of chunks) predicateOperands(chunk, acc);
+  return acc;
+}
+
 function chainMock(resolvedValue: unknown = []) {
   const chain: Record<string, any> = {};
   for (const method of ['from', 'where', 'limit', 'returning', 'values', 'set', 'for']) {
@@ -351,6 +368,39 @@ describe('vault routes', () => {
       { vaultId: VAULT_ID, snapshotId: 'snap-ext-001' },
       expect.objectContaining({ userId: 'user-123', expectedOrgId: ORG_ID })
     );
+  });
+
+  it('binds both sync status writes to (id, orgId, deviceId), not id alone', async () => {
+    const pendingChain = chainMock([]);
+    const failedChain = chainMock([]);
+    selectMock
+      .mockReturnValueOnce(chainMock([makeVault()]))
+      .mockReturnValueOnce(chainMock([{ siteId: SITE_A }]));
+    updateMock
+      .mockReturnValueOnce(pendingChain)
+      .mockReturnValueOnce(failedChain);
+    queueCommandForExecutionMock.mockResolvedValueOnce({ error: 'Device not found' });
+
+    const res = await app.request(`/backup/vault/${VAULT_ID}/sync`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+      body: JSON.stringify({ snapshotId: 'snap-ext-003' }),
+    });
+
+    expect(res.status).toBe(502);
+    // The vault was read in a separate statement, so `id` alone is a
+    // check-then-act window: both writes must repeat the axes we authorized.
+    // drizzle-orm is NOT mocked in this file, so assert on the values actually
+    // bound into the predicate rather than on a stub's shape.
+    for (const chain of [pendingChain, failedChain]) {
+      expect(chain.where).toHaveBeenCalledTimes(1);
+      const operands = predicateOperands(chain.where.mock.calls[0]![0]);
+      expect(operands).toEqual(expect.arrayContaining([
+        'local_vaults.id', VAULT_ID,
+        'local_vaults.org_id', ORG_ID,
+        'local_vaults.device_id', DEVICE_ID,
+      ]));
+    }
   });
 
   // #3531: the web client posts NO body to this route, while `fetchWithAuth`

--- a/apps/api/src/routes/backup/vault.test.ts
+++ b/apps/api/src/routes/backup/vault.test.ts
@@ -16,7 +16,7 @@ const writeRouteAuditMock = vi.fn();
 
 function chainMock(resolvedValue: unknown = []) {
   const chain: Record<string, any> = {};
-  for (const method of ['from', 'where', 'limit', 'returning', 'values', 'set']) {
+  for (const method of ['from', 'where', 'limit', 'returning', 'values', 'set', 'for']) {
     chain[method] = vi.fn(() => Object.assign(Promise.resolve(resolvedValue), chain));
   }
   return Object.assign(Promise.resolve(resolvedValue), chain);
@@ -39,6 +39,10 @@ vi.mock('../../db', () => ({
     select: (...args: unknown[]) => selectMock(...(args as [])),
     insert: (...args: unknown[]) => insertMock(...(args as [])),
     update: (...args: unknown[]) => updateMock(...(args as [])),
+    transaction: (fn: (tx: unknown) => unknown) => fn({
+      select: (...args: unknown[]) => selectMock(...(args as [])),
+      update: (...args: unknown[]) => updateMock(...(args as [])),
+    }),
   },
   runOutsideDbContext: vi.fn((fn: () => any) => fn()),
   withSystemDbAccessContext: vi.fn(async (fn: () => any) => fn()),
@@ -239,6 +243,41 @@ describe('vault routes', () => {
     expect((await res.json()).vaultPath).toBe('E:/Vault');
   });
 
+  it('hides PATCH from a caller with an empty site ceiling before database or audit work', async () => {
+    permissionsState = { allowedSiteIds: [] };
+    updateMock.mockReturnValueOnce(chainMock([makeVault({ vaultPath: 'E:/Vault' })]));
+
+    const res = await app.request(`/backup/vault/${VAULT_ID}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+      body: JSON.stringify({ vaultPath: 'E:/Vault' }),
+    });
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'Vault not found' });
+    expect(updateMock).not.toHaveBeenCalled();
+    expect(writeRouteAuditMock).not.toHaveBeenCalled();
+  });
+
+  it('locks the current selected-site device before PATCH and then applies the vault CAS', async () => {
+    permissionsState = { allowedSiteIds: [SITE_A] };
+    const vaultLookup = chainMock([{ deviceId: DEVICE_ID }]);
+    const deviceLock = chainMock([{ id: DEVICE_ID }]);
+    selectMock.mockReturnValueOnce(vaultLookup).mockReturnValueOnce(deviceLock);
+    updateMock.mockReturnValueOnce(chainMock([makeVault({ vaultPath: 'E:/Vault' })]));
+
+    const res = await app.request(`/backup/vault/${VAULT_ID}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+      body: JSON.stringify({ vaultPath: 'E:/Vault' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(deviceLock.for).toHaveBeenCalledWith('update');
+    expect(selectMock).toHaveBeenCalledTimes(2);
+    expect(updateMock).toHaveBeenCalledTimes(1);
+  });
+
   it('deactivates a vault config', async () => {
     updateMock.mockReturnValueOnce(chainMock([makeVault({ isActive: false })]));
 
@@ -249,6 +288,21 @@ describe('vault routes', () => {
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ deleted: true, id: VAULT_ID });
+  });
+
+  it('hides DELETE from a caller with an empty site ceiling before database or audit work', async () => {
+    permissionsState = { allowedSiteIds: [] };
+    updateMock.mockReturnValueOnce(chainMock([makeVault({ isActive: false })]));
+
+    const res = await app.request(`/backup/vault/${VAULT_ID}`, {
+      method: 'DELETE',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'Vault not found' });
+    expect(updateMock).not.toHaveBeenCalled();
+    expect(writeRouteAuditMock).not.toHaveBeenCalled();
   });
 
   it('dispatches a vault sync command', async () => {

--- a/apps/api/src/routes/backup/vault.test.ts
+++ b/apps/api/src/routes/backup/vault.test.ts
@@ -211,6 +211,7 @@ describe('vault routes', () => {
   });
 
   it('creates a vault config', async () => {
+    selectMock.mockReturnValueOnce(chainMock([{ siteId: SITE_A }]));
     insertMock.mockReturnValueOnce(chainMock([makeVault()]));
 
     const res = await app.request('/backup/vault', {
@@ -228,6 +229,28 @@ describe('vault routes', () => {
     const body = await res.json();
     expect(body.id).toBe(VAULT_ID);
     expect(body.vaultPath).toBe('D:/Backups/Vault');
+  });
+
+  it('rejects an unrestricted-site create when the device is outside the resolved org', async () => {
+    // An unset allowedSiteIds ceiling must not skip device ownership validation.
+    // The old early return allowed this caller-org/victim-device pair to reach INSERT.
+    selectMock.mockReturnValueOnce(chainMock([]));
+
+    const res = await app.request('/backup/vault', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+      body: JSON.stringify({
+        deviceId: OTHER_DEVICE_ID,
+        vaultPath: 'D:/Backups/Vault',
+        vaultType: 'local',
+        retentionCount: 7,
+      }),
+    });
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'Device not found or access denied' });
+    expect(selectMock).toHaveBeenCalledTimes(1);
+    expect(insertMock).not.toHaveBeenCalled();
   });
 
   it('updates a vault config', async () => {
@@ -306,9 +329,11 @@ describe('vault routes', () => {
   });
 
   it('dispatches a vault sync command', async () => {
-    selectMock.mockReturnValueOnce(chainMock([makeVault()]));
+    selectMock
+      .mockReturnValueOnce(chainMock([makeVault()]))
+      .mockReturnValueOnce(chainMock([{ siteId: SITE_A }]));
     updateMock.mockReturnValueOnce(chainMock([]));
-    queueCommandForExecutionMock.mockResolvedValueOnce(undefined);
+    queueCommandForExecutionMock.mockResolvedValueOnce({ command: { id: 'command-1' } });
 
     const res = await app.request(`/backup/vault/${VAULT_ID}/sync`, {
       method: 'POST',
@@ -324,7 +349,7 @@ describe('vault routes', () => {
       DEVICE_ID,
       'VAULT_SYNC',
       { vaultId: VAULT_ID, snapshotId: 'snap-ext-001' },
-      expect.objectContaining({ userId: 'user-123' })
+      expect.objectContaining({ userId: 'user-123', expectedOrgId: ORG_ID })
     );
   });
 
@@ -334,9 +359,11 @@ describe('vault routes', () => {
   // `400 Malformed JSON in request body` BEFORE the handler ran, so every
   // Sync Now click failed — silently, because the old UI swallowed the error.
   it('queues a sync when the client posts NO body (the web client never sends one)', async () => {
-    selectMock.mockReturnValueOnce(chainMock([makeVault()]));
+    selectMock
+      .mockReturnValueOnce(chainMock([makeVault()]))
+      .mockReturnValueOnce(chainMock([{ siteId: SITE_A }]));
     updateMock.mockReturnValueOnce(chainMock([]));
-    queueCommandForExecutionMock.mockResolvedValueOnce(undefined);
+    queueCommandForExecutionMock.mockResolvedValueOnce({ command: { id: 'command-2' } });
 
     const res = await app.request(`/backup/vault/${VAULT_ID}/sync`, {
       method: 'POST',
@@ -350,8 +377,32 @@ describe('vault routes', () => {
       DEVICE_ID,
       'VAULT_SYNC',
       { vaultId: VAULT_ID, snapshotId: undefined },
-      expect.objectContaining({ userId: 'user-123' })
+      expect.objectContaining({ userId: 'user-123', expectedOrgId: ORG_ID })
     );
+  });
+
+  it('fails a sync when dispatch rejects the expected organization before reporting pending', async () => {
+    selectMock
+      .mockReturnValueOnce(chainMock([makeVault()]))
+      .mockReturnValueOnce(chainMock([{ siteId: SITE_A }]));
+    updateMock.mockReturnValue(chainMock([]));
+    queueCommandForExecutionMock.mockResolvedValueOnce({ error: 'Device not found' });
+
+    const res = await app.request(`/backup/vault/${VAULT_ID}/sync`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+      body: JSON.stringify({ snapshotId: 'snap-ext-002' }),
+    });
+
+    expect(res.status).toBe(502);
+    expect(await res.json()).toEqual({ error: 'Failed to dispatch sync command to agent' });
+    expect(queueCommandForExecutionMock).toHaveBeenCalledWith(
+      DEVICE_ID,
+      'VAULT_SYNC',
+      { vaultId: VAULT_ID, snapshotId: 'snap-ext-002' },
+      expect.objectContaining({ userId: 'user-123', expectedOrgId: ORG_ID })
+    );
+    expect(writeRouteAuditMock).not.toHaveBeenCalled();
   });
 
   it('denies vault status for a site-restricted caller when the vault device is out-of-site', async () => {
@@ -387,13 +438,15 @@ describe('vault routes', () => {
   });
 
   it('should get vault status', async () => {
-    selectMock.mockReturnValueOnce(chainMock([makeVault({
-      lastSyncAt: new Date('2026-03-28T12:00:00.000Z'),
-      lastSyncStatus: 'completed',
-      lastSyncSnapshotId: 'snap-ext-001',
-      syncSizeBytes: 1073741824,
-      lastSyncError: null,
-    })]));
+    selectMock
+      .mockReturnValueOnce(chainMock([makeVault({
+        lastSyncAt: new Date('2026-03-28T12:00:00.000Z'),
+        lastSyncStatus: 'completed',
+        lastSyncSnapshotId: 'snap-ext-001',
+        syncSizeBytes: 1073741824,
+        lastSyncError: null,
+      })]))
+      .mockReturnValueOnce(chainMock([{ siteId: SITE_A }]));
 
     const res = await app.request(`/backup/vault/${VAULT_ID}/status`, {
       method: 'GET',

--- a/apps/api/src/routes/backup/vault.ts
+++ b/apps/api/src/routes/backup/vault.ts
@@ -21,13 +21,14 @@ export const vaultRoutes = new Hono();
 const vaultIdParam = z.object({ id: z.string().guid() });
 
 async function isDeviceSiteDenied(orgId: string, deviceId: string, permissions: UserPermissions | undefined): Promise<boolean> {
-  if (!permissions?.allowedSiteIds) return false;
   const [device] = await db
     .select({ siteId: devices.siteId })
     .from(devices)
     .where(and(eq(devices.id, deviceId), eq(devices.orgId, orgId)))
     .limit(1);
-  return !device || typeof device.siteId !== 'string' || !canAccessSite(permissions, device.siteId);
+  if (!device) return true;
+  if (!permissions?.allowedSiteIds) return false;
+  return typeof device.siteId !== 'string' || !canAccessSite(permissions, device.siteId);
 }
 
 async function resolveSiteAllowedDeviceIds(orgId: string, perms: UserPermissions | undefined): Promise<string[] | null> {
@@ -143,7 +144,7 @@ vaultRoutes.post(
 
   const payload = c.req.valid('json');
   if (await isDeviceSiteDenied(orgId, payload.deviceId, c.get('permissions') as UserPermissions | undefined)) {
-    return c.json({ error: 'Access to this site denied' }, 403);
+    return c.json({ error: 'Device not found or access denied' }, 403);
   }
   const now = new Date();
 
@@ -320,12 +321,15 @@ vaultRoutes.post(
 
     // Dispatch vault_sync command to the device
     try {
-      await queueCommandForExecution(
+      const result = await queueCommandForExecution(
         vault.deviceId,
         CommandTypes.VAULT_SYNC,
         { vaultId: vault.id, snapshotId: payload.snapshotId },
-        { userId: auth.user?.id }
+        { userId: auth.user?.id, expectedOrgId: orgId }
       );
+      if ('error' in result) {
+        throw new Error(result.error);
+      }
     } catch (err) {
       console.error('[Vault] Failed to dispatch sync command:', err);
       await db.update(localVaults).set({

--- a/apps/api/src/routes/backup/vault.ts
+++ b/apps/api/src/routes/backup/vault.ts
@@ -309,7 +309,9 @@ vaultRoutes.post(
       return c.json({ error: 'Access to this site denied' }, 403);
     }
 
-    // Update sync status to pending
+    // Update sync status to pending. The predicate repeats org_id and the
+    // device_id we just authorized: the vault was read in a separate statement
+    // above, so `id` alone would be a check-then-act window.
     await db
       .update(localVaults)
       .set({
@@ -317,7 +319,11 @@ vaultRoutes.post(
         lastSyncSnapshotId: payload.snapshotId ?? null,
         updatedAt: new Date(),
       })
-      .where(eq(localVaults.id, id));
+      .where(and(
+        eq(localVaults.id, id),
+        eq(localVaults.orgId, orgId),
+        eq(localVaults.deviceId, vault.deviceId),
+      ));
 
     // Dispatch vault_sync command to the device
     try {
@@ -336,7 +342,11 @@ vaultRoutes.post(
         lastSyncStatus: 'failed',
         lastSyncError: 'Failed to dispatch sync command to agent',
         updatedAt: new Date(),
-      }).where(eq(localVaults.id, id));
+      }).where(and(
+        eq(localVaults.id, id),
+        eq(localVaults.orgId, orgId),
+        eq(localVaults.deviceId, vault.deviceId),
+      ));
       return c.json({ error: 'Failed to dispatch sync command to agent' }, 502);
     }
 

--- a/apps/api/src/routes/backup/vault.ts
+++ b/apps/api/src/routes/backup/vault.ts
@@ -36,6 +36,65 @@ async function resolveSiteAllowedDeviceIds(orgId: string, perms: UserPermissions
   return orgDevices.filter((d) => typeof d.siteId === 'string' && canAccessSite(perms, d.siteId)).map((d) => d.id);
 }
 
+function isEmptySiteCeiling(permissions: UserPermissions | undefined): boolean {
+  const allowedSiteIds = permissions?.allowedSiteIds;
+  return allowedSiteIds !== undefined && (!Array.isArray(allowedSiteIds) || allowedSiteIds.length === 0);
+}
+
+async function updateVaultWithinCurrentSite(
+  orgId: string,
+  vaultId: string,
+  updateData: Record<string, unknown>,
+  permissions: UserPermissions | undefined,
+) {
+  const allowedSiteIds = permissions?.allowedSiteIds;
+  if (allowedSiteIds === undefined) {
+    const [row] = await db
+      .update(localVaults)
+      .set(updateData)
+      .where(and(eq(localVaults.id, vaultId), eq(localVaults.orgId, orgId)))
+      .returning();
+    return row;
+  }
+  if (!Array.isArray(allowedSiteIds) || allowedSiteIds.length === 0) return undefined;
+
+  // Device-first locking is shared with device-move paths. If the move wins,
+  // this re-read observes the new site and denies; if this lock wins, the move
+  // waits until the authorized vault mutation commits. The deviceId equality
+  // on the UPDATE is a final CAS against unsupported direct reassignment.
+  return db.transaction(async (tx) => {
+    const [vault] = await tx
+      .select({ deviceId: localVaults.deviceId })
+      .from(localVaults)
+      .where(and(eq(localVaults.id, vaultId), eq(localVaults.orgId, orgId)))
+      .limit(1);
+    if (!vault) return undefined;
+
+    const [device] = await tx
+      .select({ id: devices.id })
+      .from(devices)
+      .where(and(
+        eq(devices.id, vault.deviceId),
+        eq(devices.orgId, orgId),
+        inArray(devices.siteId, allowedSiteIds),
+      ))
+      .limit(1)
+      .for('update');
+    if (!device) return undefined;
+
+    const [row] = await tx
+      .update(localVaults)
+      .set(updateData)
+      .where(and(
+        eq(localVaults.id, vaultId),
+        eq(localVaults.orgId, orgId),
+        eq(localVaults.deviceId, vault.deviceId),
+      ))
+      .returning();
+    return row;
+  });
+}
+
 // GET /vault — list vaults for org (optional ?deviceId filter)
 vaultRoutes.get('/', requirePermission(PERMISSIONS.ORGS_READ.resource, PERMISSIONS.ORGS_READ.action), zValidator('query', vaultListSchema), async (c) => {
   const auth = c.get('auth');
@@ -136,6 +195,10 @@ vaultRoutes.patch(
 
     const { id } = c.req.valid('param');
     const payload = c.req.valid('json');
+    const permissions = c.get('permissions') as UserPermissions | undefined;
+    if (isEmptySiteCeiling(permissions)) {
+      return c.json({ error: 'Vault not found' }, 404);
+    }
 
     const updateData: Record<string, unknown> = { updatedAt: new Date() };
     if (payload.vaultPath !== undefined) updateData.vaultPath = payload.vaultPath;
@@ -143,11 +206,7 @@ vaultRoutes.patch(
     if (payload.retentionCount !== undefined) updateData.retentionCount = payload.retentionCount;
     if (payload.isActive !== undefined) updateData.isActive = payload.isActive;
 
-    const [row] = await db
-      .update(localVaults)
-      .set(updateData)
-      .where(and(eq(localVaults.id, id), eq(localVaults.orgId, orgId)))
-      .returning();
+    const row = await updateVaultWithinCurrentSite(orgId, id, updateData, permissions);
 
     if (!row) {
       return c.json({ error: 'Vault not found' }, 404);
@@ -179,12 +238,17 @@ vaultRoutes.delete(
   }
 
   const { id } = c.req.valid('param');
+  const permissions = c.get('permissions') as UserPermissions | undefined;
+  if (isEmptySiteCeiling(permissions)) {
+    return c.json({ error: 'Vault not found' }, 404);
+  }
 
-  const [row] = await db
-    .update(localVaults)
-    .set({ isActive: false, updatedAt: new Date() })
-    .where(and(eq(localVaults.id, id), eq(localVaults.orgId, orgId)))
-    .returning();
+  const row = await updateVaultWithinCurrentSite(
+    orgId,
+    id,
+    { isActive: false, updatedAt: new Date() },
+    permissions,
+  );
 
   if (!row) {
     return c.json({ error: 'Vault not found' }, 404);

--- a/apps/api/src/routes/backup/verification.siteScope.test.ts
+++ b/apps/api/src/routes/backup/verification.siteScope.test.ts
@@ -1,7 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
 
-const state = vi.hoisted(() => ({ allowedSiteIds: undefined as string[] | undefined }));
+const state = vi.hoisted(() => ({
+  allowedSiteIds: undefined as string[] | undefined,
+  // Which context key carries the ceiling. `permissions` is only set by
+  // requirePermission; `auth` is always populated by the auth middleware.
+  ceilingSource: 'both' as 'both' | 'auth-only' | 'permissions-only',
+}));
 const listBackupVerificationsMock = vi.hoisted(() => vi.fn<(...args: unknown[]) => Promise<Record<string, unknown>[]>>(async () => []));
 const listRecoveryReadinessMock = vi.hoisted(() => vi.fn<(...args: unknown[]) => Promise<Record<string, unknown>[]>>(async () => []));
 const getBackupHealthSummaryMock = vi.hoisted(() => vi.fn<(...args: unknown[]) => Promise<Record<string, unknown>>>(async () => ({
@@ -13,8 +18,15 @@ const recalculateReadinessScoresMock = vi.hoisted(() => vi.fn<(...args: unknown[
 
 vi.mock('../../middleware/auth', () => ({
   requirePermission: vi.fn(() => (c: any, next: any) => {
-    c.set('auth', { orgId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc', scope: 'organization', user: { id: 'user-1' } });
-    c.set('permissions', { allowedSiteIds: state.allowedSiteIds });
+    c.set('auth', {
+      orgId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+      scope: 'organization',
+      user: { id: 'user-1' },
+      ...(state.ceilingSource === 'permissions-only' ? {} : { allowedSiteIds: state.allowedSiteIds }),
+    });
+    if (state.ceilingSource !== 'auth-only') {
+      c.set('permissions', { allowedSiteIds: state.allowedSiteIds });
+    }
     return next();
   }),
   requireScope: vi.fn(() => (_c: any, next: any) => next()),
@@ -58,6 +70,7 @@ describe('backup verification read site scope', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     state.allowedSiteIds = undefined;
+    state.ceilingSource = 'both';
   });
 
   it('propagates a selected-site ceiling through lists, aggregates, and refresh', async () => {
@@ -100,6 +113,10 @@ describe('backup verification read site scope', () => {
       devices: [],
     });
     expect(health.data.verification.total).toBe(0);
+    // A reader who can see nothing has NOT observed a healthy fleet. Reporting
+    // 100% coverage / 'healthy' off zero visible devices is a false assurance.
+    expect(health.data.status).toBe('unknown');
+    expect(health.data.verification.coveragePercent).toBeNull();
     expect(getBackupHealthSummaryMock).not.toHaveBeenCalled();
     expect(listBackupVerificationsMock).not.toHaveBeenCalled();
     expect(listRecoveryReadinessMock).not.toHaveBeenCalled();
@@ -123,6 +140,38 @@ describe('backup verification read site scope', () => {
       'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
       undefined,
     );
+  });
+
+  it('reads the ceiling from auth when no requirePermission populated permissions', async () => {
+    state.ceilingSource = 'auth-only';
+    state.allowedSiteIds = ['aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'];
+
+    await app.request('/backup/verifications');
+    await app.request('/backup/recovery-readiness');
+    await app.request('/backup/health');
+
+    expect(listBackupVerificationsMock).toHaveBeenCalledWith(
+      'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+      expect.objectContaining({ allowedSiteIds: state.allowedSiteIds }),
+    );
+    expect(listRecoveryReadinessMock).toHaveBeenCalledWith(
+      'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+      state.allowedSiteIds,
+    );
+    expect(getBackupHealthSummaryMock).toHaveBeenCalledWith(
+      'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+      state.allowedSiteIds,
+    );
+  });
+
+  it('still finds a permissions-only ceiling (route mounted without auth-carried sites)', async () => {
+    state.ceilingSource = 'permissions-only';
+    state.allowedSiteIds = [];
+
+    const list = await (await app.request('/backup/verifications')).json();
+
+    expect(list.data).toEqual([]);
+    expect(listBackupVerificationsMock).not.toHaveBeenCalled();
   });
 
   it('projects verification details to the shipped simulated marker only', async () => {

--- a/apps/api/src/routes/backup/verification.siteScope.test.ts
+++ b/apps/api/src/routes/backup/verification.siteScope.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+const state = vi.hoisted(() => ({ allowedSiteIds: undefined as string[] | undefined }));
+const listBackupVerificationsMock = vi.hoisted(() => vi.fn<(...args: unknown[]) => Promise<Record<string, unknown>[]>>(async () => []));
+const listRecoveryReadinessMock = vi.hoisted(() => vi.fn<(...args: unknown[]) => Promise<Record<string, unknown>[]>>(async () => []));
+const getBackupHealthSummaryMock = vi.hoisted(() => vi.fn<(...args: unknown[]) => Promise<Record<string, unknown>>>(async () => ({
+  verification: { total: 0, passedLast24h: 0, failedLast24h: 0, partialLast24h: 0, coveragePercent: 100 },
+  readiness: { averageScore: 0, lowReadinessCount: 0, criticalDevicesAtRisk: 0 },
+  escalations: { verificationFailures: 0, criticalVerificationFailures: 0 },
+})));
+const recalculateReadinessScoresMock = vi.hoisted(() => vi.fn<(...args: unknown[]) => Promise<number>>(async () => 0));
+
+vi.mock('../../middleware/auth', () => ({
+  requirePermission: vi.fn(() => (c: any, next: any) => {
+    c.set('auth', { orgId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc', scope: 'organization', user: { id: 'user-1' } });
+    c.set('permissions', { allowedSiteIds: state.allowedSiteIds });
+    return next();
+  }),
+  requireScope: vi.fn(() => (_c: any, next: any) => next()),
+  requireMfa: vi.fn(() => (_c: any, next: any) => next()),
+}));
+
+vi.mock('../../services/permissions', () => ({
+  PERMISSIONS: {
+    ORGS_READ: { resource: 'organizations', action: 'read' },
+    DEVICES_EXECUTE: { resource: 'devices', action: 'execute' },
+  },
+  canAccessSite: vi.fn(() => true),
+}));
+
+vi.mock('../../db', () => ({ db: { select: vi.fn() } }));
+vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
+vi.mock('./helpers', () => ({
+  resolveScopedOrgId: (auth: { orgId?: string }) => auth.orgId,
+  toDateOrNull: () => null,
+}));
+vi.mock('./verificationService', () => ({
+  BACKUP_HIGH_READINESS_THRESHOLD: 85,
+  BACKUP_LOW_READINESS_THRESHOLD: 60,
+  BackupVerificationDispatchError: class BackupVerificationDispatchError extends Error {},
+  getBackupHealthSummary: (...args: unknown[]) => getBackupHealthSummaryMock(...args),
+  listBackupVerifications: (...args: unknown[]) => listBackupVerificationsMock(...args),
+  listRecoveryReadiness: (...args: unknown[]) => listRecoveryReadinessMock(...args),
+  recalculateReadinessScores: (...args: unknown[]) => recalculateReadinessScoresMock(...args),
+  runBackupVerification: vi.fn(),
+  toVerificationListItem: (row: { details?: Record<string, unknown> | null }) => ({
+    ...row,
+    details: row.details?.simulated === true ? { simulated: true } : null,
+  }),
+}));
+
+import { backupVerificationRoutes } from './verification';
+
+describe('backup verification read site scope', () => {
+  const app = new Hono().route('/backup', backupVerificationRoutes);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    state.allowedSiteIds = undefined;
+  });
+
+  it('propagates a selected-site ceiling through lists, aggregates, and refresh', async () => {
+    state.allowedSiteIds = ['aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'];
+
+    expect((await app.request('/backup/verifications')).status).toBe(200);
+    expect((await app.request('/backup/recovery-readiness?refresh=true')).status).toBe(200);
+    expect((await app.request('/backup/health?refresh=true')).status).toBe(200);
+
+    expect(listBackupVerificationsMock).toHaveBeenCalledWith(
+      'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+      expect.objectContaining({ allowedSiteIds: state.allowedSiteIds }),
+    );
+    expect(listRecoveryReadinessMock).toHaveBeenCalledWith(
+      'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+      state.allowedSiteIds,
+    );
+    expect(getBackupHealthSummaryMock).toHaveBeenCalledWith(
+      'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+      state.allowedSiteIds,
+    );
+    expect(recalculateReadinessScoresMock).toHaveBeenCalledTimes(2);
+    expect(recalculateReadinessScoresMock).toHaveBeenNthCalledWith(
+      1,
+      'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+      state.allowedSiteIds,
+    );
+  });
+
+  it('returns zero-safe shapes for an empty ceiling without service or DB work', async () => {
+    state.allowedSiteIds = [];
+
+    const list = await (await app.request('/backup/verifications')).json();
+    const readiness = await (await app.request('/backup/recovery-readiness?refresh=true')).json();
+    const health = await (await app.request('/backup/health?refresh=true')).json();
+
+    expect(list.data).toEqual([]);
+    expect(readiness.data).toEqual({
+      summary: { devices: 0, averageScore: 0, lowReadiness: 0, highReadiness: 0 },
+      devices: [],
+    });
+    expect(health.data.verification.total).toBe(0);
+    expect(getBackupHealthSummaryMock).not.toHaveBeenCalled();
+    expect(listBackupVerificationsMock).not.toHaveBeenCalled();
+    expect(listRecoveryReadinessMock).not.toHaveBeenCalled();
+    expect(recalculateReadinessScoresMock).not.toHaveBeenCalled();
+  });
+
+  it('preserves unrestricted behavior with an undefined ceiling', async () => {
+    await app.request('/backup/verifications');
+    await app.request('/backup/recovery-readiness');
+    await app.request('/backup/health');
+
+    expect(listBackupVerificationsMock).toHaveBeenCalledWith(
+      'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+      expect.objectContaining({ allowedSiteIds: undefined }),
+    );
+    expect(listRecoveryReadinessMock).toHaveBeenCalledWith(
+      'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+      undefined,
+    );
+    expect(getBackupHealthSummaryMock).toHaveBeenCalledWith(
+      'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+      undefined,
+    );
+  });
+
+  it('projects verification details to the shipped simulated marker only', async () => {
+    listBackupVerificationsMock.mockResolvedValueOnce([
+      {
+        id: 'verification-1',
+        details: {
+          simulated: true,
+          restorePath: '/private/customer/restore',
+          failedFiles: ['/private/customer/secret.txt'],
+          commandId: 'command-internal',
+          stdout: 'agent-controlled output',
+        },
+      },
+      {
+        id: 'verification-2',
+        details: {
+          simulated: false,
+          restorePath: '/private/customer/other',
+          commandId: 'other-command',
+        },
+      },
+    ]);
+
+    const response = await app.request('/backup/verifications');
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data).toEqual([
+      { id: 'verification-1', details: { simulated: true } },
+      { id: 'verification-2', details: null },
+    ]);
+    expect(JSON.stringify(body)).not.toContain('restorePath');
+    expect(JSON.stringify(body)).not.toContain('failedFiles');
+    expect(JSON.stringify(body)).not.toContain('command-internal');
+    expect(JSON.stringify(body)).not.toContain('agent-controlled output');
+  });
+});

--- a/apps/api/src/routes/backup/verification.ts
+++ b/apps/api/src/routes/backup/verification.ts
@@ -21,7 +21,8 @@ import {
   listBackupVerifications,
   listRecoveryReadiness,
   recalculateReadinessScores,
-  runBackupVerification
+  runBackupVerification,
+  toVerificationListItem
 } from './verificationService';
 
 export const backupVerificationRoutes = new Hono();
@@ -36,6 +37,18 @@ async function isDeviceSiteDenied(orgId: string, deviceId: string, permissions: 
   return !device || typeof device.siteId !== 'string' || !canAccessSite(permissions, device.siteId);
 }
 
+function allowedSiteIds(c: { get(key: 'permissions'): unknown }): string[] | undefined {
+  return (c.get('permissions') as UserPermissions | undefined)?.allowedSiteIds;
+}
+
+function emptyHealthSummary() {
+  return {
+    verification: { total: 0, passedLast24h: 0, failedLast24h: 0, partialLast24h: 0, coveragePercent: 100 },
+    readiness: { averageScore: 0, lowReadinessCount: 0, criticalDevicesAtRisk: 0 },
+    escalations: { verificationFailures: 0, criticalVerificationFailures: 0 },
+  };
+}
+
 backupVerificationRoutes.get('/health', requirePermission(PERMISSIONS.ORGS_READ.resource, PERMISSIONS.ORGS_READ.action), zValidator('query', backupHealthQuerySchema), async (c) => {
   const auth = c.get('auth');
   const orgId = resolveScopedOrgId(auth, c.req.query('orgId'));
@@ -44,10 +57,14 @@ backupVerificationRoutes.get('/health', requirePermission(PERMISSIONS.ORGS_READ.
   }
 
   const query = c.req.valid('query');
-  if (query.refresh === true) {
-    await recalculateReadinessScores(orgId);
+  const siteIds = allowedSiteIds(c);
+  if (siteIds?.length === 0) {
+    return c.json({ data: { status: 'healthy', ...emptyHealthSummary() } });
   }
-  const summary = await getBackupHealthSummary(orgId);
+  if (query.refresh === true) {
+    await recalculateReadinessScores(orgId, siteIds);
+  }
+  const summary = await getBackupHealthSummary(orgId, siteIds);
 
   return c.json({
     data: {
@@ -136,6 +153,8 @@ backupVerificationRoutes.get('/verifications', requirePermission(PERMISSIONS.ORG
   }
 
   const query = c.req.valid('query');
+  const siteIds = allowedSiteIds(c);
+  if (siteIds?.length === 0) return c.json({ data: [] });
   const rows = await listBackupVerifications(orgId, {
     deviceId: query.deviceId,
     backupJobId: query.backupJobId,
@@ -143,11 +162,14 @@ backupVerificationRoutes.get('/verifications', requirePermission(PERMISSIONS.ORG
     status: query.status,
     from: toDateOrNull(query.from),
     to: toDateOrNull(query.to),
-    limit: query.limit ?? 100
+    limit: query.limit ?? 100,
+    allowedSiteIds: siteIds,
   });
 
   return c.json({
-    data: rows
+    // Keep the HTTP serialization boundary explicit even though the shared
+    // list service also projects for its internal callers.
+    data: rows.map(toVerificationListItem)
   });
 });
 
@@ -159,10 +181,14 @@ backupVerificationRoutes.get('/recovery-readiness', requirePermission(PERMISSION
   }
 
   const query = c.req.valid('query');
-  if (query.refresh === true) {
-    await recalculateReadinessScores(orgId);
+  const siteIds = allowedSiteIds(c);
+  if (siteIds?.length === 0) {
+    return c.json({ data: { summary: { devices: 0, averageScore: 0, lowReadiness: 0, highReadiness: 0 }, devices: [] } });
   }
-  let rows = await listRecoveryReadiness(orgId);
+  if (query.refresh === true) {
+    await recalculateReadinessScores(orgId, siteIds);
+  }
+  let rows = await listRecoveryReadiness(orgId, siteIds);
   if (query.deviceId) {
     rows = rows.filter((row) => row.deviceId === query.deviceId);
   }

--- a/apps/api/src/routes/backup/verification.ts
+++ b/apps/api/src/routes/backup/verification.ts
@@ -37,13 +37,30 @@ async function isDeviceSiteDenied(orgId: string, deviceId: string, permissions: 
   return !device || typeof device.siteId !== 'string' || !canAccessSite(permissions, device.siteId);
 }
 
-function allowedSiteIds(c: { get(key: 'permissions'): unknown }): string[] | undefined {
-  return (c.get('permissions') as UserPermissions | undefined)?.allowedSiteIds;
+/**
+ * The caller's site ceiling. `auth.allowedSiteIds` is the primary source: the
+ * auth middleware always populates it, while `c.get('permissions')` is only
+ * set by `requirePermission`. The `permissions` fallback is kept so a route
+ * mounted without `requirePermission` still finds a ceiling if one is present
+ * — reading both can only ever make this stricter, never looser.
+ */
+function allowedSiteIds(
+  auth: { allowedSiteIds?: string[] } | undefined,
+  c: { get(key: 'permissions'): unknown },
+): string[] | undefined {
+  return auth?.allowedSiteIds ?? (c.get('permissions') as UserPermissions | undefined)?.allowedSiteIds;
 }
 
+/**
+ * Payload for a caller whose site ceiling is defined but empty: they can see
+ * no device, so there is nothing to summarize. `coveragePercent` and `status`
+ * are deliberately `null`/`'unknown'` rather than `100`/`'healthy'` — a reader
+ * who can see nothing has not observed a healthy fleet, and reporting full
+ * coverage off zero devices is an affirmative false assurance.
+ */
 function emptyHealthSummary() {
   return {
-    verification: { total: 0, passedLast24h: 0, failedLast24h: 0, partialLast24h: 0, coveragePercent: 100 },
+    verification: { total: 0, passedLast24h: 0, failedLast24h: 0, partialLast24h: 0, coveragePercent: null },
     readiness: { averageScore: 0, lowReadinessCount: 0, criticalDevicesAtRisk: 0 },
     escalations: { verificationFailures: 0, criticalVerificationFailures: 0 },
   };
@@ -57,9 +74,9 @@ backupVerificationRoutes.get('/health', requirePermission(PERMISSIONS.ORGS_READ.
   }
 
   const query = c.req.valid('query');
-  const siteIds = allowedSiteIds(c);
+  const siteIds = allowedSiteIds(auth, c);
   if (siteIds?.length === 0) {
-    return c.json({ data: { status: 'healthy', ...emptyHealthSummary() } });
+    return c.json({ data: { status: 'unknown', ...emptyHealthSummary() } });
   }
   if (query.refresh === true) {
     await recalculateReadinessScores(orgId, siteIds);
@@ -153,7 +170,7 @@ backupVerificationRoutes.get('/verifications', requirePermission(PERMISSIONS.ORG
   }
 
   const query = c.req.valid('query');
-  const siteIds = allowedSiteIds(c);
+  const siteIds = allowedSiteIds(auth, c);
   if (siteIds?.length === 0) return c.json({ data: [] });
   const rows = await listBackupVerifications(orgId, {
     deviceId: query.deviceId,
@@ -181,7 +198,7 @@ backupVerificationRoutes.get('/recovery-readiness', requirePermission(PERMISSION
   }
 
   const query = c.req.valid('query');
-  const siteIds = allowedSiteIds(c);
+  const siteIds = allowedSiteIds(auth, c);
   if (siteIds?.length === 0) {
     return c.json({ data: { summary: { devices: 0, averageScore: 0, lowReadiness: 0, highReadiness: 0 }, devices: [] } });
   }

--- a/apps/api/src/routes/backup/verificationFailClosed.test.ts
+++ b/apps/api/src/routes/backup/verificationFailClosed.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { selectMock, resolveAssignedMock } = vi.hoisted(() => ({
+  selectMock: vi.fn(),
+  resolveAssignedMock: vi.fn(),
+}));
+
+vi.mock('../../db', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../db')>();
+  return {
+    ...actual,
+    db: { ...actual.db, select: (...args: unknown[]) => selectMock(...args) },
+    withSystemDbAccessContext: async (fn: () => unknown) => fn(),
+  };
+});
+
+vi.mock('../../services/featureConfigResolver', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../services/featureConfigResolver')>();
+  return {
+    ...actual,
+    resolveAllBackupAssignedDevices: (...args: unknown[]) => resolveAssignedMock(...args),
+  };
+});
+
+vi.mock('../../services/eventBus', () => ({ publishEvent: vi.fn() }));
+
+import {
+  getBackupHealthSummary,
+  listBackupVerifications,
+  listRecoveryReadiness,
+} from './verificationService';
+import {
+  backupVerifications,
+  recoveryReadinessOrgById,
+  recoveryReadinessRecords,
+  verificationOrgById,
+} from './store';
+
+const orgId = '11111111-1111-4111-8111-111111111111';
+const deviceId = '33333333-3333-4333-8333-333333333333';
+const siteId = '55555555-5555-4555-8555-555555555555';
+
+describe('backup verification selected-site database failure', () => {
+  beforeEach(() => {
+    selectMock.mockReset();
+    selectMock.mockImplementation(() => {
+      throw new Error('selected-site database unavailable');
+    });
+    resolveAssignedMock.mockReset();
+    resolveAssignedMock.mockResolvedValue([{ deviceId }]);
+  });
+
+  it('does not fall back to in-memory verification rows', async () => {
+    const verificationId = '22222222-2222-4222-8222-222222222222';
+    backupVerifications.push({
+      id: verificationId,
+      orgId,
+      deviceId,
+      backupJobId: '44444444-4444-4444-8444-444444444444',
+      verificationType: 'integrity',
+      status: 'passed',
+      startedAt: new Date().toISOString(),
+      completedAt: new Date().toISOString(),
+      filesVerified: 1,
+      filesFailed: 0,
+      details: { restorePath: '/must-not-fallback' },
+      createdAt: new Date().toISOString(),
+    });
+    verificationOrgById.set(verificationId, orgId);
+
+    try {
+      await expect(listBackupVerifications(orgId, { allowedSiteIds: [siteId] }))
+        .resolves.toEqual([]);
+    } finally {
+      verificationOrgById.delete(verificationId);
+      backupVerifications.splice(backupVerifications.findIndex((row) => row.id === verificationId), 1);
+    }
+  });
+
+  it('does not fall back to in-memory readiness rows', async () => {
+    const readinessId = '66666666-6666-4666-8666-666666666666';
+    recoveryReadinessRecords.push({
+      id: readinessId,
+      orgId,
+      deviceId,
+      readinessScore: 99,
+      estimatedRtoMinutes: null,
+      estimatedRpoMinutes: null,
+      riskFactors: [],
+      calculatedAt: new Date().toISOString(),
+    });
+    recoveryReadinessOrgById.set(readinessId, orgId);
+
+    try {
+      await expect(listRecoveryReadiness(orgId, [siteId])).resolves.toEqual([]);
+    } finally {
+      recoveryReadinessOrgById.delete(readinessId);
+      recoveryReadinessRecords.splice(recoveryReadinessRecords.findIndex((row) => row.id === readinessId), 1);
+    }
+  });
+
+  it('returns a zero-safe health summary without leaking assigned devices', async () => {
+    const health = await getBackupHealthSummary(orgId, [siteId]);
+
+    expect(health).toEqual({
+      verification: {
+        total: 0,
+        passedLast24h: 0,
+        failedLast24h: 0,
+        partialLast24h: 0,
+        coveragePercent: 100,
+      },
+      readiness: {
+        averageScore: 0,
+        lowReadinessCount: 0,
+        criticalDevicesAtRisk: 0,
+      },
+      escalations: {
+        verificationFailures: 0,
+        criticalVerificationFailures: 0,
+      },
+    });
+  });
+});

--- a/apps/api/src/routes/backup/verificationScheduled.ts
+++ b/apps/api/src/routes/backup/verificationScheduled.ts
@@ -3,6 +3,7 @@ import * as dbModule from '../../db';
 import {
   backupJobs as backupJobsTable,
   deviceCommands,
+  devices,
   backupVerifications as backupVerificationsTable,
   RESTORABLE_BACKUP_JOB_STATUSES,
 } from '../../db/schema';
@@ -267,18 +268,25 @@ async function findPendingVerificationByCommandId(commandId: string): Promise<Ba
   }
 }
 
-async function collectDevicesToRecompute(orgId?: string): Promise<Map<string, string> | null> {
+async function collectDevicesToRecompute(orgId?: string, allowedSiteIds?: readonly string[]): Promise<Map<string, string> | null> {
   if (orgId && !isUuid(orgId)) return null;
+  if (allowedSiteIds?.length === 0) return new Map();
   try {
     const [jobRows, verificationRows] = await Promise.all([
       runWithSystemDbAccess(() => db
         .select({ orgId: backupJobsTable.orgId, deviceId: backupJobsTable.deviceId })
         .from(backupJobsTable)
-        .where(orgId ? eq(backupJobsTable.orgId, orgId) : undefined)),
+        .where(and(
+          orgId ? eq(backupJobsTable.orgId, orgId) : undefined,
+          allowedSiteIds ? sql`exists (select 1 from ${devices} where ${devices.id} = ${backupJobsTable.deviceId} and ${devices.orgId} = ${backupJobsTable.orgId} and ${inArray(devices.siteId, [...allowedSiteIds])})` : undefined,
+        ))),
       runWithSystemDbAccess(() => db
         .select({ orgId: backupVerificationsTable.orgId, deviceId: backupVerificationsTable.deviceId })
         .from(backupVerificationsTable)
-        .where(orgId ? eq(backupVerificationsTable.orgId, orgId) : undefined)),
+        .where(and(
+          orgId ? eq(backupVerificationsTable.orgId, orgId) : undefined,
+          allowedSiteIds ? sql`exists (select 1 from ${devices} where ${devices.id} = ${backupVerificationsTable.deviceId} and ${devices.orgId} = ${backupVerificationsTable.orgId} and ${inArray(devices.siteId, [...allowedSiteIds])})` : undefined,
+        ))),
     ]);
 
     const map = new Map<string, string>();
@@ -288,6 +296,7 @@ async function collectDevicesToRecompute(orgId?: string): Promise<Map<string, st
     return map;
   } catch (error) {
     console.warn('[backupVerification] DB readiness scan failed; falling back to memory:', error);
+    if (allowedSiteIds) return new Map();
     return null;
   }
 }
@@ -583,10 +592,10 @@ export async function runWeeklyTestRestore(orgId?: string): Promise<number> {
   return queued;
 }
 
-export async function recalculateReadinessScores(orgId?: string): Promise<number> {
-  const devicesToOrg = await collectDevicesToRecompute(orgId) ?? new Map<string, string>();
+export async function recalculateReadinessScores(orgId?: string, allowedSiteIds?: readonly string[]): Promise<number> {
+  const devicesToOrg = await collectDevicesToRecompute(orgId, allowedSiteIds) ?? new Map<string, string>();
 
-  if (devicesToOrg.size === 0) {
+  if (devicesToOrg.size === 0 && allowedSiteIds === undefined) {
     for (const job of backupJobs) {
       const targetOrg = jobOrgById.get(job.id);
       if (!targetOrg || !UUID_RE.test(targetOrg)) {

--- a/apps/api/src/routes/backup/verificationService.ts
+++ b/apps/api/src/routes/backup/verificationService.ts
@@ -1,9 +1,10 @@
-import { and, desc, eq, gte, lte, sql, type SQL } from 'drizzle-orm';
+import { and, desc, eq, gte, inArray, lte, sql, type SQL } from 'drizzle-orm';
 import * as dbModule from '../../db';
 import {
   backupJobs as backupJobsTable,
   backupSnapshots as backupSnapshotsTable,
   backupVerifications as backupVerificationsTable,
+  devices,
 } from '../../db/schema';
 import { recordBackupDispatchFailure } from '../../services/backupMetrics';
 import { resolveBackupProviderConfig, resolveBackupDestinationError, type BackupProviderConfig } from '../../services/backupProviderConfig';
@@ -71,6 +72,7 @@ type VerificationFilters = {
   to?: number | null;
   limit?: number;
   excludeSimulated?: boolean;
+  allowedSiteIds?: readonly string[];
 };
 
 export type RunBackupVerificationInput = {
@@ -255,15 +257,34 @@ function listBackupVerificationsFromMemory(orgId: string, filters: VerificationF
   return typeof filters.limit === 'number' ? rows.slice(0, filters.limit) : rows;
 }
 
+export function toVerificationListItem(row: BackupVerification): BackupVerification {
+  return {
+    ...row,
+    // Verification details are agent-controlled and can contain restore paths,
+    // failed-file names, command identifiers, and raw result internals. Every
+    // current list consumer only needs the simulated-evidence marker.
+    details: row.details?.simulated === true ? { simulated: true } : null,
+  };
+}
+
 async function listBackupVerificationsFromDb(
   orgId: string,
   filters: VerificationFilters = {}
 ): Promise<BackupVerification[] | null> {
   if (!supportsDbOrg(orgId)) return null;
+  if (filters.allowedSiteIds?.length === 0) return [];
   if (filters.deviceId && !isUuid(filters.deviceId)) return null;
   if (filters.backupJobId && !isUuid(filters.backupJobId)) return null;
 
   const conditions: SQL[] = [eq(backupVerificationsTable.orgId, orgId)];
+  if (filters.allowedSiteIds) {
+    conditions.push(sql`exists (
+      select 1 from ${devices}
+      where ${devices.id} = ${backupVerificationsTable.deviceId}
+        and ${devices.orgId} = ${backupVerificationsTable.orgId}
+        and ${inArray(devices.siteId, [...filters.allowedSiteIds])}
+    )`);
+  }
   if (filters.deviceId) conditions.push(eq(backupVerificationsTable.deviceId, filters.deviceId));
   if (filters.backupJobId) conditions.push(eq(backupVerificationsTable.backupJobId, filters.backupJobId));
   if (filters.verificationType === 'integrity') {
@@ -294,6 +315,7 @@ async function listBackupVerificationsFromDb(
     }));
   } catch (error) {
     console.warn('[backupVerification] DB verification read failed; falling back to memory:', error);
+    if (filters.allowedSiteIds) return [];
     return null;
   }
 }
@@ -537,8 +559,8 @@ export async function listBackupVerifications(
   filters: VerificationFilters = {}
 ): Promise<BackupVerification[]> {
   const dbRows = await listBackupVerificationsFromDb(orgId, filters);
-  if (dbRows) return dbRows;
-  return listBackupVerificationsFromMemory(orgId, filters);
+  const rows = dbRows ?? (filters.allowedSiteIds ? [] : listBackupVerificationsFromMemory(orgId, filters));
+  return rows.map(toVerificationListItem);
 }
 
 function scheduledVerificationAuth(orgId: string): AuthContext {

--- a/apps/api/src/services/aiAgentSdkTools.ts
+++ b/apps/api/src/services/aiAgentSdkTools.ts
@@ -1591,6 +1591,15 @@ export function createBreezeMcpServer(
       makeHandler('delete_tenant', getAuth, onPreToolUse, onPostToolUse)
     ),
 
+    // SEC-2026-09-05-021: get_backup_health / run_backup_verification /
+    // get_recovery_readiness are declared here but have NO executeTool
+    // registration yet (asserted by helperToolFilter.test.ts and the registry
+    // parity contract). When a handler IS wired, it MUST pass the caller's
+    // `auth.allowedSiteIds` through to getBackupHealthSummary /
+    // listRecoveryReadiness / listBackupVerifications the way
+    // routes/backup/verification.ts does — those services apply the site
+    // ceiling only when it is supplied, so an omitted argument silently
+    // returns org-wide rows to a site-restricted caller.
     tool(
       'get_backup_health',
       'Get backup and verification health summary for an organization, with optional device focus.',

--- a/apps/api/src/services/aiToolsVault.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsVault.siteScope.test.ts
@@ -106,7 +106,7 @@ describe('trigger_vault_sync — site scoping (vault → device)', () => {
     let call = 0;
     mockDb.select.mockImplementation(() => {
       call++;
-      if (call === 1) return { from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 'v1', deviceId: 'd1', isActive: true }]) }) }) };
+      if (call === 1) return { from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 'v1', orgId: 'org-1', deviceId: 'd1', isActive: true }]) }) }) };
       return { from: () => ({ where: () => ({ limit: () => Promise.resolve([{ siteId: 'site-B' }]) }) }) };
     });
     mockDb.update.mockReturnValue({ set: () => ({ where: () => Promise.resolve() }) });
@@ -116,7 +116,7 @@ describe('trigger_vault_sync — site scoping (vault → device)', () => {
 
   it('unrestricted caller is unaffected', async () => {
     mockDb.select.mockReturnValue({
-      from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 'v1', deviceId: 'd1', isActive: true }]) }) }),
+      from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 'v1', orgId: 'org-1', deviceId: 'd1', isActive: true }]) }) }),
     });
     mockDb.update.mockReturnValue({ set: () => ({ where: () => Promise.resolve() }) });
     const result = await handlerFor('trigger_vault_sync')({ vaultId: 'v1' }, makeAuth(undefined));

--- a/apps/api/src/services/aiToolsVault.test.ts
+++ b/apps/api/src/services/aiToolsVault.test.ts
@@ -58,6 +58,31 @@ function createQueryChain(rows: any[] = []) {
   return chain;
 }
 
+/**
+ * Real drizzle objects are used in this file (no schema stub), so read the
+ * predicate's column names and bound values off `queryChunks` directly.
+ * Walking only queryChunks keeps this from matching unrelated metadata and
+ * quietly passing against unfixed code.
+ */
+function predicateParts(
+  node: unknown,
+  acc: { columns: string[]; values: unknown[] } = { columns: [], values: [] },
+): { columns: string[]; values: unknown[] } {
+  if (node === null || typeof node !== 'object') return acc;
+  const record = node as Record<string, unknown>;
+  if (typeof record.name === 'string' && record.table !== undefined) {
+    acc.columns.push(record.name);
+    return acc;
+  }
+  if ('encoder' in record && 'value' in record) {
+    acc.values.push(record.value);
+    return acc;
+  }
+  const chunks = record.queryChunks;
+  if (Array.isArray(chunks)) for (const chunk of chunks) predicateParts(chunk, acc);
+  return acc;
+}
+
 function createInsertChain(rows: any[] = []) {
   const chain: any = {};
   chain.values = vi.fn(() => chain);
@@ -170,7 +195,7 @@ function prepareHandlerMocks(toolName: string) {
       mockSelectSequence([[{ id: VAULT_ID, orgId: ORG_ID, deviceId: DEVICE_ID, isActive: true }]]);
       break;
     case 'configure_vault':
-      mockSelectSequence([[{ id: VAULT_ID }]]);
+      mockSelectSequence([[{ id: VAULT_ID, orgId: ORG_ID, deviceId: DEVICE_ID }]]);
       mockUpdateSequence([[{ id: VAULT_ID, vaultPath: '/vaults/updated', vaultType: 'local' }]]);
       break;
     default:
@@ -256,6 +281,47 @@ describe('aiToolsVault handlers', () => {
       expect.objectContaining({ vaultId: VAULT_ID }),
       expect.objectContaining({ userId: 'user-1', expectedOrgId: ORG_ID }),
     );
+  });
+
+  it('binds both AI sync status writes to (id, orgId, deviceId), not id alone', async () => {
+    prepareHandlerMocks('trigger_vault_sync');
+    const updateChains: any[] = [];
+    vi.mocked(db.update).mockImplementation(() => {
+      const chain = createUpdateChain([]);
+      updateChains.push(chain);
+      return chain as any;
+    });
+    // Force the failure branch so BOTH the pending and the failed write run.
+    vi.mocked(queueCommandForExecution).mockResolvedValue({ command: null, error: 'Device not found' } as any);
+
+    await toolMap.get('trigger_vault_sync')!.handler({ vaultId: VAULT_ID }, makeAuth());
+
+    expect(updateChains).toHaveLength(2);
+    for (const chain of updateChains) {
+      const { columns, values } = predicateParts(chain.where.mock.calls[0]![0]);
+      expect(columns).toEqual(expect.arrayContaining(['id', 'org_id', 'device_id']));
+      expect(values).toEqual(expect.arrayContaining([VAULT_ID, ORG_ID, DEVICE_ID]));
+    }
+  });
+
+  it('binds the AI configure_vault update to (id, orgId, deviceId), not id alone', async () => {
+    prepareHandlerMocks('configure_vault');
+    const updateChains: any[] = [];
+    vi.mocked(db.update).mockImplementation(() => {
+      const chain = createUpdateChain([{ id: VAULT_ID, vaultPath: '/vaults/updated' }]);
+      updateChains.push(chain);
+      return chain as any;
+    });
+
+    await toolMap.get('configure_vault')!.handler(
+      { action: 'update', vaultId: VAULT_ID, vaultPath: '/vaults/updated' },
+      makeAuth(),
+    );
+
+    expect(updateChains).toHaveLength(1);
+    const { columns, values } = predicateParts(updateChains[0].where.mock.calls[0]![0]);
+    expect(columns).toEqual(expect.arrayContaining(['id', 'org_id', 'device_id']));
+    expect(values).toEqual(expect.arrayContaining([VAULT_ID, ORG_ID, DEVICE_ID]));
   });
 
   it('safeHandler returns error JSON when the handler throws', async () => {

--- a/apps/api/src/services/aiToolsVault.test.ts
+++ b/apps/api/src/services/aiToolsVault.test.ts
@@ -167,7 +167,7 @@ function prepareHandlerMocks(toolName: string) {
       ]);
       break;
     case 'trigger_vault_sync':
-      mockSelectSequence([[{ id: VAULT_ID, deviceId: DEVICE_ID, isActive: true }]]);
+      mockSelectSequence([[{ id: VAULT_ID, orgId: ORG_ID, deviceId: DEVICE_ID, isActive: true }]]);
       break;
     case 'configure_vault':
       mockSelectSequence([[{ id: VAULT_ID }]]);
@@ -244,6 +244,18 @@ describe('aiToolsVault handlers', () => {
     await toolMap.get('query_vaults')!.handler({}, auth);
 
     expect(auth.orgCondition).toHaveBeenCalled();
+  });
+
+  it('pins AI vault sync dispatch to the selected vault organization', async () => {
+    prepareHandlerMocks('trigger_vault_sync');
+    await toolMap.get('trigger_vault_sync')!.handler({ vaultId: VAULT_ID }, makeAuth());
+
+    expect(queueCommandForExecution).toHaveBeenCalledWith(
+      DEVICE_ID,
+      'vault_sync',
+      expect.objectContaining({ vaultId: VAULT_ID }),
+      expect.objectContaining({ userId: 'user-1', expectedOrgId: ORG_ID }),
+    );
   });
 
   it('safeHandler returns error JSON when the handler throws', async () => {

--- a/apps/api/src/services/aiToolsVault.ts
+++ b/apps/api/src/services/aiToolsVault.ts
@@ -258,6 +258,9 @@ export function registerVaultTools(aiTools: Map<string, AiTool>): void {
         return JSON.stringify({ error: 'Vault not found or access denied' });
       }
 
+      // Repeat the tenant and device axes the checks above authorized: the
+      // vault was read in a separate statement, so `id` alone would leave a
+      // check-then-act window.
       await db
         .update(localVaults)
         .set({
@@ -265,7 +268,11 @@ export function registerVaultTools(aiTools: Map<string, AiTool>): void {
           lastSyncSnapshotId: typeof input.snapshotId === 'string' ? input.snapshotId : null,
           updatedAt: new Date(),
         })
-        .where(eq(localVaults.id, vault.id));
+        .where(and(
+          eq(localVaults.id, vault.id),
+          eq(localVaults.orgId, vault.orgId),
+          eq(localVaults.deviceId, vault.deviceId),
+        ));
 
       const { command, error } = await queueCommandForExecution(
         vault.deviceId,
@@ -284,7 +291,11 @@ export function registerVaultTools(aiTools: Map<string, AiTool>): void {
             lastSyncStatus: 'failed',
             updatedAt: new Date(),
           })
-          .where(eq(localVaults.id, vault.id));
+          .where(and(
+            eq(localVaults.id, vault.id),
+            eq(localVaults.orgId, vault.orgId),
+            eq(localVaults.deviceId, vault.deviceId),
+          ));
         return JSON.stringify({ error });
       }
 
@@ -385,7 +396,7 @@ export function registerVaultTools(aiTools: Map<string, AiTool>): void {
         const vc = orgWhere(auth, localVaults.orgId);
         if (vc) vaultConditions.push(vc);
         const [existing] = await db
-          .select({ id: localVaults.id, deviceId: localVaults.deviceId })
+          .select({ id: localVaults.id, orgId: localVaults.orgId, deviceId: localVaults.deviceId })
           .from(localVaults)
           .where(and(...vaultConditions))
           .limit(1);
@@ -405,7 +416,11 @@ export function registerVaultTools(aiTools: Map<string, AiTool>): void {
         const [vault] = await db
           .update(localVaults)
           .set(updateData)
-          .where(eq(localVaults.id, vaultId))
+          .where(and(
+            eq(localVaults.id, vaultId),
+            eq(localVaults.orgId, existing.orgId),
+            eq(localVaults.deviceId, existing.deviceId),
+          ))
           .returning();
 
         return JSON.stringify({ success: true, vault });

--- a/apps/api/src/services/aiToolsVault.ts
+++ b/apps/api/src/services/aiToolsVault.ts
@@ -242,6 +242,7 @@ export function registerVaultTools(aiTools: Map<string, AiTool>): void {
       const [vault] = await db
         .select({
           id: localVaults.id,
+          orgId: localVaults.orgId,
           deviceId: localVaults.deviceId,
           isActive: localVaults.isActive,
         })
@@ -273,7 +274,7 @@ export function registerVaultTools(aiTools: Map<string, AiTool>): void {
           vaultId: vault.id,
           snapshotId: typeof input.snapshotId === 'string' ? input.snapshotId : undefined,
         },
-        { userId: auth.user?.id }
+        { userId: auth.user?.id, expectedOrgId: vault.orgId }
       );
 
       if (error) {

--- a/apps/web/src/components/backup/BackupVerificationOverview.tsx
+++ b/apps/web/src/components/backup/BackupVerificationOverview.tsx
@@ -40,7 +40,9 @@ type FleetHealth = {
     passedLast24h?: number;
     failedLast24h?: number;
     partialLast24h?: number;
-    coveragePercent?: number;
+    // null when the caller's site ceiling is empty: they can see no device, so
+    // there is no coverage figure to report (API returns null, not 100).
+    coveragePercent?: number | null;
   };
   readiness?: {
     averageScore?: number;

--- a/apps/web/src/components/backup/SLADashboard.tsx
+++ b/apps/web/src/components/backup/SLADashboard.tsx
@@ -42,10 +42,12 @@ type SLAEvent = {
 };
 
 type SLADashboardData = {
-  compliancePercent?: number;
+  // null when the caller's site ceiling is empty — no visible device means no
+  // compliance or RPO/RTO figure to report. Rendered via `?? 0` below.
+  compliancePercent?: number | null;
   activeBreaches?: number;
-  avgRpoMinutes?: number;
-  avgRtoMinutes?: number;
+  avgRpoMinutes?: number | null;
+  avgRtoMinutes?: number | null;
 };
 
 const eventTypeBadge: Record<string, { label: string; className: string }> = {


### PR DESCRIPTION
Three independently-reviewed Medium tenant-isolation repairs in the backup/vault area, ported onto current main from a private remediation program. All three were tested locally against a real PostgreSQL stack before this port; every gate below was re-run on this branch.

## Summary

### SEC-2026-09-05-021 — verification reads ignored the site ceiling, and listings leaked agent-supplied detail
**Wrong:** `GET /backup/verifications`, `GET /backup/health` and `GET /backup/recovery-readiness` resolved the caller's organization but applied their *site* ceiling nowhere. Rows were selected, `limit`-truncated and aggregated across every device in the organization, so a site-restricted org reader saw verification rows, readiness scores and coverage percentages for devices at sites they cannot see. The listing also returned the whole agent-controlled `details` blob (restore paths, failed-file names, command identifiers, raw result internals).

**Enforced now:** `listBackupVerifications`, `listRecoveryReadiness`, `getBackupHealthSummary` and `recalculateReadinessScores` take `allowedSiteIds` and push an `EXISTS (… devices.site_id IN …)` predicate into the SQL, so the ceiling applies **before** limit and aggregation rather than truncating a visible set out of an unscoped one. A defined-but-empty ceiling fails closed with empty data at the route. Every DB-failure fallback returns `[]` instead of the unscoped in-memory store whenever a ceiling is defined. `toVerificationListItem` reduces `details` to the shipped `{simulated: true}` marker (or `null`), applied both in the service and at the HTTP boundary.

An **undefined** ceiling (unrestricted org / partner / system callers) keeps existing behaviour apart from the `details` minimization.

### SEC-2026-09-05-024 — vault PATCH/DELETE were authorized on the org axis only
**Wrong:** both mutations required `organizations:write` + MFA and resolved the org through the scope helper, then updated `local_vaults` by `(id, org_id)` alone. RLS protects the organization axis, not the application-level site ceiling. A site-restricted org writer who learned a same-org vault UUID could change its path / type / retention / active state, or deactivate it after the vault's device had moved to a hidden site. Org-scoped audit-log listing can disclose vault resource ids, so an unguessable UUID is not a sufficient countercontrol.

**Enforced now:** one `updateVaultWithinCurrentSite` boundary for both siblings. A defined-empty or malformed ceiling fails closed with an opaque 404 *before* any database or audit effect. For a selected ceiling the helper resolves the vault under the caller's org, locks the vault's current device `FOR UPDATE` constrained by `(id, org_id, site_id IN allowedSiteIds)`, then updates only when `(id, org_id, device_id)` still matches — a final CAS against unsupported direct reassignment. An undefined ceiling keeps the existing single-statement org-predicated update. Permission, MFA, validation, audit and response behaviour are unchanged.

### SEC-2026-09-05-026 — local vaults could name another tenant's device
**Wrong:** `isDeviceSiteDenied` returned early for callers with no site ceiling, so `POST /backup/vault` inserted the caller's `org_id` alongside an *unverified* `device_id`. An unrestricted org writer with MFA who knew a foreign device UUID could create a row pairing their org with the victim's device: invisible to the victim under org-axis RLS, while its single-column `NO ACTION` device FK could block deletion of the victim's device. Separately, neither the HTTP nor the AI vault-sync path bound dispatch to the vault's stored organization — the command layer did reject the foreign device, but HTTP treated the returned `{error}` object as a pending success.

**Enforced now:**
- `isDeviceSiteDenied` always resolves the device by `(id, org_id)` first and denies when absent, so tenant ownership is checked before the site-policy short-circuit and before the insert. The 403 body is the opaque `Device not found or access denied`.
- HTTP sync passes `expectedOrgId` and recognizes the sink's `{error}` rejection, recording a visible failed state and a 502 instead of claiming pending success. `aiToolsVault` loads the vault's stored `org_id` and forwards it as `expectedOrgId`.
- New composite FK `local_vaults(device_id, org_id) → devices(id, org_id)` as the database backstop for every present and future writer — the same pattern `device_mtls_certificates` already uses against the existing `devices_id_org_id_uniq` index. It is `NO ACTION` and `DEFERRABLE INITIALLY DEFERRED` so the established device-move transaction can restamp `local_vaults.org_id` within the same transaction.
- The forward migration **restamps and deactivates** historical mismatched rows rather than deleting them — see Review fixes below.

### SEC-021 sibling — `GET /backup/sla/dashboard` leaked the same org-wide figures
`/backup/sla/dashboard` never read the site ceiling, so a site-restricted tech still received org-wide RPO/RTO averages, the active-breach count and the 30-day event count that SEC-021 had just closed on `/backup/health`. It now resolves the ceiling with the `resolveSiteAllowedDeviceIds` helper already used by `GET /events` in the same file, keeps unattributed (`device_id NULL`) events visible exactly as that sibling does, and fails closed on an empty ceiling without issuing a single aggregate query. Found in review of this PR, fixed here because it is the same finding's blast radius.

## Ported from

Local commits in the private remediation program, cherry-picked with `-x` and squashed to one commit per finding:

| Finding | Local commits | Squashed into |
|---|---|---|
| SEC-021 | `2c33a7cd64` (test), `d70b14d8e4` (fix), `c9b18432ce` (fix) | `f26369ea21` |
| SEC-024 | `658f324663` (test), `6f5c2ee241` (fix) | `50f62036bc` |
| SEC-026 | `b8efdb642b` (test), `aeab78f592` (fix) | `923938c912` |

**Changed vs. the original:**
- **Migration renamed** `2026-10-14-100600-local-vault-device-org-fk.sql` → `2026-10-15-160110-local-vault-device-org-fk.sql`, to sort after the newest committed migration (`2026-10-15-160010-backup-snapshots-layout-manifest.sql`). No references to the old path existed. *(verified)*
- **Nothing was dropped.** All seven local commits applied without conflict onto current main despite the 09-09/09-10 backup churn (backup assurance, bare-metal recovery #5520/#5523/#5529, SEC-121 #5519) — those landed in `agent/` and in backup snapshot/BMR code, not in the verification-read, vault-mutation or vault-sync paths these findings touch. *(verified: seven clean `cherry-pick` applications, then a clean `git rebase origin/main` after main advanced to `e4fbca279d` mid-run)*
- `queueCommandForExecution`'s `expectedOrgId` option that SEC-026 depends on **already exists on main** (`services/commandQueue.ts:715,984`) with its own coverage — no change was needed there. *(verified)*

**Note for the reviewer:** the brief for this port named only three commits (`c9b18432ce`, `658f324663`+`6f5c2ee241`, `aeab78f592`). Two of those are the *tail* of a longer local batch and do not stand alone: `c9b18432ce` edits test files that only exist in its two predecessors, and `aeab78f592` ships without the test commit that discriminates it. The four missing commits were located by walking each fix commit's local ancestry and are included above.

## Review fixes (second round)

### BLOCKER — the migration deleted rows; it now restamps and deactivates
The first version of `2026-10-15-160110-local-vault-device-org-fk.sql` deleted mismatched `local_vaults` rows, cascading their `vault_snapshot_inventory` children. That was the wrong repair:

- **Restamping from the device is the repo's canonical fix for this row shape.** The dynamic `breeze_cascade_device_org_id()` trigger (`2026-05-18-device-child-orgid-cascade.sql`) has restamped `local_vaults.org_id` on every device move since 2026-05-18. A mismatch found today is therefore *indistinguishable* from a benign pre-trigger device move, and the migration must not pick the destructive reading.
- **The cascade destroys victim data.** `vault_snapshot_inventory` is recovery metadata describing backups of data on the **victim org's** device. Deleting it to repair an attacker-created pointer compounds the harm.

The migration now, in one `DO` block after `SELECT set_config('breeze.scope','system',true)`:
1. `UPDATE local_vaults v SET org_id = d.org_id, is_active = false FROM devices d WHERE d.id = v.device_id AND d.org_id <> v.org_id` — restamped to the device's real tenant, and **deactivated** so an attacker-chosen `vault_path` cannot start syncing under the corrected org until a human re-enables it.
2. `UPDATE vault_snapshot_inventory i SET org_id = v.org_id FROM local_vaults v WHERE v.id = i.vault_id AND i.org_id <> v.org_id` — runs *after* the parent so it observes the corrected org. This table keys on `vault_id`, not `device_id`, so the device trigger never covers it.

Both repairs capture the affected ids (capped at 200, `(array_agg(... ORDER BY id))[1:200]`) before the update and report exact, uncapped `GET DIAGNOSTICS` counts for **both** tables in a single unconditional `RAISE WARNING` — including on a zero-count re-apply, so the forensic trail exists even when nothing was found.

### SHOULD FIX
- **`GET /backup/sla/dashboard`** — site-scoped; see the Summary section above.
- **Four remaining vault writes** (`vault.ts` sync pending + failure, `aiToolsVault.ts` sync pending + failure, `aiToolsVault.ts` configure update) matched on `id` alone *after* a check-then-act site check. Each now repeats `(id, orgId, deviceId)`, matching `updateVaultWithinCurrentSite`. `aiToolsVault`'s update branch now also selects `orgId` so it has the axis to bind. No behaviour change for legitimate callers.
- **`emptyHealthSummary()`** reported `coveragePercent: 100` / `status: 'healthy'` to a caller who can see no device. A reader who can see nothing has not observed a healthy fleet, so both are now `null` / `'unknown'`; the SLA dashboard's empty payload follows the same rule for `compliancePercent` / `avgRpoMinutes` / `avgRtoMinutes`. The only web consumers (`BackupVerificationOverview`, `SLADashboard`) already coalesce with `??`, and their types are widened to `number | null`. *(verified — grepped `coveragePercent` / `compliancePercent` / `avgRpoMinutes` across apps/web, apps/portal, apps/mobile; `BackupVerificationOverview` declares `coveragePercent` but never renders it, and `SLADashboard` renders via `?? 0`.)*

### NITs
- `readinessCalculator`'s "failed closed" warning now states what the branch actually does — it skips the synthetic readiness rows rather than adding unverified ones. `rows` is already site-scoped at that point, so no unscoped row escapes.
- New route code reads `auth.allowedSiteIds` first (the auth middleware always populates it) and only falls back to `c.get('permissions')`, which exists solely when `requirePermission` ran. Reading both can only make the check stricter, never looser. Covered by a new test that supplies the ceiling on `auth` only.
- `aiAgentSdkTools` now records that `get_backup_health` / `run_backup_verification` / `get_recovery_readiness` have **no** `executeTool` handler yet (asserted by `helperToolFilter.test.ts` and the registry parity contract) and that a future handler MUST forward `allowedSiteIds` — those services apply the ceiling only when it is supplied, so an omitted argument silently returns org-wide rows.

## Verification

All commands run in the port worktree against a disposable PostgreSQL + Redis stack (`pnpm test-stack up`, `breeze_app` non-superuser application role). Every count below is **verified** — copied from the run output — unless labelled otherwise. All counts are from runs **after** the final rebase onto `2f6986fb75`.

### Red-first (mandatory: proving every ported and review test discriminates)

**RED-A — SEC-021.** Restored main's four verification sources, kept the ported tests:
```
git checkout origin/main -- apps/api/src/routes/backup/verification.ts \
  apps/api/src/routes/backup/verificationService.ts \
  apps/api/src/routes/backup/verificationScheduled.ts \
  apps/api/src/routes/backup/readinessCalculator.ts
npx vitest run --pool=threads --maxWorkers=2 \
  src/routes/backup/verification.siteScope.test.ts \
  src/routes/backup/verificationFailClosed.test.ts
```
→ **2 files failed, 7 failed / 7 total.** Failures include cross-site rows returned to a restricted reader and `coveragePercent: 0` vs `100` on the fail-closed summary.

**RED-B — SEC-024 + SEC-026.** Restored main's `vault.ts`, `aiToolsVault.ts`, `schema/localVault.ts` (both findings edit `vault.ts`, so they revert together):
```
git checkout origin/main -- apps/api/src/routes/backup/vault.ts \
  apps/api/src/services/aiToolsVault.ts apps/api/src/db/schema/localVault.ts
npx vitest run --pool=threads --maxWorkers=2 \
  src/routes/backup/vault.test.ts src/services/aiToolsVault
```
→ **2 files failed, 1 passed; 8 failed / 35 passed (43).** Failures include the empty-ceiling PATCH/DELETE denials, the device lock/CAS path, and sync dispatch returning `200` where the fix returns `502`.

**RED-C — the migration BLOCKER fix.** Restored the delete-based migration body, cleared its `breeze_migrations` ledger row (the file is unmerged, so editing it is permitted) and dropped the constraint, then replayed:
```
git checkout HEAD -- apps/api/migrations/2026-10-15-160110-local-vault-device-org-fk.sql
psql -c "DELETE FROM breeze_migrations WHERE filename = '2026-10-15-160110-...';
         ALTER TABLE local_vaults DROP CONSTRAINT IF EXISTS local_vaults_device_org_fkey;"
npx vitest run --config vitest.integration.config.ts localVaultDeviceOrgFk
```
→ **1 failed / 1 passed (2).** `AssertionError: expected undefined to be '<orgB uuid>'` — the delete-based migration had destroyed the row the restamp test expects to find repaired. The composite-FK test still passed, confirming the new test isolates the *repair* behaviour rather than re-testing the constraint.

**RED-D — SLA dashboard.** Test written before the fix: **2 failed / 8 passed (10)** — the site-narrowing and empty-ceiling cases. The third case ("keeps unrestricted behavior unchanged") passed as the intended control.

**RED-E — `emptyHealthSummary` + the auth-first ceiling.** `git checkout HEAD -- apps/api/src/routes/backup/verification.ts` → **2 failed / 4 passed (6)**: `expected 'healthy' to be 'unknown'`, and the auth-only ceiling case never reached the service.

**RED-F — the tightened write predicates.** Against the pre-fix sources (`git show 923938c912:<file>`):
- `vault.test.ts` → **1 failed / 17 passed (18)**; the predicate contained only `['local_vaults.id', VAULT_ID]`.
- `aiToolsVault` → **2 failed / 26 passed (28)**; both predicates contained only `['id']`.

**GREEN.** All sources restored; every one of the above re-run passes (counts in the gate table below).

### Gates

| Gate | Command | Result |
|---|---|---|
| Unit (API) | `npx vitest run --pool=threads --maxWorkers=2 src/routes/backup src/services/aiToolsVault src/services/vaultSyncPersistence src/services/backup src/services/aiAgentSdkTools src/services/helperToolFilter src/db/autoMigrate.test.ts src/db/migrationRlsScope.test.ts` | **51 files, 767 passed / 2 skipped** |
| Unit (web) | `npx vitest run src/components/backup` in `apps/web` | **19 files, 111 passed** |
| Integration (backup · vault · site-scope · tenancy cascade/export) | `npx vitest run --config vitest.integration.config.ts --pool=threads --maxWorkers=2 backup Backup vault Vault SiteScope siteScope tenantCascade tenant-export-policy tenantExportErasureRoundtrip` | **25 files, 125 passed** |
| The three new integration files, verbose | `… --reporter=verbose backupVerificationSiteScope backupVaultMutationSiteScope localVaultDeviceOrgFk` | **3 files, 7 passed — 7 `✓` lines, 0 skipped** (none is `runIf`/`skipIf`-gated away) |
| Site-scope coverage contract | `npx vitest run --config vitest.config.site-scope-coverage.ts` | **7 passed** |
| Integration-suite coverage contract | `npx vitest run --config vitest.config.integration-suite-coverage.ts` | **5 passed** |
| RLS coverage contract | `npx vitest run --config vitest.config.rls-coverage.ts` | **102 passed** |
| Migration naming | `bash scripts/check-migration-naming.sh` | **OK** |
| Migration replay (idempotency) | asserted inside `localVaultDeviceOrgFk.integration.test.ts` | **second apply is a no-op; warning reports `restamped and deactivated 0 … restamped 0 …`** |
| Typecheck (API) | `NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit` | **exit 0** |
| Typecheck (web) | `npx tsc --noEmit` in `apps/web` | **exit 0** |
| Lint | `npx eslint <all 20 touched files, API + web>` | **exit 0, no findings** |

### Database-level enforcement
`localVaultDeviceOrgFk.integration.test.ts` forges the cross-tenant insert through `withDbAccessContext` on the request pool (connected as `breeze_app`, `NOSUPERUSER`/`NOBYPASSRLS`) and asserts the named rejection `{code: '23503', constraint_name: 'local_vaults_device_org_fkey'}`, plus a positive same-org control, `condeferrable/condeferred = true`, and that a device move still restamps the vault's `org_id`. *(verified — passes on this branch)*

### Registration-list contracts
`local_vaults` was already registered in `CORE_ORG_CASCADE_DELETE_ORDER`, `CORE_DEVICE_CASCADE_DELETE_TABLES`, `CORE_DEVICE_ORG_DENORMALIZED_TABLES` and `CORE_TENANT_EXPORT_POLICY`. This migration adds a **constraint**, not a column, so no `CORE_TENANT_EXPORT_POLICY` entry changes. *(verified — `tenantCascade`, `tenant-export-policy` and `tenantExportErasureRoundtrip` all pass; the FK-ordering assertion uses a topological sort of the live FK graph, and the new edge duplicates the existing `local_vaults.device_id → devices.id` edge, so it introduces no new ordering constraint.)*

### Deadlock analysis (FOR KEY SHARE on the FK parent, #3911)
An FK-column write takes `FOR KEY SHARE` on the parent row. Analysis of the three paths that can interleave — *(inferred from reading the code; **not** proven with a deterministic two-connection race test)*:
- `updateVaultWithinCurrentSite` (SEC-024) locks `devices FOR UPDATE` **first**, then updates `local_vaults`. Lock order is devices → local_vaults.
- The device-move restamp trigger already holds the `devices` row from its own `UPDATE devices` before it touches `local_vaults`. Same order.
- `POST /backup/vault` reads `devices` unlocked, then inserts `local_vaults`, taking `FOR KEY SHARE` on `devices`. Same order, weaker mode.

No path locks `local_vaults` before `devices` in an incompatible mode, so no new deadlock class is introduced. The single-column `device_id` FK already took `FOR KEY SHARE` on the same parent row for any `device_id` write; the composite FK widens that to `org_id` writes (i.e. the restamp). Note also that the SEC-024 UPDATE sets only non-FK columns, so PostgreSQL skips the RI trigger there entirely.

### Not checked
- No browser/E2E, multi-replica, load, or production validation.
- No deterministic two-connection device-move race test (the original local remediation did not claim one either).
- Self-hosted historical mismatch counts are **unknown**. The hosted figure (0 rows in both regions) is relayed from the reviewer's read-only production inventory and was **not** re-run here.
- `activeConfigs` on the SLA dashboard is still org-wide. SLA configs are org-level policy objects with no `device_id`, and `GET /backup/sla/configs` is likewise unscoped on main, so narrowing the count was left out of this change rather than done inconsistently. The effect is that `compliancePercent` can read slightly high for a site-restricted caller (visible breaches over all configs) — strictly less leaky than before, but noted rather than claimed fixed.

## Operator impact

**This migration deletes nothing.** `2026-10-15-160110-local-vault-device-org-fk.sql` restamps any historical `local_vaults` row whose `org_id` disagrees with its device's `org_id` onto the device's org, sets `is_active = false`, and restamps the row's `vault_snapshot_inventory` children to match. No row and no recovery metadata is destroyed.

- **Hosted blast radius is nil.** A read-only inventory of both production regions (run by the reviewer, 2026-09-10) found **`local_vaults` has 0 rows in EU and 0 rows in US**, so no hosted tenant has a row for this migration to touch. *(relayed from the reviewer — not independently re-run here.)* Self-hosted counts are unknown.
- The migration **always** emits `WARNING: SEC-026 cleanup restamped and deactivated % mismatched local vault(s) (ids, first 200: %) and restamped % vault_snapshot_inventory row(s) (ids, first 200: %)`, including when both counts are zero, so the record lands in the PostgreSQL log. Counts are exact and uncapped; the id lists are capped at 200 so a large historical drift cannot flood the log.
- **The affected vaults come back deactivated, on purpose.** An operator must review each one's `vault_path` before re-enabling it: the path was chosen by whoever created the row, and the row is now valid under a different tenant. `SELECT id, org_id, device_id, vault_path FROM local_vaults WHERE is_active = false;` after the deploy, correlated with the warning's id list, identifies them.
- Recommended before rollout: capture the mismatch count (`SELECT count(*) FROM local_vaults v JOIN devices d ON d.id = v.device_id WHERE v.org_id <> d.org_id;`), retain the database and log evidence, and deploy the migration before or with every API replica.
- **Rollback must be roll-forward.** Dropping the composite constraint reopens the finding. If an application rollback is unavoidable, keep the constraint and drain or disable incompatible writers.
- The migration is idempotent and safe to re-run (verified: second application is a no-op with a 0/0 warning).

**Behavioural changes operators may notice:**
- Site-restricted users will now see **fewer** rows on the backup verification, health, recovery-readiness and SLA-dashboard views — this is the fix, not a regression. Unrestricted org, partner and system callers are unaffected apart from `details` minimization.
- A user whose site ceiling is defined but **empty** now gets `status: 'unknown'` / `coveragePercent: null` from `/backup/health` and `null` compliance/RPO/RTO from `/backup/sla/dashboard`, where they previously got `'healthy'` / `100%`. That is a deliberate change from false assurance to "no data"; the shipped web components already coalesce, so they render 0 rather than breaking.
- The `/backup/verifications` response no longer carries the full agent `details` object. Any consumer that read fields other than `simulated` will see `null`. No first-party consumer in this repo does. *(verified by sweeping every caller of `listBackupVerifications`.)*
- Vault sync that the command layer rejects now returns **502 with a recorded failed state** instead of a 200 "pending". This surfaces failures that were previously silent.
- No new required environment variable, and no credential rotation is established for these findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Tugfg88kFiowD7E5xQFpU
