### PR TITLE
fix(patching): bind Windows update installs to device-observed updates on both agent and API (SEC-115)

### DIFF
--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -6577,6 +6577,21 @@ func (h *Heartbeat) resolvePatchInstallID(ref patchCommandRef) (string, error) {
 	if provider, local, ok := splitPatchID(ref.ID); ok && h.patchMgr.HasProvider(provider) {
 		return provider + ":" + local, nil
 	}
+	// Windows Update identities are device-observed: externalID is what THIS
+	// endpoint's own scan reported — the KB article when Windows exposes one,
+	// and the raw WUA UpdateID when it does not (driver and feature updates
+	// carry no KBArticleIDs). packageID is global catalog metadata that the API
+	// fills once and never rewrites, so it can carry a selector written by a
+	// different device, in a different tenant, for a different revision. Resolve
+	// the observed identity and fall back to packageID only when this device
+	// reported no external identity at all. WUA findUpdate matches both an exact
+	// UpdateID and a KB article against this device's currently applicable
+	// updates, so either form resolves against what is installable here.
+	if strings.EqualFold(strings.TrimSpace(ref.Source), "microsoft") && h.patchMgr.HasProvider("windows-update") {
+		if local := windowsUpdateLocalID(ref.ExternalID); local != "" {
+			return "windows-update:" + local, nil
+		}
+	}
 	if provider, local, ok := splitPatchID(ref.ExternalID); ok {
 		switch provider {
 		case "microsoft", "apple", "linux", "third_party", "custom":
@@ -6608,6 +6623,50 @@ func (h *Heartbeat) resolvePatchInstallID(ref patchCommandRef) (string, error) {
 	}
 
 	return providerID + ":" + localID, nil
+}
+
+// windowsUpdateLocalID normalizes the device-observed Windows Update selector
+// carried in a patch ref's externalID. It returns "" when externalID is empty
+// or is qualified for some other provider (e.g. "chocolatey:googlechrome") so
+// that those refs keep their existing provider routing below.
+func windowsUpdateLocalID(externalID string) string {
+	value := strings.TrimSpace(externalID)
+	if value == "" {
+		return ""
+	}
+	if provider, local, ok := splitPatchID(value); ok {
+		switch strings.ToLower(strings.TrimSpace(provider)) {
+		case "microsoft", "windows-update":
+			// A three-part "source:local:extra" externalID keeps only the local
+			// identity, matching patchLocalID's existing handling of that shape.
+			value = strings.TrimSpace(local)
+			if head, _, found := strings.Cut(value, ":"); found {
+				value = strings.TrimSpace(head)
+			}
+		default:
+			return ""
+		}
+	}
+	if value == "" {
+		return ""
+	}
+	if isWindowsKBID(value) {
+		return strings.ToUpper(value)
+	}
+	return value
+}
+
+func isWindowsKBID(value string) bool {
+	value = strings.ToUpper(strings.TrimSpace(value))
+	if !strings.HasPrefix(value, "KB") || len(value) == 2 {
+		return false
+	}
+	for _, r := range value[2:] {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 func (h *Heartbeat) providerForPatchRef(ref patchCommandRef) string {

--- a/agent/internal/heartbeat/heartbeat_patch_test.go
+++ b/agent/internal/heartbeat/heartbeat_patch_test.go
@@ -110,6 +110,113 @@ func TestResolvePatchInstallIDUsesPackageIDForVersionedLinuxExternalID(t *testin
 	}
 }
 
+// A Windows Update install must be selected by the identity THIS device
+// observed (patchCommandRef.ExternalID), never by the globally deduplicated
+// catalog selector (patchCommandRef.PackageID), which the API fills once from
+// whichever device created the row first — possibly in another tenant.
+//
+// Cases marked "discriminator" fail against the unfixed resolver, which took
+// PackageID first via patchLocalID. Cases marked "over-reach guard" already
+// passed before the fix; they are here to prove the new Windows-Update branch
+// does not capture refs that belong to another provider or shape.
+func TestResolvePatchInstallIDUsesDeviceObservedKBForWindowsUpdate(t *testing.T) {
+	tests := []struct {
+		name       string
+		providers  []string
+		externalID string
+		packageID  string
+		want       string
+	}{
+		{
+			// discriminator
+			name:       "global selector from another device cannot override KB",
+			externalID: "KB5034441",
+			packageID:  "windows-update:aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+			want:       "windows-update:KB5034441",
+		},
+		{
+			// discriminator: driver and feature updates expose no KBArticleIDs,
+			// so the agent reports the raw WUA UpdateID as externalId. The KB
+			// guard does not fire for those, and the poisoned catalog selector
+			// used to win.
+			name:       "KB-less driver update resolves the observed UpdateID, not the catalog selector",
+			externalID: "aaaaaaaa-1111-2222-3333-444444444444",
+			packageID:  "windows-update:99999999-9999-9999-9999-999999999999",
+			want:       "windows-update:aaaaaaaa-1111-2222-3333-444444444444",
+		},
+		{
+			// discriminator: a source-qualified externalId is still the
+			// device-observed identity.
+			name:       "source-qualified KB is not diverted by the catalog selector",
+			externalID: "microsoft:KB5034441",
+			packageID:  "windows-update:aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+			want:       "windows-update:KB5034441",
+		},
+		{
+			// over-reach guard (passed before the fix too)
+			name:       "qualified update without KB remains exact",
+			externalID: "windows-update:11111111-2222-3333-4444-555555555555",
+			packageID:  "windows-update:11111111-2222-3333-4444-555555555555",
+			want:       "windows-update:11111111-2222-3333-4444-555555555555",
+		},
+		{
+			// over-reach guard: a Microsoft-source row whose external identity
+			// is qualified for a real, present package manager must keep its
+			// own provider routing.
+			name:       "externalId qualified for another provider keeps that provider",
+			providers:  []string{"windows-update", "chocolatey"},
+			externalID: "chocolatey:googlechrome",
+			packageID:  "chocolatey:googlechrome",
+			want:       "chocolatey:googlechrome",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			providerIDs := tt.providers
+			if providerIDs == nil {
+				providerIDs = []string{"windows-update"}
+			}
+			providers := make([]patching.PatchProvider, 0, len(providerIDs))
+			for _, id := range providerIDs {
+				providers = append(providers, &heartbeatMockProvider{id: id})
+			}
+
+			h := &Heartbeat{patchMgr: patching.NewPatchManager(providers...)}
+			installID, err := h.resolvePatchInstallID(patchCommandRef{
+				ID:         "platform-patch-id",
+				Source:     "microsoft",
+				ExternalID: tt.externalID,
+				PackageID:  tt.packageID,
+			})
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if installID != tt.want {
+				t.Fatalf("installID = %q, want %q", installID, tt.want)
+			}
+		})
+	}
+}
+
+// The device-observed identity is preferred, but it is not mandatory: a ref
+// with no externalId at all must still fall back to the catalog selector
+// rather than producing an unresolvable install id.
+func TestResolvePatchInstallIDFallsBackToPackageIDWhenNoObservedIdentity(t *testing.T) {
+	h := &Heartbeat{patchMgr: patching.NewPatchManager(&heartbeatMockProvider{id: "windows-update"})}
+	installID, err := h.resolvePatchInstallID(patchCommandRef{
+		ID:        "platform-patch-id",
+		Source:    "microsoft",
+		PackageID: "windows-update:11111111-2222-3333-4444-555555555555",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if installID != "windows-update:11111111-2222-3333-4444-555555555555" {
+		t.Fatalf("installID = %q, want windows-update:11111111-2222-3333-4444-555555555555", installID)
+	}
+}
+
 func TestExecutePatchInstallCommandReportsPartialFailures(t *testing.T) {
 	provider := &heartbeatMockProvider{id: "apt"}
 	h := &Heartbeat{patchMgr: patching.NewPatchManager(provider)}

--- a/apps/api/src/routes/agents/patches.ts
+++ b/apps/api/src/routes/agents/patches.ts
@@ -50,9 +50,11 @@ function logRejections(agentId: string, kind: string, admission: PatchAdmission<
  *   are only hardened against *null downgrades* — a scan that omits a field must
  *   not blank a value an earlier scan established.
  * - **Identity-bearing** (`title`, `vendor`, `package_id`, `version`): these say
- *   *what the row is* and, for `package_id`, what actually gets installed
- *   (`routes/devices/patches.ts` forwards it into the `install_patches` command
- *   payload). Raw agent strings may only **fill** them, never rewrite them;
+ *   *what the row is*. `package_id` is forwarded for package managers whose
+ *   external identity is already provider-qualified. For KB-bearing Microsoft
+ *   rows it is display/catalog metadata only: manual dispatch deliberately
+ *   drops this global first-writer value and WUA resolves the endpoint-observed
+ *   KB instead. Raw agent strings may only **fill** these columns, never rewrite them;
  *   overwriting is reserved for server-side catalog enrichment.
  * - **Authoritative-only** (`severity`): agent scans may fill or *raise* it and
  *   nothing else. See `raiseOnlySeverity`.

--- a/apps/api/src/routes/devices/patches.test.ts
+++ b/apps/api/src/routes/devices/patches.test.ts
@@ -105,6 +105,7 @@ vi.mock('../../services/commandQueue', () => ({
 }));
 
 import { db } from '../../db';
+import { devicePatches, patches } from '../../db/schema';
 import { getDeviceWithOrgAndSiteCheck } from './helpers';
 import { queueCommandForExecution } from '../../services/commandQueue';
 import { resolvePartnerIdForOrg } from '../patches/helpers';
@@ -112,6 +113,9 @@ import { resolvePartnerIdForOrg } from '../patches/helpers';
 function selectWhereResult(rows: unknown[]) {
   return {
     from: vi.fn().mockReturnValue({
+      innerJoin: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(rows)
+      }),
       where: vi.fn().mockResolvedValue(rows)
     })
   };
@@ -537,6 +541,158 @@ describe('device patch routes', () => {
           externalId: 'apt:openssl@3.0.2-0ubuntu1.20',
           packageId: 'apt:openssl',
           title: 'OpenSSL'
+        }]
+      },
+      { userId: USER_ID, preferHeartbeat: false }
+    );
+  });
+
+  it('uses the device-observed KB selector instead of a global first-writer WUA UpdateID', async () => {
+    vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue({ id: DEVICE_ID, orgId: '11111111-1111-1111-1111-111111111111' } as any);
+    const observationWhere = vi.fn().mockResolvedValue([
+      {
+        id: PATCH_ID,
+        source: 'microsoft',
+        externalId: 'KB5034441',
+        packageId: 'windows-update:aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+        title: 'Windows Security Update'
+      }
+    ]);
+    const observationInnerJoin = vi.fn().mockReturnValue({ where: observationWhere });
+    // The direct `where` member keeps this boundary test runnable against the
+    // vulnerable baseline, where the query started from the global catalog.
+    const observationFrom = vi.fn().mockReturnValue({
+      innerJoin: observationInnerJoin,
+      where: observationWhere
+    });
+    vi.mocked(db.select)
+      .mockReturnValueOnce({ from: observationFrom } as any)
+      .mockReturnValueOnce(selectWhereResult([{ patchId: PATCH_ID }]) as any);
+    vi.mocked(queueCommandForExecution).mockResolvedValue({
+      command: { id: 'cmd-install-kb', status: 'sent' }
+    } as any);
+
+    const res = await app.request(`/devices/${DEVICE_ID}/patches/install`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ patchIds: [PATCH_ID] })
+    });
+
+    expect(res.status).toBe(200);
+    expect(observationFrom).toHaveBeenCalledWith(devicePatches);
+    expect(observationInnerJoin).toHaveBeenCalledWith(patches, expect.anything());
+    expect(JSON.stringify(observationWhere.mock.calls[0]?.[0])).toContain(DEVICE_ID);
+    expect(JSON.stringify(observationWhere.mock.calls[0]?.[0])).toContain('pending');
+    expect(JSON.stringify(observationWhere.mock.calls[0]?.[0])).toContain(PATCH_ID);
+    expect(queueCommandForExecution).toHaveBeenCalledWith(
+      DEVICE_ID,
+      'install_patches',
+      {
+        patchIds: [PATCH_ID],
+        patches: [{
+          id: PATCH_ID,
+          source: 'microsoft',
+          externalId: 'KB5034441',
+          packageId: null,
+          title: 'Windows Security Update'
+        }]
+      },
+      { userId: USER_ID, preferHeartbeat: false }
+    );
+  });
+
+  it('drops the global selector for a KB-less Microsoft update (driver/feature rows)', async () => {
+    // Driver and feature updates expose no KBArticleIDs, so the agent reports
+    // the raw WUA UpdateID as externalId. Those rows are deduplicated globally
+    // on (source, externalId) exactly like KB rows, and `packageId` is still
+    // first-writer catalog metadata, so it must be dropped here too.
+    vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue({ id: DEVICE_ID, orgId: '11111111-1111-1111-1111-111111111111' } as any);
+    const observationWhere = vi.fn().mockResolvedValue([
+      {
+        id: PATCH_ID,
+        source: 'microsoft',
+        externalId: 'aaaaaaaa-1111-2222-3333-444444444444',
+        packageId: 'windows-update:99999999-9999-9999-9999-999999999999',
+        title: 'Intel Corporation - Display - 31.0.101.5186'
+      }
+    ]);
+    const observationFrom = vi.fn().mockReturnValue({
+      innerJoin: vi.fn().mockReturnValue({ where: observationWhere }),
+      where: observationWhere
+    });
+    vi.mocked(db.select)
+      .mockReturnValueOnce({ from: observationFrom } as any)
+      .mockReturnValueOnce(selectWhereResult([{ patchId: PATCH_ID }]) as any);
+    vi.mocked(queueCommandForExecution).mockResolvedValue({
+      command: { id: 'cmd-install-driver', status: 'sent' }
+    } as any);
+
+    const res = await app.request(`/devices/${DEVICE_ID}/patches/install`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ patchIds: [PATCH_ID] })
+    });
+
+    expect(res.status).toBe(200);
+    expect(queueCommandForExecution).toHaveBeenCalledWith(
+      DEVICE_ID,
+      'install_patches',
+      {
+        patchIds: [PATCH_ID],
+        patches: [{
+          id: PATCH_ID,
+          source: 'microsoft',
+          externalId: 'aaaaaaaa-1111-2222-3333-444444444444',
+          packageId: null,
+          title: 'Intel Corporation - Display - 31.0.101.5186'
+        }]
+      },
+      { userId: USER_ID, preferHeartbeat: false }
+    );
+  });
+
+  it('keeps the package selector for non-Microsoft sources', async () => {
+    // Over-reach guard: for real package managers the packageId IS the install
+    // selector and must survive untouched.
+    vi.mocked(getDeviceWithOrgAndSiteCheck).mockResolvedValue({ id: DEVICE_ID, orgId: '11111111-1111-1111-1111-111111111111' } as any);
+    const observationWhere = vi.fn().mockResolvedValue([
+      {
+        id: PATCH_ID,
+        source: 'third_party',
+        externalId: 'winget:Google.Chrome',
+        packageId: 'winget:Google.Chrome',
+        title: 'Google Chrome'
+      }
+    ]);
+    const observationFrom = vi.fn().mockReturnValue({
+      innerJoin: vi.fn().mockReturnValue({ where: observationWhere }),
+      where: observationWhere
+    });
+    vi.mocked(db.select)
+      .mockReturnValueOnce({ from: observationFrom } as any)
+      .mockReturnValueOnce(selectWhereResult([{ patchId: PATCH_ID }]) as any);
+    vi.mocked(queueCommandForExecution).mockResolvedValue({
+      command: { id: 'cmd-install-winget', status: 'sent' }
+    } as any);
+
+    const res = await app.request(`/devices/${DEVICE_ID}/patches/install`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ patchIds: [PATCH_ID] })
+    });
+
+    expect(res.status).toBe(200);
+    expect(queueCommandForExecution).toHaveBeenCalledWith(
+      DEVICE_ID,
+      'install_patches',
+      {
+        patchIds: [PATCH_ID],
+        patches: [{
+          id: PATCH_ID,
+          source: 'third_party',
+          externalId: 'winget:Google.Chrome',
+          packageId: 'winget:Google.Chrome',
+          title: 'Google Chrome'
         }]
       },
       { userId: USER_ID, preferHeartbeat: false }

--- a/apps/api/src/routes/devices/patches.ts
+++ b/apps/api/src/routes/devices/patches.ts
@@ -509,7 +509,7 @@ patchesRoutes.post(
       return c.json({ error: 'Device not found' }, 404);
     }
 
-    const patchRefs = await db
+    const observedPatchRefs = await db
       .select({
         id: patches.id,
         source: patches.source,
@@ -517,8 +517,27 @@ patchesRoutes.post(
         packageId: patches.packageId,
         title: patches.title
       })
-      .from(patches)
-      .where(inArray(patches.id, data.patchIds));
+      .from(devicePatches)
+      .innerJoin(patches, eq(devicePatches.patchId, patches.id))
+      .where(and(
+        eq(devicePatches.deviceId, deviceId),
+        eq(devicePatches.status, 'pending'),
+        inArray(patches.id, data.patchIds)
+      ));
+
+    // `patches.externalId` is the device-observed Windows Update identity: the
+    // agent reports the KB article when Windows exposes one and the raw WUA
+    // UpdateID otherwise (driver and feature updates carry no KBArticleIDs).
+    // `patches.packageId` is global catalog metadata — ingest fills it once
+    // (`fillIfNull`) and never rewrites it — so it can hold a selector supplied
+    // by whichever device created the row first, in any tenant. It must never
+    // choose the update installed on THIS device, whether or not the row is
+    // KB-bearing. Omitting it is also safe for older agents: with no packageId
+    // their existing fallback resolves the observed externalId through WUA,
+    // which matches both a KB article and an exact UpdateID.
+    const patchRefs = observedPatchRefs.map((patch) =>
+      patch.source === 'microsoft' ? { ...patch, packageId: null } : patch
+    );
 
     if (patchRefs.length === 0) {
       return c.json({ error: 'No matching patches found' }, 404);


### PR DESCRIPTION
## Summary

A manual Windows patch install could be pointed at an update the target device never advertised.

`patches` rows are globally deduplicated on `(source, external_id)`, and ingest fills `patches.package_id` exactly once (`fillIfNull`, `routes/agents/patches.ts:244`) and **never rewrites it**. That column therefore holds whatever selector the device that created the row supplied *first* — possibly a device in a different tenant, or a different revision. `POST /devices/:id/patches/install` read the catalog row **by patch id alone**, with no reference to what the target device had observed, and forwarded that shared `package_id` into the `install_patches` command payload. On the endpoint, the agent's resolver preferred `packageId` (via `patchLocalID`, which checks it first) over the identity the device itself had reported, so the shared first-writer selector chose the update WUA installed.

This applies to **every** Microsoft row, not only KB-bearing ones. The agent reports `externalId = KBNumber || UpdateID` and `packageId = UpdateID` (`heartbeat.go:3422`, `:3481`); driver (`Type == 2`) and feature (`BrowseOnly`) updates expose no `KBArticleIDs`, so those rows are keyed by their raw UpdateID and a KB-shaped guard never fires for them.

The fix closes both halves of the boundary independently, so neither side is load-bearing alone:

- **API — `apps/api/src/routes/devices/patches.ts`.** The manual-install selection now starts at `device_patches` and inner-joins the catalog row, requiring an exact match on the target `device_id` and a `pending` observation before approval evaluation or command creation. A patch the device has not currently reported now falls out as "not found" rather than being dispatched. It then drops the global `package_id` from the command reference for **every `source = 'microsoft'` row**, KB-bearing or not. Provider-qualified identities (apt, yum, winget, homebrew, chocolatey, …) are untouched — for those, `package_id` genuinely *is* the install selector.
- **Agent — `agent/internal/heartbeat/heartbeat.go`.** `resolvePatchInstallID` resolves a Windows Update ref from the device-observed `externalId` — a KB article or a raw UpdateID, normalised by the new `windowsUpdateLocalID` — *before* it will consider `packageId`, and falls back to `packageId` only when the device reported no external identity at all. WUA's `findUpdate` (`internal/patching/windows.go:487`) matches **both** an exact `UpdateID` and a `KB`-prefixed selector against the endpoint's own `IsInstalled=0` collection, so either observed form resolves against what is actually installable here. Refs qualified for another *present* provider (e.g. `chocolatey:googlechrome`) keep their existing routing.
- **Ingest — `apps/api/src/routes/agents/patches.ts`.** Behaviour deliberately unchanged. Global catalog dedup and first-fill metadata semantics are correct; only the doc comment is corrected, since it previously described `package_id` as "what actually gets installed" — exactly the assumption this change removes.

No schema, migration, queue shape or agent command version change.

`pending` is the right gate: agent scan ingestion only ever writes `pending`, `installed` or `missing` (`routes/agents/patches.ts:168,197,297,305,435,443`), and `missing` is an explicit tombstone from a prior scan (see `OUTSTANDING_DEVICE_PATCH_STATUSES` in `db/schema/patches.ts`). All **three** web callers already source install ids exclusively from the `pending` bucket — `DevicePatchStatusTab.tsx` (two call sites) and `useBulkActions.ts` via `PatchComplianceView.tsx:216` — so no operator-visible install flow loses a target. The sibling execution path `services/vulnerabilityRemediation.ts:146-149` already used the same `device_patches … status = 'pending'` join; this brings the manual path in line with it.

### Sibling sinks audited (no second vulnerable path)

- **Scheduled patch execution** (`services/patchApprovalEvaluator.ts:373`) already resolves approved *current device observations* via `OUTSTANDING_DEVICE_PATCH_STATUSES` and does not forward the global `package_id`.
- **Vulnerability remediation** (`services/vulnerabilityRemediation.ts`) selects a current pending `device_patches` row for the exact device and sends only the patch id.

Both were left unmodified.

## Ported from

Single local commit `52d8d6c1b6cf7ee118b6d4f57296d1d08881ce1f` ("fix(patching): bind Windows update installs to device observations", 5 files / +144 / −6), authored against a base ~200 commits behind current `main`.

- Cherry-picked with `git cherry-pick -x`; it applied cleanly (one auto-merge in `heartbeat.go`) and was rebased onto `main` at `2f6986fb75`. Nothing from the original was dropped.
- **Extended during review**, because the original guards were KB-shaped and missed KB-less Microsoft rows: the API regex `source === 'microsoft' && /^KB\d+$/i` became a plain `source === 'microsoft'`, and the agent's `isWindowsKBID`-only branch became the externalId-first `windowsUpdateLocalID` path described above. Three new discriminating test cases were added (two Go, one API) plus three over-reach guards.
- Considered and rejected: replacing the literal `eq(devicePatches.status, 'pending')` with the `OUTSTANDING_DEVICE_PATCH_STATUSES` constant. The constant is `['pending']` today, so it is behaviourally identical, but the adjacent execution sibling (`vulnerabilityRemediation.ts`) uses the literal on the same join, and matching the sibling keeps the two execution paths visibly in step.
- The commit message was rewritten for a public audience; the private cherry-pick trailer was removed.

## Verification

All commands run in this worktree at head `5f14973c9d` (rebased onto `main` `2f6986fb75`). Every count below is **verified** — observed output, not inferred.

### Red-first

Mutations were applied to the *committed* fix and then reverted; the working tree is clean. Two baselines are shown: `origin/main` (the shipped vulnerable state) and the KB-only intermediate (to prove the review extension is not decorative).

**vs `origin/main` — API, both route sources restored:**
```sh
git checkout origin/main -- apps/api/src/routes/devices/patches.ts apps/api/src/routes/agents/patches.ts
cd apps/api && npx vitest run --pool=threads --maxWorkers=2 src/routes/devices/patches.test.ts \
  -t 'uses the device-observed KB selector instead of a global first-writer WUA UpdateID'
# => 1 failed | 15 skipped
#    expect(observationFrom).toHaveBeenCalledWith(devicePatches) — received the `patches` catalog table,
#    i.e. the query never consulted the device observation
```

**vs `origin/main` — API, second independent mutation.** Fixed file kept, *only* the `packageId` transform removed (`const patchRefs = observedPatchRefs;`):
```sh
# => 1 failed | 15 skipped; failure moves to expect(queueCommandForExecution) —
#    the poisoned packageId reached the command payload
```

**vs `origin/main` — agent:**
```sh
git checkout origin/main -- agent/internal/heartbeat/heartbeat.go
cd agent && go test -race ./internal/heartbeat -run TestResolvePatchInstallIDUsesDeviceObservedKBForWindowsUpdate
# => FAIL, 3 of 5 subtests:
#   global_selector_from_another_device_cannot_override_KB
#     installID = "windows-update:aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", want "windows-update:KB5034441"
#   KB-less_driver_update_resolves_the_observed_UpdateID,_not_the_catalog_selector
#     installID = "windows-update:99999999-…", want "windows-update:aaaaaaaa-1111-2222-3333-444444444444"
#   source-qualified_KB_is_not_diverted_by_the_catalog_selector
#     installID = "windows-update:aaaaaaaa-bbbb-…", want "windows-update:KB5034441"
```
Those failure strings *are* the vulnerability: the unpatched resolver installs the supplied global selector.

**vs the KB-only intermediate** (proves the review extension discriminates):
```sh
git checkout HEAD~1 -- apps/api/src/routes/devices/patches.ts   # KB regex version
# -t 'drops the global selector for a KB-less Microsoft update'
# => 1 failed | 17 skipped
#    -  "packageId": null
#    +  "packageId": "windows-update:99999999-9999-9999-9999-999999999999"

git checkout HEAD~1 -- agent/internal/heartbeat/heartbeat.go    # isWindowsKBID-only branch
# => FAIL on exactly the two new discriminating subtests; the three over-reach guards stayed green
```

The two subtests labelled **over-reach guard** in the Go table (`qualified update without KB remains exact`, `externalId qualified for another provider keeps that provider`), the API `keeps the package selector for non-Microsoft sources` case, and `TestResolvePatchInstallIDFallsBackToPackageIDWhenNoObservedIdentity` pass on the unfixed code as well. They are **not discriminators** — they exist to prove the new branch does not capture refs belonging to another provider or shape, and the test table says so inline.

Restored with `git checkout HEAD -- <files>`; all suites green again below.

### Green

API (`cd apps/api`):
```sh
npx vitest run --pool=threads --maxWorkers=2 src/routes/devices/patches src/routes/agents/patches src/routes/patches
# => 7 files, 126 passed (126)

npx vitest run --pool=threads --maxWorkers=2 src/jobs/patchJobExecutor.test.ts \
  src/services/vulnerabilityRemediation.test.ts src/services/patchApprovalEvaluator.test.ts
# => 3 files, 207 passed (207)   [the audited sibling sinks]

npx vitest run --config vitest.integration.config.ts --pool=threads --maxWorkers=2 patch Patch
# => 14 files, 79 passed (79)    [real migrated PostgreSQL]

npx vitest run --config vitest.config.site-scope-coverage.ts        # => 1 file, 7 passed (7)
npx vitest run --config vitest.config.integration-suite-coverage.ts # => 1 file, 5 passed (5)

NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit              # => exit 0
npx eslint src/routes/devices/patches.ts src/routes/devices/patches.test.ts src/routes/agents/patches.ts
# => exit 0, no findings
```

Agent (`cd agent`):
```sh
go build ./...                                  # => ok
go vet ./...                                    # => ok
go test -race ./internal/heartbeat/...          # => ok (52.8s)
go test -race ./...                             # => ok, whole agent corpus, no failures
golangci-lint run --new-from-rev=origin/main ./...                # => 0 issues
GOOS=windows golangci-lint run --new-from-rev=origin/main ./...   # => 0 issues
GOOS=darwin  golangci-lint run --new-from-rev=origin/main ./...   # => 0 issues
```

No migration, schema column or RLS-relevant table was touched, so the migration/cascade/export-policy contract suites are **not applicable** (not-checked, by design).

### Windows runtime — not checked

The Windows-only code path (`internal/patching/windows.go`, OLE/WUA) **cross-compiles** but was **not executed**:
```sh
GOOS=windows GOARCH=amd64 go test -c -o <out>.exe ./internal/heartbeat/   # => ok
```
Two `windows/amd64` test binaries were produced for a lab run — one from this branch and one control built from `origin/main`'s `heartbeat.go` with this branch's test file — to be run natively with `-test.run TestResolvePatchInstallID`. **Claim status: cross-compilation verified; the on-Windows result is not-checked at time of writing.** The resolver under test is pure Go and provider-mocked, so it does not exercise real WUA lookup, download, EULA, install or reboot behaviour — that remains unverified on a live endpoint.

## Compatibility

Mixed-version safe in **both** directions; neither side needs the other to land first.

- **New API + old agent (the common rollout order).** The API sends `packageId: null` for Microsoft rows. An old agent then falls through its existing `patchLocalID` chain to the externalId, which is returned unchanged for both a KB (`KB5034441`) and a bare UpdateID GUID (neither contains a `:`), and resolves `windows-update:<that>` through the same WUA lookup that matches both forms. **The server-side half alone closes the exposure**, because the poisoned selector is never put on the wire; old agents are protected without being upgraded.
- **Old API + new agent.** An unpatched server may still forward a foreign selector, but the new resolver takes the device-observed `externalId` first and ignores `packageId` entirely for Microsoft refs. **The agent-side half alone also closes the exposure.** It does not restore the device-observation requirement — an old API can still name an update the device never reported, and WUA then fails to find it rather than installing something else.
- **Non-Windows and non-Microsoft rows are untouched in every combination.** The agent branch is gated on `source == microsoft` *and* `HasProvider("windows-update")` *and* an externalId that is unqualified or qualified `microsoft:`/`windows-update:`; the API branch on `source === 'microsoft'`. Everything provider-qualified (apt, yum, dnf, winget, homebrew, chocolatey, apple-softwareupdate) keeps its exact current selector, including a Microsoft-source row whose externalId names a real present provider.

## Operator impact

- No action required. No schema migration, config change or customer notification.
- Behaviour change visible to operators: installing a patch a device has **not** currently reported as pending now returns `404 Some patches were not found` instead of silently queueing a command the endpoint cannot satisfy. All three web install flows build their request from the pending list, so this should not be reachable from the UI; a stale browser tab could hit it and should re-scan.
- Suggested release note: "Windows patch installation now resolves the update from the target device's current observation instead of shared catalog selector metadata."

## Follow-ups (not in this PR)

- **`rollback_patches` selects the patch globally.** `routes/devices/patches.ts:630-641` and `routes/patches/operations.ts:252-260` look the patch up without a `device_patches` join, so the rollback path has the same missing device-observation binding as the install path did. It is **pre-existing and not a `packageId` vector** — the agent resolves a rollback against `IsInstalled=1 and IsUninstallable=1` on the device itself (`internal/patching/windows.go:175`), so an unobserved or foreign selector fails to resolve rather than uninstalling something unintended. Tracked separately; a reviewer is filing it.
- WUA matches the first applicable update whose first KB article matches. If one endpoint exposes multiple applicable revisions under the same KB, KB-only selection can still be ambiguous *within that device*. It can no longer be selected by another device's UpdateID, but exact-revision behaviour would need a device-owned durable UpdateID. (KB-less rows are unaffected: they carry the UpdateID directly.)
- Device access and site authority are checked before the observation query, but the observation is not locked through command creation. A concurrent scan can retire the pending row after selection; the agent's live WUA lookup then fails closed. No deterministic race test was run — **not-checked**.
- `patches.package_id` remains first-writer catalog metadata for non-Microsoft providers, so this boundary depends on every future Microsoft execution sink staying on the device-observed path. Add sibling coverage when a new sink is introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Tugfg88kFiowD7E5xQFpU
