### PR TITLE
fix(integrations): stabilize webhook credential identity and stop echoing the secret to the web form (SEC-065)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -453,11 +453,14 @@ CLIENT_AI_ENTRA_CLIENT_ID=
 # Use: openssl rand -hex 32
 APP_ENCRYPTION_KEY=generate-a-random-hex-string-for-production
 # Key id enabling AAD-bound v3 ciphertext (vs v1 with no AAD binding).
-# REQUIRED IN PRODUCTION (boot refuses to start without it): integration provider
-# credentials (/integrations/{communication,monitoring,ticketing,psa}) are sealed
-# with v3 ciphertext bound to the provider, organization and field path, and fail
-# closed on v1 — without a key id every credential save returns 503.
-# Also required, in any environment, once M365_GRAPH_ACTIONS_TOOLS_ENABLED=true —
+# Required for integration credential sealing; boot WARNS when unset (it does not
+# refuse). Integration provider credentials
+# (/integrations/{communication,monitoring,ticketing,psa}) are sealed with v3
+# ciphertext bound to the provider, organization and field path and fail closed
+# on v1, so saving one returns 503 until this is set. Everything else keeps
+# working, so an existing install without it stays up.
+# Required outright (boot refuses), in any environment, once
+# M365_GRAPH_ACTIONS_TOOLS_ENABLED=true —
 # the m365_reset_password reveal-secret path seals its temp credential with v3
 # ciphertext and fails closed on v1 — and when BREEZE_ROLE is "api" or "worker".
 # Any [A-Za-z0-9._-]+ identifier; changing it does not itself rotate

--- a/.env.example
+++ b/.env.example
@@ -452,11 +452,16 @@ CLIENT_AI_ENTRA_CLIENT_ID=
 # CRITICAL: Generate unique keys for production
 # Use: openssl rand -hex 32
 APP_ENCRYPTION_KEY=generate-a-random-hex-string-for-production
-# Optional key id enabling AAD-bound v3 ciphertext (vs v1 with no AAD binding).
-# Required (boot refuses to start without it) once M365_GRAPH_ACTIONS_TOOLS_ENABLED=true —
+# Key id enabling AAD-bound v3 ciphertext (vs v1 with no AAD binding).
+# REQUIRED IN PRODUCTION (boot refuses to start without it): integration provider
+# credentials (/integrations/{communication,monitoring,ticketing,psa}) are sealed
+# with v3 ciphertext bound to the provider, organization and field path, and fail
+# closed on v1 — without a key id every credential save returns 503.
+# Also required, in any environment, once M365_GRAPH_ACTIONS_TOOLS_ENABLED=true —
 # the m365_reset_password reveal-secret path seals its temp credential with v3
-# ciphertext and fails closed on v1. Any [A-Za-z0-9._-]+ identifier; changing
-# it does not itself rotate APP_ENCRYPTION_KEY.
+# ciphertext and fails closed on v1 — and when BREEZE_ROLE is "api" or "worker".
+# Any [A-Za-z0-9._-]+ identifier; changing it does not itself rotate
+# APP_ENCRYPTION_KEY.
 APP_ENCRYPTION_KEY_ID=
 MFA_ENCRYPTION_KEY=generate-a-random-hex-string-for-production
 # Production startup rejects placeholder or short values when this is set.

--- a/apps/api/src/config/validate.test.ts
+++ b/apps/api/src/config/validate.test.ts
@@ -287,29 +287,62 @@ describe('validateConfig', () => {
       });
     });
 
-    it('requires APP_ENCRYPTION_KEY_ID in production for integration credential sealing', () => {
+    it('warns (but does not refuse boot) when APP_ENCRYPTION_KEY_ID is unset in production', () => {
       // No feature flag gates /integrations/{communication,monitoring,ticketing,psa}
-      // — they are mounted unconditionally under the default BREEZE_ROLE 'all',
-      // so in production the key id is required outright. Without it,
-      // encryptSecret drops the AAD and writes non-AAD enc:v1, and
-      // sealIntegrationSettings refuses the write with a runtime 503.
+      // — they are mounted unconditionally under the default BREEZE_ROLE 'all' —
+      // but this is deliberately a WARNING, not a hard error: guided-setup.sh
+      // has never generated APP_ENCRYPTION_KEY_ID, so refusing boot would brick
+      // every existing self-hosted upgrade and every fresh guided install. The
+      // failure lands at the point of use instead (503 from the seal site).
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       withEnv({
         ...validEnv,
         NODE_ENV: 'production',
+        CORS_ALLOWED_ORIGINS: 'https://app.breeze.io',
+        TRUST_PROXY_HEADERS: 'false',
         APP_ENCRYPTION_KEY_ID: '',
       }, () => {
-        expect(() => validateConfig()).toThrow(/APP_ENCRYPTION_KEY_ID/);
+        expect(() => validateConfig()).not.toThrow();
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('APP_ENCRYPTION_KEY_ID'),
+        );
+        const sealWarnings = warnSpy.mock.calls
+          .flat()
+          .filter((m) => typeof m === 'string' && m.includes('APP_ENCRYPTION_KEY_ID'));
+        expect(sealWarnings.join('\n')).toContain('503');
       });
+      warnSpy.mockRestore();
     });
 
-    it('does not require APP_ENCRYPTION_KEY_ID outside production', () => {
+    it('does not warn about APP_ENCRYPTION_KEY_ID outside production, or when it is set', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       withEnv({
         ...validEnv,
         NODE_ENV: 'development',
         APP_ENCRYPTION_KEY_ID: '',
       }, () => {
-        expect(() => validateConfig()).not.toThrow(/APP_ENCRYPTION_KEY_ID/);
+        expect(() => validateConfig()).not.toThrow();
+        expect(
+          warnSpy.mock.calls
+            .flat()
+            .filter((m) => typeof m === 'string' && m.includes('APP_ENCRYPTION_KEY_ID')),
+        ).toHaveLength(0);
       });
+      warnSpy.mockClear();
+      withEnv({
+        ...validEnv,
+        NODE_ENV: 'production',
+        CORS_ALLOWED_ORIGINS: 'https://app.breeze.io',
+        TRUST_PROXY_HEADERS: 'false',
+      }, () => {
+        validateConfig();
+        expect(
+          warnSpy.mock.calls
+            .flat()
+            .filter((m) => typeof m === 'string' && m.includes('APP_ENCRYPTION_KEY_ID')),
+        ).toHaveLength(0);
+      });
+      warnSpy.mockRestore();
     });
 
     it('requires APP_ENCRYPTION_KEY_ID when write-action tools are enabled', () => {

--- a/apps/api/src/config/validate.test.ts
+++ b/apps/api/src/config/validate.test.ts
@@ -49,6 +49,11 @@ const validEnv = {
   // never guesses its compatibility posture. Tests that assert the
   // missing/invalid throw override this.
   EVENT_PERMISSION_EPOCH_MODE: 'compat',
+  // Production-required (SEC-065): integration provider credentials are sealed
+  // with AAD-bound enc:v3 ciphertext and fail closed without an active key id.
+  // Supplied here so the suite's production happy-path tests don't trip it; the
+  // test that asserts the throw overrides it explicitly.
+  APP_ENCRYPTION_KEY_ID: 'app-test-key-1',
 };
 
 describe('validateConfig', () => {
@@ -279,6 +284,31 @@ describe('validateConfig', () => {
         M365_CUSTOMER_GRAPH_ACTIONS_CLIENT_ID: '',
       }, () => {
         expect(() => validateConfig()).toThrow(/M365_CUSTOMER_GRAPH_ACTIONS_CLIENT_ID/);
+      });
+    });
+
+    it('requires APP_ENCRYPTION_KEY_ID in production for integration credential sealing', () => {
+      // No feature flag gates /integrations/{communication,monitoring,ticketing,psa}
+      // — they are mounted unconditionally under the default BREEZE_ROLE 'all',
+      // so in production the key id is required outright. Without it,
+      // encryptSecret drops the AAD and writes non-AAD enc:v1, and
+      // sealIntegrationSettings refuses the write with a runtime 503.
+      withEnv({
+        ...validEnv,
+        NODE_ENV: 'production',
+        APP_ENCRYPTION_KEY_ID: '',
+      }, () => {
+        expect(() => validateConfig()).toThrow(/APP_ENCRYPTION_KEY_ID/);
+      });
+    });
+
+    it('does not require APP_ENCRYPTION_KEY_ID outside production', () => {
+      withEnv({
+        ...validEnv,
+        NODE_ENV: 'development',
+        APP_ENCRYPTION_KEY_ID: '',
+      }, () => {
+        expect(() => validateConfig()).not.toThrow(/APP_ENCRYPTION_KEY_ID/);
       });
     });
 

--- a/apps/api/src/config/validate.ts
+++ b/apps/api/src/config/validate.ts
@@ -1890,36 +1890,6 @@ const envSchema = envObjectSchema
       });
     }
 
-    // Integration compatibility settings ↔ APP_ENCRYPTION_KEY_ID (SEC-065).
-    //
-    // /integrations/{communication,monitoring,ticketing,psa} seal every
-    // credential-shaped provider field with AAD-bound v3 ciphertext and REFUSE
-    // to seal without a key id: encryptSecret silently drops the `aad` option
-    // and writes non-AAD enc:v1 when none is configured, which would leave the
-    // family/organization/path binding absent with nothing to signal it.
-    //
-    // Unlike the two rules above, there is no feature flag to hang this off —
-    // integrationRoutes is mounted unconditionally in index.ts, and the default
-    // BREEZE_ROLE 'all' (single-container prod and every self-host) serves it.
-    // So the condition is simply "production". Development and test keep
-    // booting without a key id; they just get the runtime 503 from
-    // sealIntegrationSettings if they actually try to store a credential.
-    //
-    // Operator note: this is a NEW required production variable in the same
-    // class as IS_HOSTED and RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS. It must be
-    // present in .env AND mapped in the api service's `environment:` block —
-    // compose only interpolates variables it lists (the #570 gap class).
-    if (isProduction && !data.APP_ENCRYPTION_KEY_ID?.trim()) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['APP_ENCRYPTION_KEY_ID'],
-        message:
-          'APP_ENCRYPTION_KEY_ID is required in production. Integration provider credentials '
-          + '(/integrations/{communication,monitoring,ticketing,psa}) are sealed with AAD-bound enc:v3 '
-          + 'ciphertext and fail closed without a key id; without it every credential save returns 503. '
-          + 'Set it alongside APP_ENCRYPTION_KEY and map it through the api service environment block.',
-      });
-    }
 
     // --- Native APNs push (all-or-none) ---
     // Push is optional, so an empty APNS_* set is fine. But a partial set
@@ -2068,6 +2038,40 @@ function collectWarnings(env: Record<string, string | undefined>): ConfigWarning
     // (AGENT_ENROLLMENT_SECRET is now a hard error in production — see the
     // schema superRefine. No warning needed here; the validator throws if
     // it's missing or weak.)
