### PR TITLE
fix(agent): remove the unaudited desktop file-drop data channel (SEC-127)

### DIFF
--- a/agent/internal/remote/desktop/session.go
+++ b/agent/internal/remote/desktop/session.go
@@ -12,7 +12,6 @@ import (
 	"github.com/pion/webrtc/v4"
 
 	"github.com/breeze-rmm/agent/internal/remote/clipboard"
-	"github.com/breeze-rmm/agent/internal/remote/filedrop"
 )
 
 const (
@@ -35,25 +34,24 @@ const (
 
 // Session represents a remote desktop WebRTC session with H264 encoding.
 type Session struct {
-	id              string
-	peerConn        *webrtc.PeerConnection
-	videoTrack      *webrtc.TrackLocalStaticSample
-	dataChannel     *webrtc.DataChannel
-	inputHandler    InputHandler
-	capturer        ScreenCapturer
-	encoder         atomic.Pointer[VideoEncoder]
-	encoderPF       PixelFormat // cached encoder input format for CPU Encode() path
-	clipboardSync   *clipboard.ClipboardSync
-	fileDropHandler *filedrop.FileDropHandler
-	cursorDC        *webrtc.DataChannel
-	controlDC       *webrtc.DataChannel
-	audioTrack      *webrtc.TrackLocalStaticSample
-	audioCapturer   AudioCapturer
-	audioEnabled    atomic.Bool
-	done            chan struct{}
-	mu              sync.RWMutex
-	isActive        bool
-	fps             int
+	id            string
+	peerConn      *webrtc.PeerConnection
+	videoTrack    *webrtc.TrackLocalStaticSample
+	dataChannel   *webrtc.DataChannel
+	inputHandler  InputHandler
+	capturer      ScreenCapturer
+	encoder       atomic.Pointer[VideoEncoder]
+	encoderPF     PixelFormat // cached encoder input format for CPU Encode() path
+	clipboardSync *clipboard.ClipboardSync
+	cursorDC      *webrtc.DataChannel
+	controlDC     *webrtc.DataChannel
+	audioTrack    *webrtc.TrackLocalStaticSample
+	audioCapturer AudioCapturer
+	audioEnabled  atomic.Bool
+	done          chan struct{}
+	mu            sync.RWMutex
+	isActive      bool
+	fps           int
 	// stopReason is the short, technician-facing text describing why teardown
 	// happened, set by StopWithReason (#5300). Empty for a plain Stop() call
 	// (operator-initiated stop, lifetime policy, peer disconnect) — callers
@@ -543,9 +541,6 @@ func (s *Session) doCleanup() {
 		}
 		if s.clipboardSync != nil {
 			s.clipboardSync.Stop()
-		}
-		if s.fileDropHandler != nil {
-			s.fileDropHandler.Close()
 		}
 		if s.cursorDC != nil {
 			s.cursorDC.Close()

--- a/agent/internal/remote/desktop/session_filedrop_boundary_test.go
+++ b/agent/internal/remote/desktop/session_filedrop_boundary_test.go
@@ -1,0 +1,102 @@
+package desktop
+
+import (
+	"embed"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// desktopSources embeds every Go source file in this package at compile time.
+//
+// Embedding rather than reading from disk keeps the contract valid when the
+// package's test binary is cross-compiled and executed on a lab machine with
+// no checkout. Embedding is also not build-constraint aware, so the scan
+// covers the Windows-, macOS- and Linux-only files of this package no matter
+// which GOOS the test binary was built for.
+//
+//go:embed *.go
+var desktopSources embed.FS
+
+const filedropImportPath = "github.com/breeze-rmm/agent/internal/remote/filedrop"
+
+// forbiddenFileDropSinks are the concrete registration sites that would put an
+// unaudited file-write path back on the wire.
+var forbiddenFileDropSinks = []string{
+	`CreateDataChannel("filedrop"`,
+	`case "filedrop"`,
+	"filedrop.NewFileDropHandler",
+}
+
+// TestDesktopDoesNotExposeUnauditedFileDropChannel is a source-boundary
+// contract for the peer-to-peer desktop transport. The API server is not in
+// this data path, so registering a filedrop channel here would let a viewer
+// write files onto the endpoint without a server-resolved capability and
+// without a durable central audit record.
+//
+// It is a source contract rather than a behavioural one because the channel
+// registration sink cannot be exercised end to end in CI — StartSession needs
+// a real display capturer. It scans the whole package, not just the WebRTC
+// session file, so the channel cannot be reintroduced from a sibling transport
+// (the WS manager, the control channel) either. A future file-transfer feature
+// must replace this contract with end-to-end capability, audit, quota,
+// ownership and cleanup tests before exposing a channel again.
+func TestDesktopDoesNotExposeUnauditedFileDropChannel(t *testing.T) {
+	names, err := fs.Glob(desktopSources, "*.go")
+	if err != nil {
+		t.Fatalf("glob embedded desktop sources: %v", err)
+	}
+
+	// Positive control: prove the embed actually produced this package's
+	// sources before trusting a scan that finds nothing. A silently empty or
+	// truncated embed would otherwise read as a pass.
+	var scanned, totalBytes int
+	sawSessionWebRTC := false
+
+	for _, name := range names {
+		if strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		raw, readErr := desktopSources.ReadFile(name)
+		if readErr != nil {
+			t.Fatalf("read embedded %s: %v", name, readErr)
+		}
+		src := string(raw)
+		scanned++
+		totalBytes += len(src)
+		if name == "session_webrtc.go" {
+			if !strings.Contains(src, `CreateDataChannel("cursor"`) {
+				t.Fatalf("embedded session_webrtc.go is missing the cursor channel registration (%d bytes) — the scan would be vacuous", len(src))
+			}
+			sawSessionWebRTC = true
+		}
+
+		fset := token.NewFileSet()
+		parsed, parseErr := parser.ParseFile(fset, name, src, parser.ImportsOnly)
+		if parseErr != nil {
+			t.Fatalf("parse imports of %s: %v", name, parseErr)
+		}
+		for _, imp := range parsed.Imports {
+			path, uErr := strconv.Unquote(imp.Path.Value)
+			if uErr == nil && path == filedropImportPath {
+				t.Errorf("%s must not import %s: the desktop transport has no server-authorized, audited file path", name, filedropImportPath)
+			}
+		}
+
+		for _, forbidden := range forbiddenFileDropSinks {
+			if strings.Contains(src, forbidden) {
+				t.Errorf("%s must not expose the unaudited filedrop path %q", name, forbidden)
+			}
+		}
+	}
+
+	if !sawSessionWebRTC {
+		t.Fatalf("embedded sources did not include session_webrtc.go (scanned %d files) — the scan would be vacuous", scanned)
+	}
+	if scanned < 50 || totalBytes < 100_000 {
+		t.Fatalf("embedded sources look truncated: %d files, %d bytes", scanned, totalBytes)
+	}
+}

--- a/agent/internal/remote/desktop/session_webrtc.go
+++ b/agent/internal/remote/desktop/session_webrtc.go
@@ -10,7 +10,6 @@ import (
 	"github.com/pion/webrtc/v4"
 
 	"github.com/breeze-rmm/agent/internal/remote/clipboard"
-	"github.com/breeze-rmm/agent/internal/remote/filedrop"
 )
 
 // SessionPolicy is the server-resolved, agent-enforced policy for a desktop
@@ -420,13 +419,12 @@ func (m *SessionManager) StartSession(sessionID string, offer string, iceServers
 		slog.Info("Clipboard sync disabled by policy", "session", sessionID)
 	}
 
-	// Create filedrop DataChannel
-	filedropDC, err := peerConn.CreateDataChannel("filedrop", nil)
-	if err != nil {
-		slog.Warn("Failed to create filedrop DataChannel", "session", sessionID, "error", err.Error())
-	} else if filedropDC != nil {
-		session.fileDropHandler = filedrop.NewFileDropHandler(filedropDC, "")
-	}
+	// Do not register a filedrop channel. Desktop media and input are peer to
+	// peer, so the API cannot authorize or centrally audit file writes that
+	// arrive over an ad-hoc data channel. The legacy handler also has no
+	// first-party viewer consumer or completed-file owner. A future transfer
+	// feature must start from an explicit server-resolved capability and add
+	// durable audit, quota, acknowledgement and cleanup semantics end to end.
 
 	// Create cursor DataChannel — streams remote cursor position to viewer for
 	// instant cursor rendering independent of video frame rate.


### PR DESCRIPTION
## Summary

**SEC-127 (Medium) — the remote desktop session exposed an unaudited file-write channel on every endpoint.**

`SessionManager.StartSession` unconditionally created a WebRTC data channel labelled `filedrop` and wired it to `filedrop.NewFileDropHandler`, which accepts `start`/`chunk`/`complete` messages and writes the received bytes to a file on the endpoint.

What was wrong:

- **No server-resolved authorization.** Desktop media and input are peer to peer — the API server is not in this data path. Every other endpoint-mutating capability on the session is gated by a server-resolved `SessionPolicy` (clipboard direction, lifetime caps); file writes were gated by nothing. The channel was created before and regardless of any policy check.
- **No durable central audit.** The handler logs `filedrop start` to the local agent log only, with a standing `TODO(#1012): route clipboard/filedrop transfers to central audit_logs`. A file written to a customer machine through a remote session left no record in `audit_logs`, so it was invisible to the partner and unreviewable after the fact.
- **No consumer, no owner.** No first-party client ever used it. The viewer creates only `input` and `control` channels, and its `ondatachannel` handler (`apps/viewer/src/lib/transports/webrtc.ts`) reacts only to `cursor` and `clipboard` — a `filedrop` channel offered by the agent was silently ignored. Nothing owned the completed file: no quota, no acknowledgement, no cleanup.

What the fix enforces:

- The desktop session no longer registers the channel, no longer holds a `fileDropHandler`, and no longer imports `internal/remote/filedrop` — in either `session.go` or `session_webrtc.go`. The agent's inbound `peerConn.OnDataChannel` switch has no `filedrop` case, so a peer that opens a channel by that name now gets a channel with no handler attached: no message is parsed and no file is written.
- A source-boundary contract test (`session_filedrop_boundary_test.go`) scans **every** Go file in the `desktop` package for the `filedrop` import (via `go/parser`, `ImportsOnly`) and for the three concrete registration sinks. Scanning the whole package rather than the two files touched here means the channel cannot be reintroduced from a sibling transport (`ws_manager.go`, `session_control.go`) without turning the test red.

## Ported from

Local security-remediation commit `70bf06dfb854a6ec749ff363da5272448257c35d` ("fix(agent): remove unaudited desktop filedrop channel"), authored ~200 commits behind main.

Resolved against current main:

- **`session.go` struct conflict — kept main's version.** The original commit rewrote the whole `Session` field block; main has since added the `stopReason` field and its doc comment (#5300). Resolution keeps main's block verbatim, minus the `fileDropHandler` field, re-aligned by `gofmt`. Nothing from #5481 (lease) or SEC-121 (#5519) was reverted; neither touches this hunk.
- **`session_webrtc.go` applied cleanly.** The removed block sat directly after the policy-gated clipboard channel, which main has not moved.
- **The boundary test was rewritten, not ported as-is.** The original read `session_webrtc.go` from disk with `os.ReadFile` at run time. That breaks for a cross-compiled test binary executed on a lab machine with no checkout, and it covered only one file. It now embeds the package's sources with `//go:embed *.go`, which also makes the scan build-constraint independent — the Windows-, macOS- and Linux-only files of this package are all scanned no matter which `GOOS` the binary was built for. A positive control asserts the embed produced real content (sentinel string, file count, byte count) before a clean scan is allowed to read as a pass.

Nothing was dropped as already-on-main: the channel registration, the handler field and both imports were all still present on `origin/main` at `2f6986fb75`.

## Verification

All commands run from `agent/` on the rebased branch (base `2f6986fb75`). Claims labelled **verified** were run and observed; **inferred** was reasoned, not executed.

**Red-first (verified).** `origin/main`'s sources restored under the new test:

```
git checkout origin/main -- agent/internal/remote/desktop/session.go \
                            agent/internal/remote/desktop/session_webrtc.go
go test -count=1 -run TestDesktopDoesNotExposeUnauditedFileDropChannel -v ./internal/remote/desktop/
```

→ **FAIL**, 4 distinct violations:

```
session.go must not import github.com/breeze-rmm/agent/internal/remote/filedrop
session_webrtc.go must not import github.com/breeze-rmm/agent/internal/remote/filedrop
session_webrtc.go must not expose the unaudited filedrop path "CreateDataChannel(\"filedrop\""
session_webrtc.go must not expose the unaudited filedrop path "filedrop.NewFileDropHandler"
--- FAIL: TestDesktopDoesNotExposeUnauditedFileDropChannel (0.00s)
```

Then `git checkout HEAD -- <same two files>` → **PASS**. The test is not vacuous.

**Suite (verified).**

| Command | Result |
|---|---|
| `go build ./...` | 0 errors |
| `go vet ./...` | 0 findings |
| `go test -race -count=1 ./internal/remote/...` | 5/5 packages ok (`clipboard`, `desktop`, `desktop/x11`, `filedrop`, `tools`) |
| `CGO_ENABLED=0 go test -count=1 ./...` | 78 packages ok; 2 pre-existing failures in `internal/monitoring` (`TestMonitorRunsImmediateCheckOnStart`, `TestApplyConfigRestopsAndRestarts`) — that package is byte-identical to `origin/main` in this diff, so they are unrelated to this change (**verified** by `git diff origin/main --stat`: 3 files, all under `internal/remote/desktop`) |
| `golangci-lint run --new-from-rev=origin/main ./...` (`CGO_ENABLED=0`, exactly as the **Lint Agent (Go)** job runs it) | `0 issues.` |
| `GOOS=windows golangci-lint run --new-from-rev=origin/main ./...` | `0 issues.` |
| `GOOS=darwin golangci-lint run --new-from-rev=origin/main ./...` | `0 issues.` |
| `GOOS={windows,darwin,linux} go build ./...` | 0 errors each |

Local `golangci-lint` is 2.13.2; CI pins 2.12.2 (**inferred** that the two agree on this diff — the diff introduces no new lint surface beyond one test file, and all three GOOS runs report zero new issues).

**Cross-platform runtime (verified to build; runtime result pending).** `GOOS=windows GOARCH=amd64 go test -c` binaries for the fix and for `origin/main` were produced and confirmed to differ (the control embeds main's `Failed to create filedrop DataChannel` string; the fix binary does not). They are being executed natively on a Windows lab machine; the contract is platform-independent source scanning, so the expected result is PASS on the fix binary and FAIL on the control.

**Repo-wide sweep (verified).** `grep -rn -i 'filedrop|file_drop|file-drop'` over `agent/ apps/ packages/ ee/ e2e-tests/ docs/`: after this change the only remaining references are the now-unreferenced `agent/internal/remote/filedrop` package and its own tests, three `TODO(#1012)` audit comments in `clipboard/sync.go`, and historical security-report docs. **No viewer, web, helper, mobile or API code expects the channel** — `apps/web`'s `pkg-file-dropped-notice` is the software-package upload UI and is unrelated. Nothing needed removing or gating outside the agent.

## Compatibility

**No client behaviour changes.** The agent was the offerer for this channel; no shipped client opened it.

- **Every shipped viewer (web, Tauri helper, mobile):** unaffected. They create `input` and `control` themselves and handle only `cursor` and `clipboard` from `ondatachannel`. A `filedrop` channel arriving from the agent was already ignored, so its absence is invisible — no error, no reconnect, no degraded session. No version floor, no agent/viewer ordering constraint.
- **A third-party or future peer that opens `filedrop` itself:** the SCTP channel still opens (Pion accepts inbound channels), but the agent's `OnDataChannel` switch has no `filedrop` case, so no `OnMessage` handler is attached, no protocol frame is parsed, and no file is created. It fails closed and silently rather than erroring the session.
- **SDP:** one fewer pre-negotiated data channel in the agent's answer. The channel was created before ICE gathering, so this is an m-line/stream-id difference only; no renegotiation semantics change.

## Operator impact

- **Techs:** none in practice — there was no UI for this anywhere in the product, so no workflow loses a button. Any tool that reached the channel out-of-band loses it.
- **File transfer as a feature is unchanged elsewhere:** script/file deployment continues to go through the API-authorized, audited paths.
- **Remaining item for a follow-up (not in this PR):** `agent/internal/remote/filedrop` is now unreferenced by production code but still compiled into the agent binary. It is left in place deliberately — deleting it is outside the ported fix, and the package retains prior hardening (private receive directory, path-traversal rejection, size and concurrency caps) that a properly authorized transfer feature would build on. The boundary test is what prevents it being re-wired into the desktop transport in the meantime. A future file-transfer feature must begin from a server-resolved capability in `SessionPolicy` and add durable `audit_logs` records, quota, acknowledgement and cleanup end to end — and must replace this source contract with those end-to-end tests rather than deleting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Tugfg88kFiowD7E5xQFpU