+
+    // Integration compatibility settings ↔ APP_ENCRYPTION_KEY_ID (SEC-065).
+    //
+    // /integrations/{communication,monitoring,ticketing,psa} seal every
+    // credential-shaped provider field with AAD-bound enc:v3 ciphertext and
+    // REFUSE to seal without a key id: encryptSecret silently drops the `aad`
+    // option and writes non-AAD enc:v1 when none is configured, which would
+    // leave the family/organization/path binding absent with nothing to signal
+    // it. sealIntegrationSettings therefore throws and the routes return 503.
+    //
+    // This is a WARNING, not a boot refusal, for the same reason as the
+    // TRUST_CF_CONNECTING_IP rule above: hard-failing would break every
+    // existing self-hosted upgrade and every fresh guided install.
+    // scripts/guided-setup.sh generates APP_ENCRYPTION_KEY but has never
+    // generated APP_ENCRYPTION_KEY_ID, so a refusal here would brick installs
+    // that are otherwise healthy — the integration compatibility routes are a
+    // small, optional surface and are not worth taking the whole API down for.
+    // The hosted droplets set the key id; self-hosts generally do not.
+    //
+    // The failure is therefore deferred and loud at the point of use rather
+    // than at boot. Note this is a warning only about the INTEGRATION seal —
+    // BREEZE_ROLE api|worker and M365_GRAPH_ACTIONS_TOOLS_ENABLED=true still
+    // refuse boot without the key id (see the schema superRefine).
+    if (!(env.APP_ENCRYPTION_KEY_ID ?? '').trim()) {
+      warnings.push({
+        key: 'APP_ENCRYPTION_KEY_ID',
+        message:
+          'APP_ENCRYPTION_KEY_ID is not set. It is required for integration credential sealing: '
+          + 'saving provider credentials on /integrations/{communication,monitoring,ticketing,psa} '
+          + 'will return 503 until it is set, because those credentials are sealed with AAD-bound '
+          + 'enc:v3 ciphertext and fail closed rather than degrade to unbound enc:v1. Set it '
+          + 'alongside APP_ENCRYPTION_KEY and map it through the api service environment block.',
+      });
+    }
 
     // SR2-16: a prod deploy that trusts proxy headers but leaves
     // TRUST_CF_CONNECTING_IP off resolves client IPs from X-Forwarded-For only.

--- a/apps/api/src/config/validate.ts
+++ b/apps/api/src/config/validate.ts
@@ -1890,6 +1890,37 @@ const envSchema = envObjectSchema
       });
     }
 
+    // Integration compatibility settings ↔ APP_ENCRYPTION_KEY_ID (SEC-065).
+    //
+    // /integrations/{communication,monitoring,ticketing,psa} seal every
+    // credential-shaped provider field with AAD-bound v3 ciphertext and REFUSE
+    // to seal without a key id: encryptSecret silently drops the `aad` option
+    // and writes non-AAD enc:v1 when none is configured, which would leave the
+    // family/organization/path binding absent with nothing to signal it.
+    //
+    // Unlike the two rules above, there is no feature flag to hang this off —
+    // integrationRoutes is mounted unconditionally in index.ts, and the default
+    // BREEZE_ROLE 'all' (single-container prod and every self-host) serves it.
+    // So the condition is simply "production". Development and test keep
+    // booting without a key id; they just get the runtime 503 from
+    // sealIntegrationSettings if they actually try to store a credential.
+    //
+    // Operator note: this is a NEW required production variable in the same
+    // class as IS_HOSTED and RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS. It must be
+    // present in .env AND mapped in the api service's `environment:` block —
+    // compose only interpolates variables it lists (the #570 gap class).
+    if (isProduction && !data.APP_ENCRYPTION_KEY_ID?.trim()) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['APP_ENCRYPTION_KEY_ID'],
+        message:
+          'APP_ENCRYPTION_KEY_ID is required in production. Integration provider credentials '
+          + '(/integrations/{communication,monitoring,ticketing,psa}) are sealed with AAD-bound enc:v3 '
+          + 'ciphertext and fail closed without a key id; without it every credential save returns 503. '
+          + 'Set it alongside APP_ENCRYPTION_KEY and map it through the api service environment block.',
+      });
+    }
+
     // --- Native APNs push (all-or-none) ---
     // Push is optional, so an empty APNS_* set is fine. But a partial set
     // (e.g. team + bundle without the signing key) would silently fail to

--- a/apps/api/src/routes/integrations.test.ts
+++ b/apps/api/src/routes/integrations.test.ts
@@ -56,6 +56,39 @@ describe('integration compatibility routes', () => {
     expect(payload.data.slack.enabled).toBe(true);
   });
 
+  it('never echoes Discord or Teams credentials from compatibility storage', async () => {
+    const discordSecret = 'https://discord.example.test/api/webhooks/id/private-token';
+    const discordSave = await app.request('/integrations/discord', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+      body: JSON.stringify({ enabled: true, webhookUrl: discordSecret })
+    });
+    expect(discordSave.status).toBe(200);
+    const discordPayload = await discordSave.json();
+    expect(JSON.stringify(discordPayload)).not.toContain(discordSecret);
+    expect(discordPayload.data.discord.webhookUrl).toBe('********');
+
+    const teamsSecret = 'teams-client-secret-value';
+    const teamsSave = await app.request('/integrations/teams', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+      body: JSON.stringify({ enabled: true, clientId: 'public-client-id', clientSecret: teamsSecret })
+    });
+    expect(teamsSave.status).toBe(200);
+
+    const loaded = await app.request('/integrations/communication', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer token' }
+    });
+    const loadedText = await loaded.text();
+    expect(loadedText).not.toContain(discordSecret);
+    expect(loadedText).not.toContain(teamsSecret);
+    const loadedPayload = JSON.parse(loadedText);
+    expect(loadedPayload.data.discord.webhookUrl).toBe('********');
+    expect(loadedPayload.data.teams.clientSecret).toBe('********');
+    expect(loadedPayload.data.teams.clientId).toBe('public-client-id');
+  });
+
   it('supports monitoring settings read/write and test', async () => {
     const save = await app.request('/integrations/monitoring', {
       method: 'PUT',
@@ -78,6 +111,75 @@ describe('integration compatibility routes', () => {
       body: JSON.stringify({ provider: 'grafana' })
     });
     expect(test.status).toBe(200);
+  });
+
+  it('never echoes monitoring provider credentials and preserves non-secret settings', async () => {
+    const secrets = {
+      grafana: 'grafana-private-api-key',
+      pagerDuty: 'pagerduty-private-integration-key',
+      opsGenie: 'opsgenie-private-api-key',
+      webhook: 'https://hooks.example.test/services/private-token'
+    };
+    const save = await app.request('/integrations/monitoring', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+      body: JSON.stringify({
+        grafana: { enabled: true, url: 'https://grafana.example.test', apiKey: secrets.grafana },
+        pagerDuty: { enabled: true, integrationKey: secrets.pagerDuty },
+        opsGenie: { enabled: true, apiKey: secrets.opsGenie, team: 'platform' },
+        webhooks: { endpoints: [{ id: 'one', name: 'relay', url: secrets.webhook, enabled: true }] }
+      })
+    });
+    expect(save.status).toBe(200);
+    const saveText = await save.text();
+    for (const secret of Object.values(secrets)) expect(saveText).not.toContain(secret);
+
+    const get = await app.request('/integrations/monitoring', {
+      headers: { Authorization: 'Bearer token' }
+    });
+    const getText = await get.text();
+    for (const secret of Object.values(secrets)) expect(getText).not.toContain(secret);
+    const payload = JSON.parse(getText).data;
+    expect(payload.grafana).toEqual({ enabled: true, url: 'https://grafana.example.test', apiKey: '********' });
+    expect(payload.pagerDuty.integrationKey).toBe('********');
+    expect(payload.opsGenie).toEqual({ enabled: true, apiKey: '********', team: 'platform' });
+    expect(payload.webhooks.endpoints[0]).toEqual({ id: 'one', name: 'relay', url: '********', enabled: true });
+  });
+
+  it('assigns an id before an id-less webhook is returned and accepts its masked resave', async () => {
+    const first = await app.request('/integrations/monitoring', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+      body: JSON.stringify({
+        webhooks: { endpoints: [{ name: 'legacy', url: 'https://hooks.example.test/legacy' }] }
+      })
+    });
+    expect(first.status).toBe(200);
+    const firstEndpoint = (await first.json()).data.webhooks.endpoints[0];
+    expect(firstEndpoint).toMatchObject({ name: 'legacy', url: '********' });
+    expect(firstEndpoint.id).toEqual(expect.any(String));
+
+    const second = await app.request('/integrations/monitoring', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+      body: JSON.stringify({ webhooks: { endpoints: [firstEndpoint] } })
+    });
+    expect(second.status).toBe(200);
+    expect((await second.json()).data.webhooks.endpoints[0]).toEqual(firstEndpoint);
+  });
+
+  it('masks credential-shaped siblings in ticketing compatibility blobs', async () => {
+    const ticketPassword = 'ticketing-private-password';
+    const ticket = await app.request('/integrations/ticketing', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+      body: JSON.stringify({ provider: 'zendesk', credentials: { username: 'agent@example.test', password: ticketPassword } })
+    });
+    expect(ticket.status).toBe(200);
+    const ticketText = await ticket.text();
+    expect(ticketText).not.toContain(ticketPassword);
+    expect(JSON.parse(ticketText).data.credentials.password).toBe('********');
+
   });
 
   it('supports ticketing read/write and test', async () => {
@@ -131,6 +233,7 @@ describe('integration compatibility routes', () => {
   });
 
   it('supports psa read/write/test compatibility', async () => {
+    const psaSecret = 'psa-private-api-secret';
     const initial = await app.request('/integrations/psa', {
       method: 'GET',
       headers: { Authorization: 'Bearer token' }
@@ -140,9 +243,17 @@ describe('integration compatibility routes', () => {
     const save = await app.request('/integrations/psa', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
-      body: JSON.stringify({ provider: 'connectwise', settings: { baseUrl: 'https://example.com' } })
+      body: JSON.stringify({
+        provider: 'connectwise',
+        apiKey: 'public-id',
+        apiSecret: psaSecret,
+        settings: { baseUrl: 'https://example.com' }
+      })
     });
     expect(save.status).toBe(200);
+    const saveText = await save.text();
+    expect(saveText).not.toContain(psaSecret);
+    expect(JSON.parse(saveText).data.apiSecret).toBe('********');
 
     const get = await app.request('/integrations/psa', {
       method: 'GET',

--- a/apps/api/src/routes/integrations.test.ts
+++ b/apps/api/src/routes/integrations.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
 
 vi.mock('../middleware/auth', () => ({
@@ -23,6 +23,26 @@ vi.mock('../services/auditEvents', () => ({
 }));
 
 import { integrationRoutes } from './integrations';
+
+// These routes seal provider credentials with AAD-bound enc:v3 ciphertext and
+// fail closed (503) when no active key id is configured — which is what the
+// shared test setup leaves behind. Production is required to set this (see the
+// APP_ENCRYPTION_KEY_ID rule in config/validate.ts); mirror that here so the
+// suite exercises the configured path, and restore the ambient env afterwards.
+const priorEncryptionKey = process.env.APP_ENCRYPTION_KEY;
+const priorEncryptionKeyId = process.env.APP_ENCRYPTION_KEY_ID;
+
+beforeAll(() => {
+  process.env.APP_ENCRYPTION_KEY = 'integration-routes-test-key-material';
+  process.env.APP_ENCRYPTION_KEY_ID = 'integration-routes-test';
+});
+
+afterAll(() => {
+  if (priorEncryptionKey === undefined) delete process.env.APP_ENCRYPTION_KEY;
+  else process.env.APP_ENCRYPTION_KEY = priorEncryptionKey;
+  if (priorEncryptionKeyId === undefined) delete process.env.APP_ENCRYPTION_KEY_ID;
+  else process.env.APP_ENCRYPTION_KEY_ID = priorEncryptionKeyId;
+});
 
 describe('integration compatibility routes', () => {
   let app: Hono;
@@ -267,5 +287,35 @@ describe('integration compatibility routes', () => {
       body: JSON.stringify({ provider: 'connectwise' })
     });
     expect(test.status).toBe(200);
+  });
+
+  it('refuses the write with 503 when no active encryption key id is configured', async () => {
+    const restore = process.env.APP_ENCRYPTION_KEY_ID;
+    delete process.env.APP_ENCRYPTION_KEY_ID;
+    try {
+      const save = await app.request('/integrations/ticketing', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ provider: 'example', apiKey: 'unsealable-api-key' })
+      });
+
+      expect(save.status).toBe(503);
+      const body = await save.json();
+      expect(body.error).toContain('APP_ENCRYPTION_KEY_ID');
+    } finally {
+      if (restore === undefined) delete process.env.APP_ENCRYPTION_KEY_ID;
+      else process.env.APP_ENCRYPTION_KEY_ID = restore;
+    }
+
+    // Nothing was stored. The compatibility maps are module-level and outlive
+    // each test's app, so assert on the credential itself rather than on the
+    // store being empty: the refused write must not have left a plaintext or
+    // v1-sealed value behind for a reader to pick up.
+    const read = await app.request('/integrations/ticketing', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer token' }
+    });
+    expect(read.status).toBe(200);
+    expect(await read.text()).not.toContain('unsealable-api-key');
   });
 });

--- a/apps/api/src/routes/integrations.ts
+++ b/apps/api/src/routes/integrations.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
 import { writeRouteAudit } from '../services/auditEvents';
 import {
+  IntegrationSecretsUnavailableError,
   InvalidIntegrationSecretError,
   maskIntegrationSettings,
   sealIntegrationSettings,
@@ -112,12 +113,19 @@ function protectSettings(
   existing: Record<string, unknown> | undefined,
   family: string,
   orgId: string,
-): { ok: true; value: Record<string, unknown> } | { ok: false; error: string } {
+): { ok: true; value: Record<string, unknown> } | { ok: false; error: string; status: 400 | 503 } {
   try {
     return { ok: true, value: sealIntegrationSettings(body, existing, family, orgId) };
   } catch (error) {
+    // Operator misconfiguration, not a bad request: the caller cannot fix it by
+    // changing the payload, so 503 rather than 400. These routes already
+    // require organizations:write + MFA, so the operator-actionable message is
+    // not being handed to an anonymous or read-only caller.
+    if (error instanceof IntegrationSecretsUnavailableError) {
+      return { ok: false, error: error.message, status: 503 };
+    }
     if (error instanceof InvalidIntegrationSecretError) {
-      return { ok: false, error: error.message };
+      return { ok: false, error: error.message, status: 400 };
     }
     throw error;
   }
@@ -162,7 +170,7 @@ for (const provider of ['slack', 'teams', 'discord'] as const) {
       `communication.${provider}`,
       orgResult.orgId,
     );
-    if (!protectedBody.ok) return c.json({ error: protectedBody.error }, 400);
+    if (!protectedBody.ok) return c.json({ error: protectedBody.error }, protectedBody.status);
     const updated = { ...existing, [provider]: protectedBody.value };
     communicationSettings.set(orgResult.orgId, updated);
 
@@ -208,7 +216,7 @@ integrationRoutes.put('/monitoring', requireScope('organization', 'partner', 'sy
     'monitoring',
     orgResult.orgId,
   );
-  if (!protectedBody.ok) return c.json({ error: protectedBody.error }, 400);
+  if (!protectedBody.ok) return c.json({ error: protectedBody.error }, protectedBody.status);
   monitoringSettings.set(orgResult.orgId, protectedBody.value);
   return c.json({ success: true, data: maskIntegrationSettings(protectedBody.value) });
 });
@@ -239,7 +247,7 @@ integrationRoutes.post('/ticketing', requireScope('organization', 'partner', 'sy
   }
 
   const protectedBody = protectSettings(body, ticketingSettings.get(orgResult.orgId), 'ticketing', orgResult.orgId);
-  if (!protectedBody.ok) return c.json({ error: protectedBody.error }, 400);
+  if (!protectedBody.ok) return c.json({ error: protectedBody.error }, protectedBody.status);
   ticketingSettings.set(orgResult.orgId, protectedBody.value);
   return c.json({
     success: true,
@@ -279,7 +287,7 @@ integrationRoutes.post('/psa', requireScope('organization', 'partner', 'system')
   }
 
   const protectedBody = protectSettings(body, psaSettings.get(orgResult.orgId), 'psa', orgResult.orgId);
-  if (!protectedBody.ok) return c.json({ error: protectedBody.error }, 400);
+  if (!protectedBody.ok) return c.json({ error: protectedBody.error }, protectedBody.status);
   psaSettings.set(orgResult.orgId, protectedBody.value);
   return c.json({ success: true, data: maskIntegrationSettings(protectedBody.value) });
 });
@@ -296,7 +304,7 @@ integrationRoutes.put('/psa', requireScope('organization', 'partner', 'system'),
   }
 
   const protectedBody = protectSettings(body, psaSettings.get(orgResult.orgId), 'psa', orgResult.orgId);
-  if (!protectedBody.ok) return c.json({ error: protectedBody.error }, 400);
+  if (!protectedBody.ok) return c.json({ error: protectedBody.error }, protectedBody.status);
   psaSettings.set(orgResult.orgId, protectedBody.value);
   return c.json({ success: true, data: maskIntegrationSettings(protectedBody.value) });
 });

--- a/apps/api/src/routes/integrations.ts
+++ b/apps/api/src/routes/integrations.ts
@@ -2,6 +2,11 @@ import { Hono } from 'hono';
 import { z } from 'zod';
 import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
 import { writeRouteAudit } from '../services/auditEvents';
+import {
+  InvalidIntegrationSecretError,
+  maskIntegrationSettings,
+  sealIntegrationSettings,
+} from '../services/integrationSettingsSecrets';
 import { PERMISSIONS } from '../services/permissions';
 
 export const integrationRoutes = new Hono();
@@ -102,6 +107,22 @@ function requestedOrgId(c: { req: { query: (key: string) => string | undefined }
   return c.req.query('orgId');
 }
 
+function protectSettings(
+  body: Record<string, unknown>,
+  existing: Record<string, unknown> | undefined,
+  family: string,
+  orgId: string,
+): { ok: true; value: Record<string, unknown> } | { ok: false; error: string } {
+  try {
+    return { ok: true, value: sealIntegrationSettings(body, existing, family, orgId) };
+  } catch (error) {
+    if (error instanceof InvalidIntegrationSecretError) {
+      return { ok: false, error: error.message };
+    }
+    throw error;
+  }
+}
+
 integrationRoutes.use('*', authMiddleware);
 
 integrationRoutes.get('/communication', requireScope('organization', 'partner', 'system'), requireIntegrationRead, async (c) => {
@@ -116,7 +137,7 @@ integrationRoutes.get('/communication', requireScope('organization', 'partner', 
     return c.json({ error: 'Communication settings not found' }, 404);
   }
 
-  return c.json({ data: existing });
+  return c.json({ data: maskIntegrationSettings(existing) });
 });
 
 for (const provider of ['slack', 'teams', 'discord'] as const) {
@@ -132,7 +153,17 @@ for (const provider of ['slack', 'teams', 'discord'] as const) {
     }
 
     const existing = communicationSettings.get(orgResult.orgId) ?? {};
-    const updated = { ...existing, [provider]: body };
+    const currentProvider = existing[provider];
+    const protectedBody = protectSettings(
+      body,
+      currentProvider && typeof currentProvider === 'object' && !Array.isArray(currentProvider)
+        ? currentProvider as Record<string, unknown>
+        : undefined,
+      `communication.${provider}`,
+      orgResult.orgId,
+    );
+    if (!protectedBody.ok) return c.json({ error: protectedBody.error }, 400);
+    const updated = { ...existing, [provider]: protectedBody.value };
     communicationSettings.set(orgResult.orgId, updated);
 
     if (body.test === true) {
@@ -146,7 +177,7 @@ for (const provider of ['slack', 'teams', 'discord'] as const) {
       resourceName: provider
     });
 
-    return c.json({ success: true, data: updated });
+    return c.json({ success: true, data: maskIntegrationSettings(updated) });
   });
 }
 
@@ -157,7 +188,7 @@ integrationRoutes.get('/monitoring', requireScope('organization', 'partner', 'sy
     return c.json({ error: orgResult.error }, orgResult.status);
   }
 
-  return c.json({ data: monitoringSettings.get(orgResult.orgId) ?? {} });
+  return c.json({ data: maskIntegrationSettings(monitoringSettings.get(orgResult.orgId) ?? {}) });
 });
 
 integrationRoutes.put('/monitoring', requireScope('organization', 'partner', 'system'), requireIntegrationWrite, requireMfa(), async (c) => {
@@ -171,8 +202,15 @@ integrationRoutes.put('/monitoring', requireScope('organization', 'partner', 'sy
     return c.json({ error: orgResult.error }, orgResult.status);
   }
 
-  monitoringSettings.set(orgResult.orgId, body);
-  return c.json({ success: true, data: body });
+  const protectedBody = protectSettings(
+    body,
+    monitoringSettings.get(orgResult.orgId),
+    'monitoring',
+    orgResult.orgId,
+  );
+  if (!protectedBody.ok) return c.json({ error: protectedBody.error }, 400);
+  monitoringSettings.set(orgResult.orgId, protectedBody.value);
+  return c.json({ success: true, data: maskIntegrationSettings(protectedBody.value) });
 });
 
 integrationRoutes.post('/monitoring/test', requireScope('organization', 'partner', 'system'), requireIntegrationWrite, requireMfa(), async (c) => {
@@ -186,7 +224,7 @@ integrationRoutes.get('/ticketing', requireScope('organization', 'partner', 'sys
     return c.json({ error: orgResult.error }, orgResult.status);
   }
 
-  return c.json({ data: ticketingSettings.get(orgResult.orgId) ?? {} });
+  return c.json({ data: maskIntegrationSettings(ticketingSettings.get(orgResult.orgId) ?? {}) });
 });
 
 integrationRoutes.post('/ticketing', requireScope('organization', 'partner', 'system'), requireIntegrationWrite, requireMfa(), async (c) => {
@@ -200,8 +238,14 @@ integrationRoutes.post('/ticketing', requireScope('organization', 'partner', 'sy
     return c.json({ error: orgResult.error }, orgResult.status);
   }
 
-  ticketingSettings.set(orgResult.orgId, body);
-  return c.json({ success: true, message: 'Ticketing settings saved.', data: body });
+  const protectedBody = protectSettings(body, ticketingSettings.get(orgResult.orgId), 'ticketing', orgResult.orgId);
+  if (!protectedBody.ok) return c.json({ error: protectedBody.error }, 400);
+  ticketingSettings.set(orgResult.orgId, protectedBody.value);
+  return c.json({
+    success: true,
+    message: 'Ticketing settings saved.',
+    data: maskIntegrationSettings(protectedBody.value),
+  });
 });
 
 integrationRoutes.post('/ticketing/test', requireScope('organization', 'partner', 'system'), requireIntegrationWrite, requireMfa(), async (c) => {
@@ -220,7 +264,7 @@ integrationRoutes.get('/psa', requireScope('organization', 'partner', 'system'),
     return c.json({ error: 'PSA settings not found' }, 404);
   }
 
-  return c.json({ data: existing });
+  return c.json({ data: maskIntegrationSettings(existing) });
 });
 
 integrationRoutes.post('/psa', requireScope('organization', 'partner', 'system'), requireIntegrationWrite, requireMfa(), async (c) => {
@@ -234,8 +278,10 @@ integrationRoutes.post('/psa', requireScope('organization', 'partner', 'system')
     return c.json({ error: orgResult.error }, orgResult.status);
   }
 
-  psaSettings.set(orgResult.orgId, body);
-  return c.json({ success: true, data: body });
+  const protectedBody = protectSettings(body, psaSettings.get(orgResult.orgId), 'psa', orgResult.orgId);
+  if (!protectedBody.ok) return c.json({ error: protectedBody.error }, 400);
+  psaSettings.set(orgResult.orgId, protectedBody.value);
+  return c.json({ success: true, data: maskIntegrationSettings(protectedBody.value) });
 });
 
 integrationRoutes.put('/psa', requireScope('organization', 'partner', 'system'), requireIntegrationWrite, requireMfa(), async (c) => {
@@ -249,8 +295,10 @@ integrationRoutes.put('/psa', requireScope('organization', 'partner', 'system'),
     return c.json({ error: orgResult.error }, orgResult.status);
   }
 
-  psaSettings.set(orgResult.orgId, body);
-  return c.json({ success: true, data: body });
+  const protectedBody = protectSettings(body, psaSettings.get(orgResult.orgId), 'psa', orgResult.orgId);
+  if (!protectedBody.ok) return c.json({ error: protectedBody.error }, 400);
+  psaSettings.set(orgResult.orgId, protectedBody.value);
+  return c.json({ success: true, data: maskIntegrationSettings(protectedBody.value) });
 });
 
 integrationRoutes.post('/psa/test', requireScope('organization', 'partner', 'system'), requireIntegrationWrite, requireMfa(), async (c) => {

--- a/apps/api/src/services/integrationSettingsSecrets.test.ts
+++ b/apps/api/src/services/integrationSettingsSecrets.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import { decryptSecret } from './secretCrypto';
+import {
+  INTEGRATION_MASKED_SECRET,
+  InvalidIntegrationSecretError,
+  integrationSettingsSecretAad,
+  maskIntegrationSettings,
+  sealIntegrationSettings,
+} from './integrationSettingsSecrets';
+
+describe('integration settings secret storage', () => {
+  it('encrypts secret-shaped fields and masks response projections', () => {
+    const input = {
+      provider: 'example',
+      credentials: { username: 'agent', password: 'private-password' },
+      apiKey: 'private-api-key',
+      url: 'https://public.example.test',
+    };
+    const sealed = sealIntegrationSettings(input, undefined, 'ticketing', 'org-a');
+
+    expect(sealed.credentials).not.toEqual(input.credentials);
+    const password = (sealed.credentials as Record<string, unknown>).password as string;
+    expect(password).toMatch(/^enc:v[123]:/);
+    expect(decryptSecret(password, {
+      aad: integrationSettingsSecretAad('ticketing', 'org-a', ['credentials', 'password']),
+    })).toBe('private-password');
+
+    expect(maskIntegrationSettings(sealed)).toEqual({
+      provider: 'example',
+      credentials: { username: 'agent', password: INTEGRATION_MASKED_SECRET },
+      apiKey: INTEGRATION_MASKED_SECRET,
+      url: 'https://public.example.test',
+    });
+  });
+
+  it('preserves an existing ciphertext when a client resaves a masked marker', () => {
+    const first = sealIntegrationSettings({ apiSecret: 'private-secret' }, undefined, 'psa', 'org-a');
+    const second = sealIntegrationSettings(
+      { apiSecret: INTEGRATION_MASKED_SECRET, enabled: false },
+      first,
+      'psa',
+      'org-a',
+    );
+    expect(second.apiSecret).toBe(first.apiSecret);
+    expect(second.enabled).toBe(false);
+  });
+
+  it('rejects a masked marker when no secret is configured at that exact path', () => {
+    expect(() => sealIntegrationSettings(
+      { apiKey: INTEGRATION_MASKED_SECRET },
+      undefined,
+      'monitoring',
+      'org-a',
+    )).toThrow(InvalidIntegrationSecretError);
+  });
+
+  it('rejects client-supplied ciphertext instead of accepting an opaque envelope', () => {
+    expect(() => sealIntegrationSettings(
+      { apiKey: 'enc:v3:forged-envelope' },
+      undefined,
+      'monitoring',
+      'org-a',
+    )).toThrow(InvalidIntegrationSecretError);
+  });
+
+  it('treats monitoring webhook endpoint URLs as secrets without masking ordinary URLs', () => {
+    const sealed = sealIntegrationSettings({
+      grafana: { url: 'https://grafana.example.test' },
+      webhooks: { endpoints: [{ url: 'https://hooks.example.test/private' }] },
+    }, undefined, 'monitoring', 'org-a');
+    const masked = maskIntegrationSettings(sealed);
+
+    expect((masked.grafana as Record<string, unknown>).url).toBe('https://grafana.example.test');
+    const endpoints = (masked.webhooks as { endpoints: Array<Record<string, unknown>> }).endpoints;
+    expect(endpoints[0]?.url).toBe(INTEGRATION_MASKED_SECRET);
+  });
+
+  it('preserves webhook ciphertext by endpoint id when endpoints are reordered', () => {
+    const first = sealIntegrationSettings({
+      webhooks: {
+        endpoints: [
+          { id: 'primary', url: 'https://hooks.example.test/primary' },
+          { id: 'secondary', url: 'https://hooks.example.test/secondary' },
+        ],
+      },
+    }, undefined, 'monitoring', 'org-a');
+    const firstEndpoints = (first.webhooks as { endpoints: Array<Record<string, unknown>> }).endpoints;
+
+    const reordered = sealIntegrationSettings({
+      webhooks: {
+        endpoints: [
+          { id: 'secondary', url: INTEGRATION_MASKED_SECRET },
+          { id: 'primary', url: INTEGRATION_MASKED_SECRET },
+        ],
+      },
+    }, first, 'monitoring', 'org-a');
+    const reorderedEndpoints = (
+      reordered.webhooks as { endpoints: Array<Record<string, unknown>> }
+    ).endpoints;
+
+    expect(reorderedEndpoints[0]?.url).toBe(firstEndpoints[1]?.url);
+    expect(reorderedEndpoints[1]?.url).toBe(firstEndpoints[0]?.url);
+  });
+
+  it('rejects duplicate webhook endpoint ids before preserving masked secrets', () => {
+    const existing = sealIntegrationSettings({
+      webhooks: { endpoints: [{ id: 'duplicate', url: 'https://hooks.example.test/original' }] },
+    }, undefined, 'monitoring', 'org-a');
+
+    expect(() => sealIntegrationSettings({
+      webhooks: {
+        endpoints: [
+          { id: 'duplicate', url: INTEGRATION_MASKED_SECRET },
+          { id: 'duplicate', url: INTEGRATION_MASKED_SECRET },
+        ],
+      },
+    }, existing, 'monitoring', 'org-a')).toThrow(InvalidIntegrationSecretError);
+  });
+
+  it('assigns a durable id to an id-less webhook before its masked round trip', () => {
+    const first = sealIntegrationSettings({
+      webhooks: { endpoints: [{ url: 'https://hooks.example.test/legacy' }] },
+    }, undefined, 'monitoring', 'org-a');
+    const firstEndpoint = (
+      first.webhooks as { endpoints: Array<Record<string, unknown>> }
+    ).endpoints[0];
+
+    expect(firstEndpoint?.id).toEqual(expect.any(String));
+    const second = sealIntegrationSettings({
+      webhooks: {
+        endpoints: [{ id: firstEndpoint?.id, url: INTEGRATION_MASKED_SECRET }],
+      },
+    }, first, 'monitoring', 'org-a');
+    const secondEndpoint = (
+      second.webhooks as { endpoints: Array<Record<string, unknown>> }
+    ).endpoints[0];
+    expect(secondEndpoint).toEqual(firstEndpoint);
+  });
+});

--- a/apps/api/src/services/integrationSettingsSecrets.test.ts
+++ b/apps/api/src/services/integrationSettingsSecrets.test.ts
@@ -1,12 +1,35 @@
-import { describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { decryptSecret } from './secretCrypto';
 import {
   INTEGRATION_MASKED_SECRET,
+  IntegrationSecretsUnavailableError,
   InvalidIntegrationSecretError,
   integrationSettingsSecretAad,
+  isSecretFieldName,
   maskIntegrationSettings,
   sealIntegrationSettings,
 } from './integrationSettingsSecrets';
+
+// The shared test setup configures neither APP_ENCRYPTION_KEY nor
+// APP_ENCRYPTION_KEY_ID, which is exactly the deployment shape this module now
+// refuses to seal in (encryptSecret would drop the AAD and write enc:v1). Give
+// the suite a real active key id so it exercises the v3 path that production
+// is required to run, and restore the ambient env afterwards so no other file
+// in this worker inherits it.
+const priorEncryptionKey = process.env.APP_ENCRYPTION_KEY;
+const priorEncryptionKeyId = process.env.APP_ENCRYPTION_KEY_ID;
+
+beforeAll(() => {
+  process.env.APP_ENCRYPTION_KEY = 'integration-settings-secrets-test-key-material';
+  process.env.APP_ENCRYPTION_KEY_ID = 'integration-settings-test';
+});
+
+afterAll(() => {
+  if (priorEncryptionKey === undefined) delete process.env.APP_ENCRYPTION_KEY;
+  else process.env.APP_ENCRYPTION_KEY = priorEncryptionKey;
+  if (priorEncryptionKeyId === undefined) delete process.env.APP_ENCRYPTION_KEY_ID;
+  else process.env.APP_ENCRYPTION_KEY_ID = priorEncryptionKeyId;
+});
 
 describe('integration settings secret storage', () => {
   it('encrypts secret-shaped fields and masks response projections', () => {
@@ -20,7 +43,7 @@ describe('integration settings secret storage', () => {
 
     expect(sealed.credentials).not.toEqual(input.credentials);
     const password = (sealed.credentials as Record<string, unknown>).password as string;
-    expect(password).toMatch(/^enc:v[123]:/);
+    expect(password).toMatch(/^enc:v3:integration-settings-test:/);
     expect(decryptSecret(password, {
       aad: integrationSettingsSecretAad('ticketing', 'org-a', ['credentials', 'password']),
     })).toBe('private-password');
@@ -135,5 +158,168 @@ describe('integration settings secret storage', () => {
       second.webhooks as { endpoints: Array<Record<string, unknown>> }
     ).endpoints[0];
     expect(secondEndpoint).toEqual(firstEndpoint);
+  });
+
+  it('seals with AAD-bound v3 ciphertext, never the non-AAD v1 fallback', () => {
+    const sealed = sealIntegrationSettings(
+      { apiKey: 'private-api-key' },
+      undefined,
+      'monitoring',
+      'org-a',
+    );
+
+    // enc:v1 is the shape encryptSecret falls back to when no key id is
+    // configured. It encrypts, but it silently ignores the `aad` option, so a
+    // v1 value here would mean the family/org/path binding does not exist.
+    expect(sealed.apiKey).toMatch(/^enc:v3:integration-settings-test:/);
+    expect(sealed.apiKey).not.toMatch(/^enc:v1:/);
+    expect(
+      decryptSecret(sealed.apiKey as string, {
+        aad: integrationSettingsSecretAad('monitoring', 'org-a', ['apiKey']),
+      }),
+    ).toBe('private-api-key');
+  });
+
+  it('refuses to seal a credential when no active encryption key id is configured', () => {
+    const restore = process.env.APP_ENCRYPTION_KEY_ID;
+    delete process.env.APP_ENCRYPTION_KEY_ID;
+    try {
+      expect(() =>
+        sealIntegrationSettings({ apiKey: 'private-api-key' }, undefined, 'monitoring', 'org-a'),
+      ).toThrow(IntegrationSecretsUnavailableError);
+      expect(() =>
+        sealIntegrationSettings({ apiKey: 'private-api-key' }, undefined, 'monitoring', 'org-a'),
+      ).toThrow(/APP_ENCRYPTION_KEY_ID/);
+
+      // A payload with no credential in it is unaffected: the assertion is made
+      // at the point of encryption, so non-secret settings still save.
+      expect(
+        sealIntegrationSettings(
+          { enabled: true, defaultChannel: '#ops' },
+          undefined,
+          'monitoring',
+          'org-a',
+        ),
+      ).toEqual({ enabled: true, defaultChannel: '#ops' });
+    } finally {
+      if (restore === undefined) delete process.env.APP_ENCRYPTION_KEY_ID;
+      else process.env.APP_ENCRYPTION_KEY_ID = restore;
+    }
+  });
+
+  describe('credential-shaped field-name matching', () => {
+    // The six names that the previous exact-name denylist missed entirely.
+    it.each([
+      'apiToken',
+      'signingSecret',
+      'sharedSecret',
+      'bearerToken',
+      'dsn',
+      'passphrase',
+    ])('treats %s as a credential', (field) => {
+      expect(isSecretFieldName(field)).toBe(true);
+
+      const sealed = sealIntegrationSettings({ [field]: 'private-value' }, undefined, 'psa', 'org-a');
+      expect(sealed[field]).toMatch(/^enc:v3:/);
+      expect(maskIntegrationSettings(sealed)[field]).toBe(INTEGRATION_MASKED_SECRET);
+    });
+
+    // Everything the previous exact-name set already covered must stay covered.
+    it.each([
+      'accessToken',
+      'apiKey',
+      'apiSecret',
+      'authToken',
+      'clientSecret',
+      'connectionString',
+      'integrationKey',
+      'password',
+      'privateKey',
+      'refreshToken',
+      'secret',
+      'secretKey',
+      'token',
+      'webhookSecret',
+      'webhookUrl',
+    ])('still treats %s as a credential', (field) => {
+      expect(isSecretFieldName(field)).toBe(true);
+    });
+
+    // Shipped non-credential fields of the four compatibility stores, plus the
+    // explicit allowlist entries, must keep round-tripping in clear.
+    it.each([
+      'enabled',
+      'provider',
+      'baseUrl',
+      'workspaceId',
+      'workspaceName',
+      'defaultChannel',
+      'clientId',
+      'tenantId',
+      'severity',
+      'username',
+      'keyId',
+      'keyName',
+      'tokenCount',
+    ])('does not treat %s as a credential', (field) => {
+      expect(isSecretFieldName(field)).toBe(false);
+    });
+
+    it('seals a credential-named STRING but walks a credential-named CONTAINER', () => {
+      // 'credentials' contains the 'credential' part. As a string it is a leaf
+      // secret and must be sealed; as an object it is a container whose leaves
+      // are judged by their own names, so the password seals and the username
+      // keeps round-tripping in clear.
+      const asString = sealIntegrationSettings(
+        { credentials: 'user:private-password' },
+        undefined,
+        'ticketing',
+        'org-a',
+      );
+      expect(asString.credentials).toMatch(/^enc:v3:/);
+      expect(maskIntegrationSettings(asString)).toEqual({
+        credentials: INTEGRATION_MASKED_SECRET,
+      });
+
+      const asContainer = sealIntegrationSettings(
+        { credentials: { username: 'agent', password: 'private-password' } },
+        undefined,
+        'ticketing',
+        'org-a',
+      );
+      const sealedContainer = asContainer.credentials as Record<string, unknown>;
+      expect(sealedContainer.username).toBe('agent');
+      expect(sealedContainer.password).toMatch(/^enc:v3:/);
+
+      // The masked projection must WALK the container. Returning it untouched
+      // would hand the reader the raw ciphertext of everything inside it.
+      expect(maskIntegrationSettings(asContainer)).toEqual({
+        credentials: { username: 'agent', password: INTEGRATION_MASKED_SECRET },
+      });
+    });
+
+    it('rejects a non-string, non-container value at a credential-shaped name', () => {
+      expect(() =>
+        sealIntegrationSettings({ apiKey: 12345 }, undefined, 'psa', 'org-a'),
+      ).toThrow(InvalidIntegrationSecretError);
+    });
+
+    it('leaves allowlisted names unsealed and unmasked end to end', () => {
+      const sealed = sealIntegrationSettings(
+        { keyName: 'primary', tokenCount: '3', apiToken: 'private-token' },
+        undefined,
+        'ticketing',
+        'org-a',
+      );
+
+      expect(sealed.keyName).toBe('primary');
+      expect(sealed.tokenCount).toBe('3');
+      expect(sealed.apiToken).toMatch(/^enc:v3:/);
+      expect(maskIntegrationSettings(sealed)).toEqual({
+        keyName: 'primary',
+        tokenCount: '3',
+        apiToken: INTEGRATION_MASKED_SECRET,
+      });
+    });
   });
 });

--- a/apps/api/src/services/integrationSettingsSecrets.test.ts
+++ b/apps/api/src/services/integrationSettingsSecrets.test.ts
@@ -304,6 +304,33 @@ describe('integration settings secret storage', () => {
       ).toThrow(InvalidIntegrationSecretError);
     });
 
+    it('seals and masks string elements inside a credential-named ARRAY', () => {
+      // Array elements have no field name of their own (`index:0`, `"0"`, …),
+      // so a credential-named array key must lend its own secret-ness to each
+      // string element rather than leaving them to round-trip in clear.
+      const sealed = sealIntegrationSettings(
+        { tokens: ['abc', 'def'] },
+        undefined,
+        'ticketing',
+        'org-a',
+      );
+      const sealedTokens = sealed.tokens as string[];
+      expect(sealedTokens[0]).toMatch(/^enc:v3:/);
+      expect(sealedTokens[1]).toMatch(/^enc:v3:/);
+      expect(sealedTokens[0]).not.toBe('abc');
+      expect(sealedTokens[1]).not.toBe('def');
+
+      const masked = maskIntegrationSettings(sealed);
+      expect(masked.tokens).toEqual([INTEGRATION_MASKED_SECRET, INTEGRATION_MASKED_SECRET]);
+    });
+
+    it('does not seal or mask a non-credential array', () => {
+      const input = { metrics: { selected: ['cpu', 'memory'] } };
+      const sealed = sealIntegrationSettings(input, undefined, 'monitoring', 'org-a');
+      expect(sealed).toEqual(input);
+      expect(maskIntegrationSettings(sealed)).toEqual(input);
+    });
+
     it('leaves allowlisted names unsealed and unmasked end to end', () => {
       const sealed = sealIntegrationSettings(
         { keyName: 'primary', tokenCount: '3', apiToken: 'private-token' },

--- a/apps/api/src/services/integrationSettingsSecrets.ts
+++ b/apps/api/src/services/integrationSettingsSecrets.ts
@@ -1,0 +1,187 @@
+import { randomUUID } from 'crypto';
+import { encryptSecret, isEncryptedSecret } from './secretCrypto';
+
+export const INTEGRATION_MASKED_SECRET = '********';
+
+const SECRET_FIELD_NAMES = new Set([
+  'accesstoken',
+  'apikey',
+  'apisecret',
+  'authtoken',
+  'clientsecret',
+  'connectionstring',
+  'integrationkey',
+  'password',
+  'privatekey',
+  'refreshtoken',
+  'secret',
+  'secretkey',
+  'token',
+  'webhooksecret',
+  'webhookurl',
+]);
+
+export class InvalidIntegrationSecretError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidIntegrationSecretError';
+  }
+}
+
+type JsonRecord = Record<string, unknown>;
+
+function normalizedFieldName(field: string): string {
+  return field.replace(/[^a-z0-9]/gi, '').toLowerCase();
+}
+
+function isSecretPath(path: readonly string[]): boolean {
+  const last = path.at(-1);
+  if (!last) return false;
+  if (SECRET_FIELD_NAMES.has(normalizedFieldName(last))) return true;
+  return last === 'url' && path.includes('webhooks') && path.includes('endpoints');
+}
+
+export function integrationSettingsSecretAad(
+  family: string,
+  orgId: string,
+  path: readonly string[],
+): string {
+  return `integration-settings:v1:${family}:${orgId}:${JSON.stringify(path)}`;
+}
+
+function valueAtPath(value: unknown, path: readonly string[]): unknown {
+  let current = value;
+  for (const part of path) {
+    if (Array.isArray(current)) {
+      const index = Number(part);
+      if (!Number.isSafeInteger(index) || index < 0) return undefined;
+      current = current[index];
+    } else if (current && typeof current === 'object') {
+      current = (current as JsonRecord)[part];
+    } else {
+      return undefined;
+    }
+  }
+  return current;
+}
+
+function recordId(value: unknown): string | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const id = (value as JsonRecord).id;
+  return typeof id === 'string' && id.length > 0 ? id : undefined;
+}
+
+function isWebhookEndpointsPath(path: readonly string[]): boolean {
+  return path.at(-1) === 'endpoints' && path.includes('webhooks');
+}
+
+function ensureWebhookEndpointId(value: unknown): unknown {
+  if (!value || typeof value !== 'object' || Array.isArray(value) || recordId(value)) return value;
+  return { ...(value as JsonRecord), id: randomUUID() };
+}
+
+function arrayEntryContext(
+  entries: unknown[],
+  existing: unknown,
+  entry: unknown,
+  index: number,
+  path: readonly string[],
+): { existingEntry: unknown; pathPart: string } {
+  // Monitoring webhook endpoints are the only shipped secret-bearing array.
+  // Bind their ciphertext to the endpoint's durable UI identifier so a reorder
+  // cannot attach one destination's secret to another destination.
+  const isWebhookEndpoints = isWebhookEndpointsPath(path);
+  if (!isWebhookEndpoints) {
+    return {
+      existingEntry: Array.isArray(existing) ? existing[index] : undefined,
+      pathPart: `index:${index}`,
+    };
+  }
+  const id = recordId(entry);
+  if (!id) {
+    return {
+      existingEntry: Array.isArray(existing) ? existing[index] : undefined,
+      pathPart: `index:${index}`,
+    };
+  }
+  if (entries.filter((candidate) => recordId(candidate) === id).length !== 1) {
+    throw new InvalidIntegrationSecretError(`Duplicate integration setting id ${JSON.stringify(id)}`);
+  }
+  const existingMatches = Array.isArray(existing)
+    ? existing.filter((candidate) => recordId(candidate) === id)
+    : [];
+  if (existingMatches.length > 1) {
+    throw new InvalidIntegrationSecretError(`Stored integration setting id ${JSON.stringify(id)} is ambiguous`);
+  }
+  return { existingEntry: existingMatches[0], pathPart: `id:${JSON.stringify(id)}` };
+}
+
+function sealValue(
+  value: unknown,
+  existing: unknown,
+  family: string,
+  orgId: string,
+  path: readonly string[],
+): unknown {
+  if (isSecretPath(path)) {
+    if (typeof value !== 'string') {
+      throw new InvalidIntegrationSecretError(`Secret field ${path.join('.')} must be a string`);
+    }
+    if (value === INTEGRATION_MASKED_SECRET) {
+      if (typeof existing !== 'string' || existing.length === 0) {
+        throw new InvalidIntegrationSecretError(`Secret field ${path.join('.')} is not already configured`);
+      }
+      return existing;
+    }
+    if (value.length === 0) return '';
+    if (isEncryptedSecret(value)) {
+      throw new InvalidIntegrationSecretError(`Secret field ${path.join('.')} must not contain ciphertext`);
+    }
+    return encryptSecret(value, { aad: integrationSettingsSecretAad(family, orgId, path) });
+  }
+
+  if (Array.isArray(value)) {
+    const entries = isWebhookEndpointsPath(path) ? value.map(ensureWebhookEndpointId) : value;
+    return entries.map((entry, index) => {
+      const context = arrayEntryContext(entries, existing, entry, index, path);
+      return sealValue(entry, context.existingEntry, family, orgId, [...path, context.pathPart]);
+    });
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as JsonRecord).map(([key, entry]) => [
+        key,
+        sealValue(entry, valueAtPath(existing, [key]), family, orgId, [...path, key]),
+      ]),
+    );
+  }
+  return value;
+}
+
+export function sealIntegrationSettings(
+  value: JsonRecord,
+  existing: JsonRecord | undefined,
+  family: string,
+  orgId: string,
+): JsonRecord {
+  return sealValue(value, existing, family, orgId, []) as JsonRecord;
+}
+
+function maskValue(value: unknown, path: readonly string[]): unknown {
+  if (isSecretPath(path)) {
+    return typeof value === 'string' && value.length > 0 ? INTEGRATION_MASKED_SECRET : value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry, index) => maskValue(entry, [...path, String(index)]));
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as JsonRecord).map(([key, entry]) => [key, maskValue(entry, [...path, key])]),
+    );
+  }
+  return value;
+}
+
+export function maskIntegrationSettings(value: JsonRecord): JsonRecord {
+  return maskValue(value, []) as JsonRecord;
+}

--- a/apps/api/src/services/integrationSettingsSecrets.ts
+++ b/apps/api/src/services/integrationSettingsSecrets.ts
@@ -165,6 +165,38 @@ function arrayEntryContext(
   return { existingEntry: existingMatches[0], pathPart: `id:${JSON.stringify(id)}` };
 }
 
+function sealSecretLeaf(
+  value: unknown,
+  existing: unknown,
+  family: string,
+  orgId: string,
+  path: readonly string[],
+): unknown {
+  if (typeof value !== 'string') {
+    throw new InvalidIntegrationSecretError(`Secret field ${path.join('.')} must be a string`);
+  }
+  if (value === INTEGRATION_MASKED_SECRET) {
+    if (typeof existing !== 'string' || existing.length === 0) {
+      throw new InvalidIntegrationSecretError(`Secret field ${path.join('.')} is not already configured`);
+    }
+    return existing;
+  }
+  if (value.length === 0) return '';
+  if (isEncryptedSecret(value)) {
+    throw new InvalidIntegrationSecretError(`Secret field ${path.join('.')} must not contain ciphertext`);
+  }
+  // Fail closed rather than let encryptSecret drop the AAD and write v1.
+  if (!getActiveSecretEncryptionKeyId()) {
+    throw new IntegrationSecretsUnavailableError(
+      `Integration secret ${path.join('.')} cannot be stored: APP_ENCRYPTION_KEY_ID is not configured on this `
+        + 'API instance, so the credential would be sealed as non-AAD enc:v1 ciphertext with no binding to its '
+        + 'provider, organization or endpoint. Set APP_ENCRYPTION_KEY_ID (alongside APP_ENCRYPTION_KEY) and '
+        + 'restart the API.',
+    );
+  }
+  return encryptSecret(value, { aad: integrationSettingsSecretAad(family, orgId, path) });
+}
+
 function sealValue(
   value: unknown,
   existing: unknown,
@@ -180,37 +212,27 @@ function sealValue(
   // confusion that must not reach storage. Sealing a container by its name is
   // not an option — it would have to be stringified, and masking it back would
   // destroy the non-secret siblings inside it.
-  if (isSecretPath(path) && !(value !== null && typeof value === 'object')) {
-    if (typeof value !== 'string') {
-      throw new InvalidIntegrationSecretError(`Secret field ${path.join('.')} must be a string`);
-    }
-    if (value === INTEGRATION_MASKED_SECRET) {
-      if (typeof existing !== 'string' || existing.length === 0) {
-        throw new InvalidIntegrationSecretError(`Secret field ${path.join('.')} is not already configured`);
-      }
-      return existing;
-    }
-    if (value.length === 0) return '';
-    if (isEncryptedSecret(value)) {
-      throw new InvalidIntegrationSecretError(`Secret field ${path.join('.')} must not contain ciphertext`);
-    }
-    // Fail closed rather than let encryptSecret drop the AAD and write v1.
-    if (!getActiveSecretEncryptionKeyId()) {
-      throw new IntegrationSecretsUnavailableError(
-        `Integration secret ${path.join('.')} cannot be stored: APP_ENCRYPTION_KEY_ID is not configured on this `
-          + 'API instance, so the credential would be sealed as non-AAD enc:v1 ciphertext with no binding to its '
-          + 'provider, organization or endpoint. Set APP_ENCRYPTION_KEY_ID (alongside APP_ENCRYPTION_KEY) and '
-          + 'restart the API.',
-      );
-    }
-    return encryptSecret(value, { aad: integrationSettingsSecretAad(family, orgId, path) });
+  //
+  // Array ELEMENTS never carry a name of their own (their path parts are
+  // synthetic: `index:N` or `id:"..."`), so `isSecretPath` cannot judge a
+  // bare element by itself — `{ tokens: ["abc"] }` would otherwise stay
+  // plaintext forever. A secret-named array therefore lends its own
+  // secret-ness to each of its direct string elements below; a credential
+  // path is still only ever decided by the enclosing field's own name.
+  const pathIsSecret = isSecretPath(path);
+  if (pathIsSecret && !(value !== null && typeof value === 'object')) {
+    return sealSecretLeaf(value, existing, family, orgId, path);
   }
 
   if (Array.isArray(value)) {
     const entries = isWebhookEndpointsPath(path) ? value.map(ensureWebhookEndpointId) : value;
     return entries.map((entry, index) => {
       const context = arrayEntryContext(entries, existing, entry, index, path);
-      return sealValue(entry, context.existingEntry, family, orgId, [...path, context.pathPart]);
+      const elementPath = [...path, context.pathPart];
+      if (pathIsSecret && !(entry !== null && typeof entry === 'object')) {
+        return sealSecretLeaf(entry, context.existingEntry, family, orgId, elementPath);
+      }
+      return sealValue(entry, context.existingEntry, family, orgId, elementPath);
     });
   }
   if (value && typeof value === 'object') {
@@ -233,15 +255,29 @@ export function sealIntegrationSettings(
   return sealValue(value, existing, family, orgId, []) as JsonRecord;
 }
 
+function maskSecretLeaf(value: unknown): unknown {
+  return typeof value === 'string' && value.length > 0 ? INTEGRATION_MASKED_SECRET : value;
+}
+
 function maskValue(value: unknown, path: readonly string[]): unknown {
-  // Same leaf-vs-container split as sealValue. Returning a credential-NAMED
-  // container unchanged here would hand the caller the raw ciphertext of every
-  // secret inside it, so containers must fall through to the walk below.
-  if (isSecretPath(path) && !(value !== null && typeof value === 'object')) {
-    return typeof value === 'string' && value.length > 0 ? INTEGRATION_MASKED_SECRET : value;
+  // Same leaf-vs-container split as sealValue, including the array-element
+  // inheritance: an element path (`index:N` / `"N"`) carries no name of its
+  // own, so a credential-named array lends its secret-ness to each direct
+  // string element instead of leaving it to round-trip unmasked. Returning a
+  // credential-NAMED container unchanged here would hand the caller the raw
+  // ciphertext of every secret inside it, so containers must fall through to
+  // the walk below.
+  const pathIsSecret = isSecretPath(path);
+  if (pathIsSecret && !(value !== null && typeof value === 'object')) {
+    return maskSecretLeaf(value);
   }
   if (Array.isArray(value)) {
-    return value.map((entry, index) => maskValue(entry, [...path, String(index)]));
+    return value.map((entry, index) => {
+      if (pathIsSecret && !(entry !== null && typeof entry === 'object')) {
+        return maskSecretLeaf(entry);
+      }
+      return maskValue(entry, [...path, String(index)]);
+    });
   }
   if (value && typeof value === 'object') {
     return Object.fromEntries(

--- a/apps/api/src/services/integrationSettingsSecrets.ts
+++ b/apps/api/src/services/integrationSettingsSecrets.ts
@@ -1,30 +1,72 @@
 import { randomUUID } from 'crypto';
-import { encryptSecret, isEncryptedSecret } from './secretCrypto';
+import { encryptSecret, getActiveSecretEncryptionKeyId, isEncryptedSecret } from './secretCrypto';
 
 export const INTEGRATION_MASKED_SECRET = '********';
 
-const SECRET_FIELD_NAMES = new Set([
-  'accesstoken',
-  'apikey',
-  'apisecret',
-  'authtoken',
-  'clientsecret',
+/**
+ * Credential-shaped field-name PARTS, matched as substrings of the normalized
+ * (lowercased, non-alphanumerics stripped) field name.
+ *
+ * This deliberately mirrors `SUSPICIOUS_NAME_PARTS` in `tenantExportPolicy.ts`
+ * rather than listing exact names. An exact-name denylist is one provider away
+ * from being wrong: the shipped stores accept arbitrary JSON, so `apiToken`,
+ * `signingSecret`, `sharedSecret`, `bearerToken`, `dsn` and `passphrase` all
+ * sailed straight through the previous exact-match set and were echoed in
+ * plaintext. Substring matching fails CLOSED — an unrecognised credential name
+ * is far likelier to contain one of these parts than to match a name we
+ * happened to enumerate.
+ *
+ * `connectionstring` and `webhookurl` are kept as whole-word parts because
+ * neither decomposes into any of the generic parts below.
+ */
+const SECRET_NAME_PARTS = [
   'connectionstring',
-  'integrationkey',
+  'credential',
+  'dsn',
+  'key',
+  'passphrase',
   'password',
-  'privatekey',
-  'refreshtoken',
+  'refresh',
   'secret',
-  'secretkey',
   'token',
-  'webhooksecret',
   'webhookurl',
-]);
+] as const;
+
+/**
+ * Normalized field names that match a part above but are known NOT to be
+ * secret, so they keep round-tripping in clear. None of these appear in the
+ * four shipped compatibility stores today (their fields are `enabled`,
+ * `workspaceId`, `clientId`, `tenantId`, `defaultChannel`, `provider`,
+ * `baseUrl`, `severity` and the credential fields themselves) — the set is the
+ * documented escape hatch for the identifier/counter shapes that substring
+ * matching would otherwise over-capture. Adding an entry here removes a field
+ * from encryption and masking, so each one needs a test proving it carries no
+ * credential material.
+ */
+const NON_SECRET_FIELD_NAMES = new Set(['keyid', 'keyname', 'tokencount']);
 
 export class InvalidIntegrationSecretError extends Error {
   constructor(message: string) {
     super(message);
     this.name = 'InvalidIntegrationSecretError';
+  }
+}
+
+/**
+ * Raised when a credential would have to be sealed but no active secret
+ * encryption key id is configured.
+ *
+ * `encryptSecret` does NOT fail when `APP_ENCRYPTION_KEY_ID` is unset — it
+ * silently drops the `aad` option and writes non-AAD `enc:v1:` ciphertext. The
+ * value would still be encrypted, so nothing would look broken, but the
+ * family/organization/path binding this module relies on to stop a ciphertext
+ * being replayed into a different provider, org or endpoint would simply not
+ * exist. Refuse the write instead of degrading silently.
+ */
+export class IntegrationSecretsUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'IntegrationSecretsUnavailableError';
   }
 }
 
@@ -34,10 +76,17 @@ function normalizedFieldName(field: string): string {
   return field.replace(/[^a-z0-9]/gi, '').toLowerCase();
 }
 
+export function isSecretFieldName(field: string): boolean {
+  const normalized = normalizedFieldName(field);
+  if (!normalized) return false;
+  if (NON_SECRET_FIELD_NAMES.has(normalized)) return false;
+  return SECRET_NAME_PARTS.some((part) => normalized.includes(part));
+}
+
 function isSecretPath(path: readonly string[]): boolean {
   const last = path.at(-1);
   if (!last) return false;
-  if (SECRET_FIELD_NAMES.has(normalizedFieldName(last))) return true;
+  if (isSecretFieldName(last)) return true;
   return last === 'url' && path.includes('webhooks') && path.includes('endpoints');
 }
 
@@ -123,7 +172,15 @@ function sealValue(
   orgId: string,
   path: readonly string[],
 ): unknown {
-  if (isSecretPath(path)) {
+  // A credential-shaped NAME can label either a leaf secret (`apiKey: "..."`)
+  // or a container of them (`credentials: { username, password }` — 'credentials'
+  // contains the 'credential' part). Decide on the value, not the name alone:
+  // a string leaf is sealed, an object/array is walked as an ordinary container
+  // whose leaves are judged by their own names, and any other scalar is a type
+  // confusion that must not reach storage. Sealing a container by its name is
+  // not an option — it would have to be stringified, and masking it back would
+  // destroy the non-secret siblings inside it.
+  if (isSecretPath(path) && !(value !== null && typeof value === 'object')) {
     if (typeof value !== 'string') {
       throw new InvalidIntegrationSecretError(`Secret field ${path.join('.')} must be a string`);
     }
@@ -136,6 +193,15 @@ function sealValue(
     if (value.length === 0) return '';
     if (isEncryptedSecret(value)) {
       throw new InvalidIntegrationSecretError(`Secret field ${path.join('.')} must not contain ciphertext`);
+    }
+    // Fail closed rather than let encryptSecret drop the AAD and write v1.
+    if (!getActiveSecretEncryptionKeyId()) {
+      throw new IntegrationSecretsUnavailableError(
+        `Integration secret ${path.join('.')} cannot be stored: APP_ENCRYPTION_KEY_ID is not configured on this `
+          + 'API instance, so the credential would be sealed as non-AAD enc:v1 ciphertext with no binding to its '
+          + 'provider, organization or endpoint. Set APP_ENCRYPTION_KEY_ID (alongside APP_ENCRYPTION_KEY) and '
+          + 'restart the API.',
+      );
     }
     return encryptSecret(value, { aad: integrationSettingsSecretAad(family, orgId, path) });
   }
@@ -168,7 +234,10 @@ export function sealIntegrationSettings(
 }
 
 function maskValue(value: unknown, path: readonly string[]): unknown {
-  if (isSecretPath(path)) {
+  // Same leaf-vs-container split as sealValue. Returning a credential-NAMED
+  // container unchanged here would hand the caller the raw ciphertext of every
+  // secret inside it, so containers must fall through to the walk below.
+  if (isSecretPath(path) && !(value !== null && typeof value === 'object')) {
     return typeof value === 'string' && value.length > 0 ? INTEGRATION_MASKED_SECRET : value;
   }
   if (Array.isArray(value)) {

--- a/apps/web/src/components/integrations/MonitoringIntegration.test.tsx
+++ b/apps/web/src/components/integrations/MonitoringIntegration.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import MonitoringIntegration from "./MonitoringIntegration";
@@ -119,6 +119,40 @@ describe("MonitoringIntegration — token-capability gate (partner admin)", () =
         "/integrations/monitoring",
       ),
     );
+  });
+
+  it("adds a collision-free webhook id beside an existing masked endpoint", async () => {
+    fetchWithAuthMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: {
+          webhooks: {
+            enabled: true,
+            endpoints: [
+              { id: "wh-1", name: "Existing", url: "********", enabled: true },
+            ],
+          },
+        },
+      }),
+    } as Response);
+    render(<MonitoringIntegration />);
+
+    await screen.findByDisplayValue("Existing");
+    fireEvent.change(
+      screen.getByPlaceholderText("https://hooks.monitoring.io/breeze"),
+      { target: { value: "https://hooks.example.test/new" } },
+    );
+    fireEvent.click(screen.getByRole("button", { name: /add endpoint/i }));
+    fireEvent.click(screen.getByRole("button", { name: /save settings/i }));
+
+    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalledTimes(2));
+    const [, saveOptions] = fetchWithAuthMock.mock.calls[1] ?? [];
+    const saved = JSON.parse(String(saveOptions?.body));
+    expect(saved.webhooks.endpoints).toHaveLength(2);
+    expect(saved.webhooks.endpoints[0]).toMatchObject({ id: "wh-1", url: "********" });
+    expect(saved.webhooks.endpoints[1].id).toEqual(expect.any(String));
+    expect(saved.webhooks.endpoints[1].id).not.toBe("wh-1");
   });
 });
 

--- a/apps/web/src/components/integrations/MonitoringIntegration.tsx
+++ b/apps/web/src/components/integrations/MonitoringIntegration.tsx
@@ -63,11 +63,7 @@ type MonitoringSettings = {
 
 type ProviderKey = Exclude<keyof MonitoringSettings, "metrics">;
 
-let webhookIdCounter = 0;
-const createWebhookId = () => {
-  webhookIdCounter += 1;
-  return `wh-${webhookIdCounter}`;
-};
+const createWebhookId = () => crypto.randomUUID();
 
 type TestResult = {
   state: "idle" | "testing" | "success" | "error";

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -112,11 +112,16 @@ JWT_SECRET=
 # (apps/api/src/services/jwt.ts) and are intentionally not env-configurable.
 AGENT_ENROLLMENT_SECRET=
 APP_ENCRYPTION_KEY=
-# Optional key id enabling AAD-bound v3 ciphertext (vs v1 with no AAD binding).
-# Required (boot refuses to start without it) once M365_GRAPH_ACTIONS_TOOLS_ENABLED=true —
+# Key id enabling AAD-bound v3 ciphertext (vs v1 with no AAD binding).
+# REQUIRED IN PRODUCTION (boot refuses to start without it): integration provider
+# credentials (/integrations/{communication,monitoring,ticketing,psa}) are sealed
+# with v3 ciphertext bound to the provider, organization and field path, and fail
+# closed on v1 — without a key id every credential save returns 503.
+# Also required, in any environment, once M365_GRAPH_ACTIONS_TOOLS_ENABLED=true —
 # the m365_reset_password reveal-secret path seals its temp credential with v3
-# ciphertext and fails closed on v1. Any [A-Za-z0-9._-]+ identifier; changing
-# it does not itself rotate APP_ENCRYPTION_KEY.
+# ciphertext and fails closed on v1 — and when BREEZE_ROLE is "api" or "worker".
+# Any [A-Za-z0-9._-]+ identifier; changing it does not itself rotate
+# APP_ENCRYPTION_KEY.
 APP_ENCRYPTION_KEY_ID=
 MFA_ENCRYPTION_KEY=
 ENROLLMENT_KEY_PEPPER=

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -113,11 +113,14 @@ JWT_SECRET=
 AGENT_ENROLLMENT_SECRET=
 APP_ENCRYPTION_KEY=
 # Key id enabling AAD-bound v3 ciphertext (vs v1 with no AAD binding).
-# REQUIRED IN PRODUCTION (boot refuses to start without it): integration provider
-# credentials (/integrations/{communication,monitoring,ticketing,psa}) are sealed
-# with v3 ciphertext bound to the provider, organization and field path, and fail
-# closed on v1 — without a key id every credential save returns 503.
-# Also required, in any environment, once M365_GRAPH_ACTIONS_TOOLS_ENABLED=true —
+# Required for integration credential sealing; boot WARNS when unset (it does not
+# refuse). Integration provider credentials
+# (/integrations/{communication,monitoring,ticketing,psa}) are sealed with v3
+# ciphertext bound to the provider, organization and field path and fail closed
+# on v1, so saving one returns 503 until this is set. Everything else keeps
+# working, so an existing install without it stays up.
+# Required outright (boot refuses), in any environment, once
+# M365_GRAPH_ACTIONS_TOOLS_ENABLED=true —
 # the m365_reset_password reveal-secret path seals its temp credential with v3
 # ciphertext and fails closed on v1 — and when BREEZE_ROLE is "api" or "worker".
 # Any [A-Za-z0-9._-]+ identifier; changing it does not itself rotate


### PR DESCRIPTION
## Summary

**SEC-065 (Medium) — generic integration settings echoed credentials to lower-privileged readers, and webhook credential identity was unstable.**

The `/integrations` compatibility routes (`communication`, `monitoring`, `ticketing`, `psa`) stored arbitrary provider settings verbatim in four process-local maps and echoed them back on every read **and** on every write response. Writing those settings requires `organizations:write` + MFA; reading them requires only `organizations:read`. So any same-org actor holding the strictly weaker read permission could retrieve usable plaintext credentials — shipped fields include Discord `webhookUrl`, Teams `clientSecret`, Grafana / OpsGenie `apiKey`, PagerDuty `integrationKey`, monitoring `webhooks.endpoints[].url`, and the credential-shaped ticketing / PSA fields. The org resolver stopped cross-*org* access, but drew no line between a writer and a reader inside one org.

What this PR enforces:

- **Seal before store.** Credential-shaped keys are recognised recursively (`apiKey`, `clientSecret`, `password`, `token`, `privateKey`, `webhookUrl`, … plus `webhooks.endpoints[].url`) and encrypted with the existing AES-256-GCM `secretCrypto` service before anything is written to the map. Family, organization and structural path are passed as AAD.
- **Mask every projection.** GET and the write responses return the fixed marker `********` in place of any stored secret. Non-secret settings are returned unchanged.
- **Round-trip without leaking.** A `********` on write preserves *exactly* the stored ciphertext. A marker with nothing stored, a non-string secret value, or client-supplied ciphertext is rejected with `400` **before** the map write.
- **Durable webhook identity.** Webhook endpoint ciphertext is keyed to the endpoint's `id`, not to its array index, so reordering the endpoint list cannot re-attach one destination's secret to another destination. Duplicate ids in the request, or an ambiguous stored id, are rejected before write.
- **Server-derived ids.** The API assigns a `crypto.randomUUID()` id to any id-less endpoint *before* sealing and returns it alongside the masked projection, so a legacy endpoint can complete a masked round trip instead of being permanently unsaveable.
- **Web form stops echoing / colliding.** `MonitoringIntegration` generated endpoint ids from a module-level counter (`wh-1`, `wh-2`, …), which could re-emit an id already loaded from the server — now rejected as a duplicate by the API above. It now uses `crypto.randomUUID()`, matching the existing pattern in `PartnerRemoteAccessTab.tsx`, `DRPlanEditor.tsx` and 12 other web call sites. The form already round-trips the `********` marker rather than the secret.

Review round (commit 2) hardened two things the first pass got wrong:

- **No silent v1 fallback.** `encryptSecret` does not fail when `APP_ENCRYPTION_KEY_ID` is unset — it silently drops the `aad` option and writes non-AAD `enc:v1:`. `config/validate.ts` required the key id only for `BREEZE_ROLE=api|worker` and for `M365_GRAPH_ACTIONS_TOOLS_ENABLED=true`, so on the default role `all` (single-container prod, and every self-host) the family/org/path binding above would simply not have existed, with nothing to signal it. `sealIntegrationSettings` now asserts an active key id at the point of encryption and throws `IntegrationSecretsUnavailableError`; the routes map that to **503** naming `APP_ENCRYPTION_KEY_ID`, and nothing is stored. The assertion is lazy, so a settings blob containing no credential still saves. Boot additionally **warns** in production when the key id is missing (a warning, not a refusal — see Operator impact).
- **Credential names matched by part, not by exact name.** The original denylist enumerated 15 exact names and therefore missed `apiToken`, `signingSecret`, `sharedSecret`, `bearerToken`, `dsn` and `passphrase` — all of which these stores accept and would have echoed in plaintext. It now matches substrings mirroring `SUSPICIOUS_NAME_PARTS` in `tenantExportPolicy.ts`, with an explicit `NON_SECRET_FIELD_NAMES` allowlist for identifier/counter shapes. Part matching made a credential-shaped *name* ambiguous between a leaf secret and a container (`credentials` contains `credential`), so `sealValue` and `maskValue` now decide on the **value**: a string is sealed/masked, an object or array is walked as a container whose leaves are judged by their own names, any other scalar is still rejected. The `maskValue` half of that matters on its own — name-only matching returned a credential-named object *untouched*, which would have handed the reader the raw ciphertext of everything inside it.

Scope note: these four maps are process-local and volatile — restart loses them and replicas diverge. This PR closes the plaintext storage and response disclosure; it does **not** make the compatibility feature durable, and the `/test` endpoints still return canned success.

## Ported from

Local (never-pushed) remediation branch `fix/sec-065-secret-redaction`, four commits, cherry-picked with `-x` in order and squashed into one:

| SHA | Subject |
|---|---|
| `b3c2865d84ec60cc935f249b5b5323de511095cb` | `test(api): reproduce integration credential echoes` (red-first baseline) |
| `4408b1bddfa49f228cfd267c04d9019dcde7916f` | `fix(api): seal generic integration credentials` |
| `c59ceffa9e8bce0193162a242865a817fc358bb7` | `fix(api): preserve webhook secrets by endpoint identity` |
| `1876154725b391c0f405f1ed9f34febd8a8f33e5` | `fix(integrations): stabilize webhook credential identity` |

**Nothing was dropped or rewritten.** All four cherry-picks applied with zero conflicts: the five files they touch (`routes/integrations.ts`, `routes/integrations.test.ts`, `services/secretCrypto.ts`, `components/integrations/MonitoringIntegration.{tsx,test.tsx}`) are byte-identical between the original base `e595fde9ce` and current `main` — verified with `git diff e595fde9ce origin/main -- <paths>` returning empty for those paths. The squashed diff is 6 files / +536 / −21, matching the private remediation record's recorded diffstat exactly.

Commits 2 and 3 on this branch are not ports — they are the review response described above, plus its tests, the `config/validate.ts` warning and the `.env.example` documentation.

The terminal commit alone is not portable: it edits `services/integrationSettingsSecrets.ts`, a file that does not exist on `main` — it is created by `4408b1bd`. The four commits are one finding and land as one commit.

## Verification

All commands run in the worktree at the post-rebase head. Every count below is **verified** (observed output), not inferred.

**Red-first, pass A — whole fix reverted.** `git checkout origin/main -- apps/api/src/routes/integrations.ts apps/web/src/components/integrations/MonitoringIntegration.tsx && rm apps/api/src/services/integrationSettingsSecrets.ts`

- `cd apps/api && npx vitest run --pool=threads --maxWorkers=2 src/routes/integrations.test.ts src/services/integrationSettingsSecrets` → **2 files failed, 5 failed / 6 passed (11)**. The five: `never echoes Discord or Teams credentials…` (`expected … not to contain 'https://discord.example.test/api/webh…'`), `never echoes monitoring provider credentials…` (`not to contain 'grafana-private-api-key'`), `assigns an id before an id-less webhook is returned and accepts its masked resave`, `masks credential-shaped siblings in ticketing compatibility blobs` (`not to contain 'ticketing-private-password'`), `supports psa read/write/test compatibility` (`not to contain 'psa-private-api-secret'`). The service test file fails to load at all (`Cannot find module './integrationSettingsSecrets'`) — expected, the module is new.
- `cd apps/web && npx vitest run src/components/integrations/MonitoringIntegration.test.tsx` → **1 failed / 5 passed (6)**: `adds a collision-free webhook id beside an existing masked endpoint` — `expected 'wh-1' not to be 'wh-1'`, with React additionally warning `Encountered two children with the same key, 'wh-1'`.

**Red-first, pass B — only the endpoint-identity logic reverted** (service file replaced with its index-keyed version from `4408b1bd`, everything else at HEAD), to prove the identity tests discriminate the identity fix specifically and not just the sealing:

- `cd apps/api && npx vitest run --pool=threads --maxWorkers=2 src/services/integrationSettingsSecrets src/routes/integrations.test.ts` → **3 failed / 16 passed (19)**: `preserves webhook ciphertext by endpoint id when endpoints are reordered`, `assigns a durable id to an id-less webhook before its masked round trip`, `assigns an id before an id-less webhook is returned and accepts its masked resave`.

**Green at HEAD** (`git checkout HEAD -- <src files>`; `git status` clean):

| Gate | Command | Result |
|---|---|---|
| API unit | `cd apps/api && npx vitest run --pool=threads --maxWorkers=2 src/services/integrationSettingsSecrets src/routes/integrations src/services/secretCrypto` | **3 files, 54/54 passed** |
| API unit (sibling route) | `… npx vitest run --pool=threads --maxWorkers=2 src/routes/integrationConnectionScope.test.ts` | **1 file, 93/93 passed** |
| Web unit | `cd apps/web && npx vitest run src/components/integrations` | **19 files, 277/277 passed** |
| Integration | `cd apps/api && npx vitest run --config vitest.integration.config.ts --pool=threads --maxWorkers=2 webhook` (+ ephemeral pg/redis via `pnpm test-stack up`) | **4 files, 15/15 passed** |
| Contract | `cd apps/api && npx vitest run --config vitest.config.integration-suite-coverage.ts` | **1 file, 5/5 passed** |
| Contract | `cd apps/api && npx vitest run --config vitest.config.site-scope-coverage.ts` | **1 file, 7/7 passed** |
| Typecheck | `cd apps/api && NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit` | **exit 0** |
| Typecheck | `cd apps/web && NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit` | **exit 0** |
| Lint | `cd apps/api && npx eslint src/routes/integrations{,.test}.ts src/services/integrationSettingsSecrets{,.test}.ts` | **exit 0** |
| Lint | `cd apps/web && npx eslint src/components/integrations/MonitoringIntegration.{tsx,test.tsx}` | **exit 0** |

API unit and web unit gates were re-run after rebasing onto current `main` (`2f6986fb75`) and still report 54/54 and 277/277 — **verified**.

### Round 2 (review fixes)

Red-first here is **surgical** — reverting the whole commit would leave the new test files importing symbols that do not exist, and an undefined import throws a `TypeError` rather than discriminating behaviour. Each control was disabled individually on top of `HEAD` instead, so every red below is a real assertion failure:

- **Key-id assertion** disabled (`if (false && !getActiveSecretEncryptionKeyId())`), everything else at HEAD → `cd apps/api && npx vitest run --pool=threads --maxWorkers=2 src/services/integrationSettingsSecrets src/routes/integrations.test.ts` → **2 failed / 57 passed (59)**, exactly the two intended: `refuses to seal a credential when no active encryption key id is configured` (`expected function to throw an error, but it didn't`) and `refuses the write with 503 when no active encryption key id is configured` (`expected 200 to be 503`).
- **Part matcher** reverted to the old 15 exact names, export kept → **8 failed / 39 passed (47)**: the six missed names (`apiToken`, `signingSecret`, `sharedSecret`, `bearerToken`, `dsn`, `passphrase`) plus the credential-container and allowlist tests. All 15 `still treats … as a credential` and all 13 `does not treat … as a credential` cases stayed green, so the change is additive, not a re-shuffle.
- **v1-degradation probe** — assertion disabled *and* the suite's key id removed → `seals with AAD-bound v3 ciphertext, never the non-AAD v1 fallback` fails with `expected 'enc:v1:D7owPVqkZ4R3tCM1.…' to match /^enc:v3:integration-settings-test:/`. That is the finding reproduced directly: the code really does emit unbound v1 in that configuration.
- **Config warning** disabled (`if (false && !(env.APP_ENCRYPTION_KEY_ID ?? '').trim())`) → `warns (but does not refuse boot) when APP_ENCRYPTION_KEY_ID is unset in production` fails with `expected "warn" to be called with arguments: [ StringContaining{…} ]`, **1 failed / 377 passed (378)**.

Green at the new head (`a00a45a945`): API `src/config/ src/services/integrationSettingsSecrets src/routes/integrations src/services/secretCrypto src/worker.boot.test.ts src/services/ipAllowlist` → **31 files, 799/799 passed** (the config-adjacent suites are included because the new production rule could have tripped any test that boots a production config; none did). Web `src/components/integrations` → **19 files, 277/277**. Integration `webhook` family → **4 files, 15/15**. `integration-suite-coverage` → **5/5**. `site-scope-coverage` → **7/7**. api + web `tsc --noEmit` → exit 0. eslint on all six touched API files → exit 0.

**Not checked:** no migration, schema column, RLS policy or cascade list is touched by this change, so the DB contract suites (`rls-coverage`, `tenant-export-policy`, `tenantCascade`, `tenantExportErasureRoundtrip`, `autoMigrate`, `migrationRlsScope`) were not run. No production, provider, browser-E2E or multi-replica testing was performed or is claimed. The full API corpus was not re-run here; the focused selections above are the evidence.

## Operator impact

- **Response-contract change.** `GET`/`PUT`/`POST` on `/integrations/{communication,monitoring,ticketing,psa}` now return `********` where a credential-shaped value used to be returned in plaintext. The shipped web client already preserves the marker; any **external** API client that reads these endpoints expecting plaintext, or that blindly replaces the masked field, needs inventorying before rollout.
- **`APP_ENCRYPTION_KEY_ID` is needed for integration credential sealing, but boot only WARNS when it is unset — nothing is bricked.** An earlier revision of this PR made it a production boot refusal; that was withdrawn. `scripts/guided-setup.sh` generates `APP_ENCRYPTION_KEY` but has never generated `APP_ENCRYPTION_KEY_ID`, so a refusal would have taken down every existing self-hosted upgrade and every fresh guided install for the sake of one small, optional route family. Instead:
  - **Fresh guided installs and existing self-hosts without the key keep booting normally.** Everything except integration credential storage is unaffected.
  - Saving a credential on `/integrations/{communication,monitoring,ticketing,psa}` returns **503** with a message naming `APP_ENCRYPTION_KEY_ID` until the operator sets it. Credentials fail closed rather than degrading to unbound `enc:v1` — that is the actual security control, and it is unchanged.
  - Production boot logs a warning saying exactly that, in the same place and for the same reason as the adjacent `TRUST_CF_CONNECTING_IP` warning ("hard-failing would break legitimate non-Cloudflare self-hosters").
  - A follow-up is being filed for `guided-setup.sh` to generate the key id.
  - Both hosted droplets already have it set (checked). It must live in `/opt/breeze/.env` **and** be mapped in the `api` service's `environment:` block — compose only interpolates variables it lists, the #570 gap class.
  - Note for anyone setting it for the first time: it also switches every *other* `encryptSecret` caller from `enc:v1:` to `enc:v2:`/`enc:v3:` for new writes. Existing v1 ciphertext still decrypts through the legacy path, so it is forward-compatible, but it is a fleet-wide crypto-format change — set it deliberately rather than discover it at deploy time.
  - The two pre-existing hard requirements are untouched: `BREEZE_ROLE=api|worker` and `M365_GRAPH_ACTIONS_TOOLS_ENABLED=true` still refuse boot without the key id.
- **New user-visible failure mode: `400` on a stale tab.** The four stores are per-process `Map`s. A form loaded before an API restart — or against a different replica — holds `********` for a secret the new process has never stored, and resaving it now returns `400` naming the field instead of silently writing the literal mask. Reloading the page clears it. This is inherent to sealing a volatile store and is the correct failure, but support should recognise it.
- **`prometheus.endpointUrl` and `grafana.url` are deliberately NOT treated as secret.** They are operator-visible endpoint identity, shown in the form and useful for diagnosis; masking them would hide which target is configured. The residual is that an operator who embeds basic-auth userinfo in one (`https://user:pass@host`) leaks it to a read-only viewer. If that shape turns out to be real in the field, the fix is to add `endpointurl` and the webhook-style path rule for `url` under those providers — not to mask every URL.
- **Roll API and web together.** An older web build using the `wh-N` counter can emit an endpoint id that collides with one already stored, which the new API rejects with `400`. New web + old API is harmless.
- **Webhook endpoint ids are now durable and server-assigned.** Previously-id-less endpoints receive a UUID on their next save.
- **No data migration.** The four stores are process-local and volatile, so a restart already clears any historical plaintext; there is no persistent row to migrate or inventory, and historical exposure cannot be reconstructed from them. Rotate integration credentials only if deployment or log evidence establishes actual exposure — no such evidence was used here.
- **AAD caveat, stated precisely.** Deployments with an active key id produce v3 AAD-bound envelopes. Legacy v1 encryption still encrypts but does not authenticate the AAD — this PR inherits the existing incremental crypto rollout and does not claim to complete it.
- **Rollback reopens the plaintext echo** on subsequent writes and is not an acceptable steady state; prefer a corrected roll-forward.
- Secret recognition is an explicit set of known credential-shaped key names plus monitoring webhook URLs, not a typed provider manifest. A future provider that names its credential something else needs to be added to `SECRET_FIELD_NAMES` with a regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Tugfg88kFiowD7E5xQFpU
