### PR TITLE
fix(automation): re-check device organization at dispatch and cancel CIS remediation on org move (SEC-118)

### DIFF
--- a/apps/api/migrations/2026-10-15-160140-cancel-cis-remediation-on-device-org-move.sql
+++ b/apps/api/migrations/2026-10-15-160140-cancel-cis-remediation-on-device-org-move.sql
@@ -1,0 +1,71 @@
+-- A pending/queued CIS remediation was admitted for the source organization.
+-- Device org moves re-stamp cis_remediation_actions.org_id,
+-- so without a pre-cascade fence the later worker cannot distinguish that old
+-- authority from a remediation genuinely admitted in the destination org.
+--
+-- This BEFORE trigger runs after the devices row has been locked by UPDATE and
+-- before the AFTER trigger breeze_cascade_device_org_id() re-stamps device
+-- children -- which is the whole point of choosing BEFORE. The worker
+-- takes locks in the same device -> action order, so exactly one side wins:
+-- either the command exists before the move (the separate device_commands
+-- lifecycle boundary), or the still-pre-command action becomes terminal here.
+
+CREATE OR REPLACE FUNCTION public.breeze_cancel_cis_remediation_before_device_org_move()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+BEGIN
+  IF OLD.org_id IS NOT DISTINCT FROM NEW.org_id THEN
+    RETURN NEW;
+  END IF;
+
+  -- MERGE FENCE. An org merge is not a device move: orgMergeExecutors repoints
+  -- the loser org's devices to the survivor set-based, which fires this trigger
+  -- for every device at once. Those remediations were admitted for a tenant
+  -- that is being ABSORBED, not left behind -- the admitting authority survives
+  -- the merge -- so cancelling them would destroy live work and stamp a reason
+  -- ('device_org_changed_before_dispatch') that is simply untrue. Let the row
+  -- travel to the survivor via breeze_cascade_device_org_id()'s re-stamp loop
+  -- instead. Same fence, and the same reason, as the device_group_memberships
+  -- delete and the tickets requester_contact_id detach in
+  -- 2026-10-14-100000-ai-operator-thin-slice.sql.
+  IF EXISTS (
+    SELECT 1 FROM public.organizations o
+     WHERE o.id = OLD.org_id AND o.status::text = 'merging'
+  ) THEN
+    RETURN NEW;
+  END IF;
+
+  -- `org_id = OLD.org_id` is LOAD-BEARING, not a redundant narrowing of
+  -- `device_id`. Every index on cis_remediation_actions is org_id-leading
+  -- (cis_remediation_org_device_status_idx is (org_id, device_id, status)), so
+  -- a bare `device_id = ...` predicate has no usable index and degrades to a
+  -- sequential scan per row. That is the v0.111.0 US-outage shape: harmless on
+  -- a single-device move, a table scan per device on any future set-based
+  -- devices.org_id UPDATE. The pre-move org is exactly the org every row this
+  -- trigger may cancel is stamped with, because the cascade re-stamp has not
+  -- run yet at BEFORE time.
+  UPDATE public.cis_remediation_actions
+     SET status = 'cancelled',
+         details = COALESCE(details, '{}'::jsonb) || jsonb_build_object(
+           'cancelledReason', 'device_org_changed_before_dispatch',
+           'cancelledAt', clock_timestamp()
+         )
+   WHERE org_id = OLD.org_id
+     AND device_id = OLD.id
+     AND status IN ('pending_approval', 'queued');
+
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.breeze_cancel_cis_remediation_before_device_org_move() FROM PUBLIC;
+
+DROP TRIGGER IF EXISTS breeze_cancel_cis_remediation_before_device_org_move ON public.devices;
+CREATE TRIGGER breeze_cancel_cis_remediation_before_device_org_move
+BEFORE UPDATE OF org_id ON public.devices
+FOR EACH ROW
+WHEN (OLD.org_id IS DISTINCT FROM NEW.org_id)
+EXECUTE FUNCTION public.breeze_cancel_cis_remediation_before_device_org_move();

--- a/apps/api/src/__tests__/integration/automationDeviceMoveAuthority.integration.test.ts
+++ b/apps/api/src/__tests__/integration/automationDeviceMoveAuthority.integration.test.ts
@@ -1,0 +1,925 @@
+/**
+ * Real-PostgreSQL proof for the pre-command device-move boundary. All targets,
+ * commands and tenants are synthetic; no agent socket or provider is used.
+ */
+import './setup';
+
+import { randomUUID } from 'node:crypto';
+import { eq, inArray, sql } from 'drizzle-orm';
+import { Hono } from 'hono';
+import { describe, expect, it } from 'vitest';
+
+import { withSystemDbAccessContext } from '../../db';
+import {
+  automationActionResults,
+  automationResourceBindings,
+  automationRunDeviceResults,
+  automationRuns,
+  automations,
+  cisRemediationActions,
+  deviceCommands,
+  devices,
+  deploymentResults,
+  organizations,
+  softwareCatalog,
+  softwareDeployments,
+  softwareVersions,
+} from '../../db/schema';
+import {
+  configPolicyAutomations,
+  configPolicyFeatureLinks,
+  configurationPolicies,
+} from '../../db/schema/configurationPolicies';
+import {
+  executeAutomationRun,
+  executeConfigPolicyAutomationRun,
+  __testOnly as automationRuntimeTestOnly,
+} from '../../services/automationRuntime';
+import { __testOnly as cisJobsTestOnly } from '../../jobs/cisJobs';
+import { createAccessToken } from '../../services/jwt';
+import { moveOrgRoutes } from '../../routes/devices/moveOrg';
+import {
+  createOrganization,
+  createPartner,
+  createSite,
+  setupTestEnvironment,
+} from './db-utils';
+import { getTestDb } from './setup';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+async function waitForAdvisoryLockWaiter(tx: ReturnType<typeof getTestDb>): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const result = await tx.execute(sql`
+      SELECT EXISTS (
+        SELECT 1
+        FROM pg_locks
+        WHERE locktype = 'advisory'
+          AND NOT granted
+      ) AS blocked
+    `) as unknown as Array<{ blocked: boolean }>;
+    if (result[0]?.blocked) return;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error('Timed out waiting for the dispatch advisory-lock waiter');
+}
+
+async function createDeployTarget(orgId: string) {
+  const adminDb = getTestDb();
+  const [catalog] = await adminDb.insert(softwareCatalog).values({
+    orgId,
+    partnerId: null,
+    name: `Synthetic authority package ${randomUUID()}`,
+  }).returning();
+  await adminDb.insert(softwareVersions).values({
+    catalogId: catalog!.id,
+    version: '1.0.0',
+    downloadUrl: 'https://example.invalid/authority-package.test',
+    supportedOs: ['linux'],
+    isLatest: true,
+  });
+  return catalog!;
+}
+
+async function bindDeployTarget(args: {
+  automationId: string;
+  ownerOrgId: string | null;
+  ownerPartnerId: string | null;
+  resourceOrgId: string;
+  catalogId: string;
+}) {
+  await getTestDb().insert(automationResourceBindings).values({
+    automationId: args.automationId,
+    orgId: args.ownerOrgId,
+    partnerId: args.ownerPartnerId,
+    resourceKind: 'software_catalog',
+    resourceId: args.catalogId,
+    expectedResourceOrgId: args.resourceOrgId,
+    expectedResourcePartnerId: null,
+    expectedResourceIsSystem: false,
+    state: 'active',
+  });
+}
+
+describe('automation and CIS pre-command authority across device org moves', () => {
+  runDb('denies the moved target, preserves an allowed control, and cancels CIS before child restamp', async () => {
+    const adminDb = getTestDb();
+    const partner = await createPartner();
+    const sourceOrg = await createOrganization({ partnerId: partner.id });
+    const destinationOrg = await createOrganization({ partnerId: partner.id });
+    const sourceSite = await createSite({ orgId: sourceOrg.id });
+    const destinationSite = await createSite({ orgId: destinationOrg.id });
+
+    const [allowedDevice, movedDevice] = await adminDb.insert(devices).values([
+      {
+        orgId: sourceOrg.id,
+        siteId: sourceSite.id,
+        agentId: `authority-allowed-${randomUUID()}`,
+        hostname: 'authority-allowed',
+        osType: 'linux',
+        osVersion: 'test',
+        architecture: 'amd64',
+        agentVersion: 'test',
+        status: 'online',
+      },
+      {
+        orgId: sourceOrg.id,
+        siteId: sourceSite.id,
+        agentId: `authority-moved-${randomUUID()}`,
+        hostname: 'authority-moved',
+        osType: 'linux',
+        osVersion: 'test',
+        architecture: 'amd64',
+        agentVersion: 'test',
+        status: 'online',
+      },
+    ]).returning();
+
+    const [automation] = await adminDb.insert(automations).values({
+      orgId: sourceOrg.id,
+      partnerId: null,
+      name: `Source authority automation ${randomUUID()}`,
+      trigger: { type: 'manual' },
+      conditions: { type: 'devices', deviceIds: [allowedDevice!.id, movedDevice!.id] },
+      actions: [{ type: 'execute_command', command: 'synthetic-authority-control' }],
+      onFailure: 'stop',
+    }).returning();
+    const [run] = await adminDb.insert(automationRuns).values({
+      automationId: automation!.id,
+      triggeredBy: 'authority-integration',
+      status: 'running',
+      devicesTargeted: 2,
+    }).returning();
+    const [cisAction] = await adminDb.insert(cisRemediationActions).values({
+      orgId: sourceOrg.id,
+      deviceId: movedDevice!.id,
+      checkId: 'authority.synthetic',
+      action: 'synthetic',
+      status: 'queued',
+      approvalStatus: 'approved',
+      details: { synthetic: true },
+    }).returning();
+
+    // Exercise the database trigger path directly, not only the HTTP route.
+    await adminDb.update(devices).set({
+      orgId: destinationOrg.id,
+      siteId: destinationSite.id,
+    }).where(eq(devices.id, movedDevice!.id));
+
+    const outcome = await withSystemDbAccessContext(() => executeAutomationRun(
+      run!.id,
+      [allowedDevice!.id, movedDevice!.id],
+    ));
+    expect(outcome.status).toBe('running');
+
+    const commands = await adminDb
+      .select({ deviceId: deviceCommands.deviceId })
+      .from(deviceCommands)
+      .where(inArray(deviceCommands.deviceId, [allowedDevice!.id, movedDevice!.id]));
+    expect(commands).toEqual([{ deviceId: allowedDevice!.id }]);
+
+    // The denied target does NOT vanish. `devices_targeted` counted it, so it
+    // must be visible in the run with a terminal failed row naming the reason —
+    // a silently-missing device is indistinguishable from the bug.
+    const deviceResults = await adminDb
+      .select({
+        deviceId: automationRunDeviceResults.deviceId,
+        status: automationRunDeviceResults.status,
+        error: automationRunDeviceResults.error,
+      })
+      .from(automationRunDeviceResults)
+      .where(eq(automationRunDeviceResults.runId, run!.id));
+    const actionResults = await adminDb
+      .select({ deviceId: automationActionResults.deviceId })
+      .from(automationActionResults)
+      .where(eq(automationActionResults.runId, run!.id));
+    expect(deviceResults).toHaveLength(2);
+    expect(deviceResults).toEqual(expect.arrayContaining([
+      expect.objectContaining({ deviceId: allowedDevice!.id }),
+      expect.objectContaining({
+        deviceId: movedDevice!.id,
+        status: 'failed',
+        error: expect.stringContaining('no longer belongs'),
+      }),
+    ]));
+    // A denied target is denied BEFORE any action sink, so it has no per-action
+    // rows at all — only the device-level failure above.
+    expect(actionResults).toEqual([{ deviceId: allowedDevice!.id }]);
+
+    // A partner-owned automation retains authority when the same device moves
+    // between two CURRENT member organizations of that partner. This positive
+    // control proves the repair follows the durable owner boundary rather than
+    // treating every org change as a blanket denial.
+    const [partnerAutomation] = await adminDb.insert(automations).values({
+      orgId: null,
+      partnerId: partner.id,
+      name: `Partner authority automation ${randomUUID()}`,
+      trigger: { type: 'manual' },
+      conditions: { type: 'devices', deviceIds: [movedDevice!.id] },
+      actions: [{ type: 'execute_command', command: 'synthetic-partner-authority-control' }],
+      onFailure: 'stop',
+    }).returning();
+    const [partnerRun] = await adminDb.insert(automationRuns).values({
+      automationId: partnerAutomation!.id,
+      triggeredBy: 'authority-partner-integration',
+      status: 'running',
+      devicesTargeted: 1,
+    }).returning();
+    await withSystemDbAccessContext(() => executeAutomationRun(
+      partnerRun!.id,
+      [movedDevice!.id],
+    ));
+    const partnerCommands = await adminDb
+      .select({ deviceId: deviceCommands.deviceId })
+      .from(deviceCommands)
+      .where(eq(deviceCommands.deviceId, movedDevice!.id));
+    expect(partnerCommands).toEqual([{ deviceId: movedDevice!.id }]);
+
+    const [cancelled] = await adminDb
+      .select({
+        orgId: cisRemediationActions.orgId,
+        status: cisRemediationActions.status,
+        details: cisRemediationActions.details,
+      })
+      .from(cisRemediationActions)
+      .where(eq(cisRemediationActions.id, cisAction!.id));
+    expect(cancelled).toMatchObject({
+      orgId: destinationOrg.id,
+      status: 'cancelled',
+      details: expect.objectContaining({ cancelledReason: 'device_org_changed_before_dispatch' }),
+    });
+  }, 30_000);
+
+  runDb('move lock wins against automation and CIS dispatch, denying both before command creation', async () => {
+    const adminDb = getTestDb();
+    const partner = await createPartner();
+    const sourceOrg = await createOrganization({ partnerId: partner.id });
+    const destinationOrg = await createOrganization({ partnerId: partner.id });
+    const sourceSite = await createSite({ orgId: sourceOrg.id });
+    const destinationSite = await createSite({ orgId: destinationOrg.id });
+    const [device] = await adminDb.insert(devices).values({
+      orgId: sourceOrg.id,
+      siteId: sourceSite.id,
+      agentId: `authority-race-${randomUUID()}`,
+      hostname: 'authority-race',
+      osType: 'linux',
+      osVersion: 'test',
+      architecture: 'amd64',
+      agentVersion: 'test',
+      status: 'online',
+    }).returning();
+    const [action] = await adminDb.insert(cisRemediationActions).values({
+      orgId: sourceOrg.id,
+      deviceId: device!.id,
+      checkId: 'authority.race',
+      action: 'synthetic',
+      status: 'queued',
+      approvalStatus: 'approved',
+      details: { synthetic: true },
+    }).returning();
+    const [automation] = await adminDb.insert(automations).values({
+      orgId: sourceOrg.id,
+      partnerId: null,
+      name: `Move-wins automation ${randomUUID()}`,
+      trigger: { type: 'manual' },
+      conditions: { type: 'devices', deviceIds: [device!.id] },
+      actions: [{ type: 'execute_command', command: 'synthetic-move-wins' }],
+      onFailure: 'stop',
+    }).returning();
+    let workerPromise!: ReturnType<typeof cisJobsTestOnly.processRemediationAction>;
+    let automationAuthorityPromise!: ReturnType<
+      typeof automationRuntimeTestOnly.lockCurrentAutomationTargetDevices
+    >;
+    await adminDb.transaction(async (tx) => {
+      await tx.select({ id: devices.id })
+        .from(devices)
+        .where(eq(devices.id, device!.id))
+        .for('update');
+
+      workerPromise = cisJobsTestOnly.processRemediationAction({
+        type: 'remediate-action',
+        actionId: action!.id,
+      });
+      automationAuthorityPromise = withSystemDbAccessContext(() =>
+        automationRuntimeTestOnly.lockCurrentAutomationTargetDevices(automation!, [device!.id]));
+      const early = await Promise.race([
+        Promise.all([workerPromise, automationAuthorityPromise]).then(() => 'settled' as const),
+        new Promise<'blocked'>((resolve) => setTimeout(() => resolve('blocked'), 100)),
+      ]);
+      expect(early).toBe('blocked');
+
+      await tx.update(devices).set({
+        orgId: destinationOrg.id,
+        siteId: destinationSite.id,
+      }).where(eq(devices.id, device!.id));
+    });
+
+    expect(await workerPromise).toEqual({
+      actionId: action!.id,
+      queued: false,
+      commandId: null,
+    });
+    expect(await automationAuthorityPromise).toEqual([]);
+    const commands = await adminDb
+      .select({ id: deviceCommands.id })
+      .from(deviceCommands)
+      .where(eq(deviceCommands.deviceId, device!.id));
+    expect(commands).toEqual([]);
+    const [cancelled] = await adminDb
+      .select({ status: cisRemediationActions.status, orgId: cisRemediationActions.orgId })
+      .from(cisRemediationActions)
+      .where(eq(cisRemediationActions.id, action!.id));
+    expect(cancelled).toEqual({ status: 'cancelled', orgId: destinationOrg.id });
+  }, 30_000);
+
+  runDb('deploy sink lock wins before a concurrent move and commits against the source owner', async () => {
+    const adminDb = getTestDb();
+    const partner = await createPartner();
+    const sourceOrg = await createOrganization({ partnerId: partner.id });
+    const destinationOrg = await createOrganization({ partnerId: partner.id });
+    const sourceSite = await createSite({ orgId: sourceOrg.id });
+    const destinationSite = await createSite({ orgId: destinationOrg.id });
+    const [device] = await adminDb.insert(devices).values({
+      orgId: sourceOrg.id,
+      siteId: sourceSite.id,
+      agentId: `authority-sink-wins-${randomUUID()}`,
+      hostname: 'authority-sink-wins',
+      osType: 'linux',
+      osVersion: 'test',
+      architecture: 'amd64',
+      agentVersion: 'test',
+      status: 'online',
+    }).returning();
+    const catalog = await createDeployTarget(sourceOrg.id);
+    const [automation] = await adminDb.insert(automations).values({
+      orgId: sourceOrg.id,
+      partnerId: null,
+      name: `Sink-wins automation ${randomUUID()}`,
+      trigger: { type: 'manual' },
+      conditions: { type: 'devices', deviceIds: [device!.id] },
+      actions: [{ type: 'deploy_software', catalogId: catalog.id }],
+      onFailure: 'stop',
+    }).returning();
+    await bindDeployTarget({
+      automationId: automation!.id,
+      ownerOrgId: sourceOrg.id,
+      ownerPartnerId: null,
+      resourceOrgId: sourceOrg.id,
+      catalogId: catalog.id,
+    });
+    const [run] = await adminDb.insert(automationRuns).values({
+      automationId: automation!.id,
+      triggeredBy: 'authority-sink-wins',
+      status: 'running',
+      devicesTargeted: 1,
+    }).returning();
+
+    await adminDb.execute(sql.raw(`
+      CREATE OR REPLACE FUNCTION public.test_block_deployment_result_insert()
+      RETURNS trigger LANGUAGE plpgsql AS $$
+      BEGIN
+        PERFORM pg_advisory_xact_lock(118001);
+        RETURN NEW;
+      END $$;
+      DROP TRIGGER IF EXISTS test_block_deployment_result_insert ON public.deployment_results;
+      CREATE TRIGGER test_block_deployment_result_insert
+      BEFORE INSERT ON public.deployment_results
+      FOR EACH ROW
+      WHEN (NEW.device_id = '${device!.id}'::uuid)
+      EXECUTE FUNCTION public.test_block_deployment_result_insert();
+    `));
+
+    let dispatchPromise!: ReturnType<typeof executeAutomationRun>;
+    let movePromise!: Promise<unknown>;
+    try {
+      await adminDb.transaction(async (tx) => {
+        await tx.execute(sql`SELECT pg_advisory_xact_lock(118001)`);
+        dispatchPromise = withSystemDbAccessContext(() => executeAutomationRun(run!.id, [device!.id]));
+        await waitForAdvisoryLockWaiter(tx as unknown as ReturnType<typeof getTestDb>);
+
+        movePromise = adminDb.update(devices).set({
+          orgId: destinationOrg.id,
+          siteId: destinationSite.id,
+        }).where(eq(devices.id, device!.id));
+        const moveState = await Promise.race([
+          movePromise.then(() => 'settled' as const),
+          new Promise<'blocked'>((resolve) => setTimeout(() => resolve('blocked'), 100)),
+        ]);
+        expect(moveState).toBe('blocked');
+      });
+
+      await dispatchPromise;
+      await movePromise;
+      const commands = await adminDb
+        .select({ deviceId: deviceCommands.deviceId })
+        .from(deviceCommands)
+        .where(eq(deviceCommands.deviceId, device!.id));
+      expect(commands).toEqual([{ deviceId: device!.id }]);
+      const results = await adminDb.select({ deviceId: deploymentResults.deviceId })
+        .from(deploymentResults)
+        .where(eq(deploymentResults.deviceId, device!.id));
+      expect(results).toEqual([{ deviceId: device!.id }]);
+    } finally {
+      await adminDb.execute(sql.raw(`
+        DROP TRIGGER IF EXISTS test_block_deployment_result_insert ON public.deployment_results;
+        DROP FUNCTION IF EXISTS public.test_block_deployment_result_insert();
+      `));
+    }
+  }, 30_000);
+
+  runDb('standalone deploy_software completes while holding the current-owner lock', async () => {
+    const adminDb = getTestDb();
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const site = await createSite({ orgId: org.id });
+    const [device] = await adminDb.insert(devices).values({
+      orgId: org.id,
+      siteId: site.id,
+      agentId: `authority-deploy-positive-${randomUUID()}`,
+      hostname: 'authority-deploy-positive',
+      osType: 'linux', osVersion: 'test', architecture: 'amd64', agentVersion: 'test', status: 'online',
+    }).returning();
+    const catalog = await createDeployTarget(org.id);
+    const [automation] = await adminDb.insert(automations).values({
+      orgId: org.id,
+      partnerId: null,
+      name: `Deploy authority positive ${randomUUID()}`,
+      trigger: { type: 'manual' },
+      conditions: { type: 'devices', deviceIds: [device!.id] },
+      actions: [{ type: 'deploy_software', catalogId: catalog.id }],
+      onFailure: 'stop',
+    }).returning();
+    await bindDeployTarget({
+      automationId: automation!.id,
+      ownerOrgId: org.id,
+      ownerPartnerId: null,
+      resourceOrgId: org.id,
+      catalogId: catalog.id,
+    });
+    const [run] = await adminDb.insert(automationRuns).values({
+      automationId: automation!.id,
+      triggeredBy: 'authority-deploy-positive',
+      status: 'running',
+      devicesTargeted: 1,
+    }).returning();
+
+    const outcome = await withSystemDbAccessContext(() => executeAutomationRun(run!.id, [device!.id]));
+    expect(outcome.status).toBe('running');
+    const deployments = await adminDb.select({ id: softwareDeployments.id, orgId: softwareDeployments.orgId })
+      .from(softwareDeployments)
+      .where(eq(softwareDeployments.orgId, org.id));
+    expect(deployments).toHaveLength(1);
+    const results = await adminDb.select({ deviceId: deploymentResults.deviceId })
+      .from(deploymentResults)
+      .where(eq(deploymentResults.deploymentId, deployments[0]!.id));
+    expect(results).toEqual([{ deviceId: device!.id }]);
+    const commands = await adminDb.select({ deviceId: deviceCommands.deviceId })
+      .from(deviceCommands)
+      .where(eq(deviceCommands.deviceId, device!.id));
+    expect(commands).toEqual([{ deviceId: device!.id }]);
+  }, 30_000);
+
+  runDb('rechecks and locks current partner membership before dispatch', async () => {
+    const adminDb = getTestDb();
+    const sourcePartner = await createPartner();
+    const destinationPartner = await createPartner();
+    const org = await createOrganization({ partnerId: sourcePartner.id });
+    const site = await createSite({ orgId: org.id });
+    const [device] = await adminDb.insert(devices).values({
+      orgId: org.id,
+      siteId: site.id,
+      agentId: `authority-partner-move-${randomUUID()}`,
+      hostname: 'authority-partner-move',
+      osType: 'linux', osVersion: 'test', architecture: 'amd64', agentVersion: 'test', status: 'online',
+    }).returning();
+    const [automation] = await adminDb.insert(automations).values({
+      orgId: null,
+      partnerId: sourcePartner.id,
+      name: `Partner membership automation ${randomUUID()}`,
+      trigger: { type: 'manual' },
+      conditions: { type: 'devices', deviceIds: [device!.id] },
+      actions: [{ type: 'execute_command', command: 'synthetic-partner-move' }],
+      onFailure: 'stop',
+    }).returning();
+    const [run] = await adminDb.insert(automationRuns).values({
+      automationId: automation!.id,
+      triggeredBy: 'authority-partner-move',
+      status: 'running',
+      devicesTargeted: 1,
+    }).returning();
+
+    let dispatchSettled!: Promise<{ error?: unknown }>;
+    await adminDb.transaction(async (tx) => {
+      await tx.select({ id: organizations.id })
+        .from(organizations)
+        .where(eq(organizations.id, org.id))
+        .for('update');
+      await tx.update(organizations)
+        .set({ partnerId: destinationPartner.id })
+        .where(eq(organizations.id, org.id));
+
+      dispatchSettled = withSystemDbAccessContext(() => executeAutomationRun(run!.id, [device!.id])).then(
+        () => ({}),
+        (error: unknown) => ({ error }),
+      );
+      const early = await Promise.race([
+        dispatchSettled.then(() => 'settled' as const),
+        new Promise<'blocked'>((resolve) => setTimeout(() => resolve('blocked'), 100)),
+      ]);
+      expect(early).toBe('blocked');
+    });
+
+    const outcome = await dispatchSettled;
+    expect(outcome.error).toBeUndefined();
+    const commands = await adminDb.select({ id: deviceCommands.id })
+      .from(deviceCommands)
+      .where(eq(deviceCommands.deviceId, device!.id));
+    expect(commands).toEqual([]);
+  }, 30_000);
+
+  // ==========================================================================
+  // SEC-118 review blocker 1 — cross-org LOCK ORDER (#3778)
+  // ==========================================================================
+  //
+  // The repo-wide order for anything that spans organizations is
+  // `organizations FOR SHARE (ascending) -> devices -> children`
+  // (services/orgCurrencyCore.ts's readOrgStampingDefaultsMany, used by
+  // routes/devices/moveOrg.ts and services/ticketService.ts). The first cut of
+  // this fix locked devices FIRST and organizations SECOND for partner-owned
+  // automations, which is the AB-BA Postgres resolves by killing one side with
+  // 40P01: a partner automation dispatching while one of its own targets is
+  // being moved would abort at random.
+  //
+  // This test pins the ORDER itself rather than hoping a race reproduces. A
+  // third transaction holds the device's organization in a mode that conflicts
+  // with FOR SHARE; the dispatch must then be blocked on the ORGANIZATION and
+  // must NOT yet hold the device row. Under the inverted order the device lock
+  // is taken first and the `FOR UPDATE` probe below blocks instead of
+  // returning.
+  runDb('takes organizations before devices, so a concurrent move cannot deadlock it', async () => {
+    const adminDb = getTestDb();
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const site = await createSite({ orgId: org.id });
+    const [device] = await adminDb.insert(devices).values({
+      orgId: org.id,
+      siteId: site.id,
+      agentId: `authority-order-${randomUUID()}`,
+      hostname: 'authority-order',
+      osType: 'linux',
+      osVersion: 'test',
+      architecture: 'amd64',
+      agentVersion: 'test',
+      status: 'online',
+    }).returning();
+    const [automation] = await adminDb.insert(automations).values({
+      orgId: null,
+      partnerId: partner.id,
+      name: `Lock-order automation ${randomUUID()}`,
+      trigger: { type: 'manual' },
+      conditions: { type: 'devices', deviceIds: [device!.id] },
+      actions: [{ type: 'execute_command', command: 'synthetic-lock-order' }],
+      onFailure: 'stop',
+    }).returning();
+
+    let authorityPromise!: Promise<unknown>;
+    let releaseAuthority!: () => void;
+    const authorityHeld = new Promise<void>((resolve) => { releaseAuthority = resolve; });
+
+    await adminDb.transaction(async (blocker) => {
+      // Conflicts with the dispatch's `organizations FOR SHARE`.
+      await blocker.select({ id: organizations.id })
+        .from(organizations)
+        .where(eq(organizations.id, org.id))
+        .for('no key update');
+
+      authorityPromise = withSystemDbAccessContext(async () => {
+        const locked = await automationRuntimeTestOnly
+          .lockCurrentAutomationTargetDevices(automation!, [device!.id]);
+        // Hold the authority transaction open so the probe below observes the
+        // locks it actually took, not the locks it released at commit.
+        await authorityHeld;
+        return locked;
+      });
+
+      // 1. The dispatch is stuck. (On the organization — proven by 2.)
+      const early = await Promise.race([
+        authorityPromise.then(() => 'settled' as const),
+        new Promise<'blocked'>((resolve) => setTimeout(() => resolve('blocked'), 400)),
+      ]);
+      expect(early).toBe('blocked');
+
+      // 2. ...and it holds NO lock on the device row: an independent
+      //    transaction can still take `devices FOR UPDATE` immediately. This is
+      //    the assertion that fails under the inverted (devices-first) order.
+      const probe = adminDb.transaction(async (tx) => {
+        await tx.select({ id: devices.id })
+          .from(devices)
+          .where(eq(devices.id, device!.id))
+          .for('update');
+        return 'acquired' as const;
+      });
+      const probeOutcome = await Promise.race([
+        probe,
+        new Promise<'blocked'>((resolve) => setTimeout(() => resolve('blocked'), 2_000)),
+      ]);
+      expect(probeOutcome).toBe('acquired');
+    });
+
+    releaseAuthority();
+    // Once the organization lock is released the dispatch completes normally
+    // and still admits its own partner's device.
+    const locked = await authorityPromise as Array<{ id: string }>;
+    expect(locked.map((row) => row.id)).toEqual([device!.id]);
+  }, 30_000);
+
+  // End-to-end form of the same blocker: the REAL `POST /devices/:id/move-org`
+  // route running concurrently with a partner-owned dispatch of that exact
+  // device. Either order is acceptable — the move may win or the dispatch may
+  // win — but neither side may abort with a deadlock (40P01).
+  //
+  // HONEST LIMIT: this is a regression NET, not the discriminating control.
+  // Measured against the inverted (devices-first) order it does not reliably go
+  // red — six attempts produced no 40P01 in one run — because the interleaving
+  // the deadlock needs (dispatch holds the device, move holds the orgs, each
+  // then wants the other's) depends on where the scheduler happens to land. The
+  // deterministic proof of the lock order is the test above; this one exists to
+  // catch a regression that shows up under real concurrency rather than under a
+  // hand-built lock sequence, and to prove a losing dispatch loses CLOSED.
+  runDb('never deadlocks a partner-owned dispatch against the real move-org route', async () => {
+    const adminDb = getTestDb();
+    const env = await setupTestEnvironment({ scope: 'partner' });
+    const { partner, organization: sourceOrg, site: sourceSite, user, role } = env;
+    const destinationOrg = await createOrganization({ partnerId: partner.id });
+    const destinationSite = await createSite({ orgId: destinationOrg.id });
+
+    const token = await createAccessToken({
+      sub: user.id,
+      email: user.email,
+      roleId: role.id,
+      orgId: null,
+      partnerId: partner.id,
+      scope: 'partner',
+      mfa: true,
+      aep: 1,
+      mep: 1,
+      sid: 'sec118-deadlock-session',
+    });
+    const app = new Hono();
+    app.route('/devices', moveOrgRoutes);
+
+    const deadlocks: string[] = [];
+    for (let attempt = 0; attempt < 6; attempt += 1) {
+      const [device] = await adminDb.insert(devices).values({
+        orgId: sourceOrg.id,
+        siteId: sourceSite.id,
+        agentId: `authority-deadlock-${randomUUID()}`,
+        hostname: `authority-deadlock-${attempt}`,
+        osType: 'linux',
+        osVersion: 'test',
+        architecture: 'amd64',
+        agentVersion: 'test',
+        status: 'online',
+      }).returning();
+      const [automation] = await adminDb.insert(automations).values({
+        orgId: null,
+        partnerId: partner.id,
+        name: `Deadlock automation ${randomUUID()}`,
+        trigger: { type: 'manual' },
+        conditions: { type: 'devices', deviceIds: [device!.id] },
+        actions: [{ type: 'execute_command', command: 'synthetic-deadlock' }],
+        onFailure: 'stop',
+      }).returning();
+      const [run] = await adminDb.insert(automationRuns).values({
+        automationId: automation!.id,
+        triggeredBy: 'authority-deadlock',
+        status: 'running',
+        devicesTargeted: 1,
+      }).returning();
+
+      const movePromise = app.request(`/devices/${device!.id}/move-org`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ orgId: destinationOrg.id, siteId: destinationSite.id }),
+      });
+      const dispatchPromise = withSystemDbAccessContext(() =>
+        executeAutomationRun(run!.id, [device!.id]));
+
+      const [moveOutcome, dispatchOutcome] = await Promise.allSettled([movePromise, dispatchPromise]);
+      for (const outcome of [moveOutcome, dispatchOutcome]) {
+        if (outcome.status !== 'rejected') continue;
+        const message = outcome.reason instanceof Error
+          ? `${outcome.reason.message}${outcome.reason.stack ? '' : ''}`
+          : String(outcome.reason);
+        // 40P01 is what this test rules out.
+        if (/40P01|deadlock detected/i.test(message)) deadlocks.push(message);
+      }
+      // Both sides must reach a decision; a move that 500s is not "no deadlock".
+      if (moveOutcome.status === 'fulfilled') {
+        expect([200, 409]).toContain(moveOutcome.value.status);
+      }
+
+      // A dispatch that LOSES the race must lose closed. The move winning is a
+      // legitimate outcome — the pre-existing org-mismatch guard in
+      // seedAutomationActionResults raises on the run's own seeding step when
+      // the device leaves mid-flight — but it must never leave a command
+      // behind for a device that is no longer in the automation's owner org.
+      if (dispatchOutcome.status === 'rejected') {
+        const [movedRow] = await adminDb.select({ orgId: devices.orgId })
+          .from(devices)
+          .where(eq(devices.id, device!.id));
+        const leftBehind = await adminDb.select({ id: deviceCommands.id })
+          .from(deviceCommands)
+          .where(eq(deviceCommands.deviceId, device!.id));
+        expect({ orgId: movedRow?.orgId, commands: leftBehind }).toEqual({
+          orgId: destinationOrg.id,
+          commands: [],
+        });
+      }
+    }
+    expect(deadlocks).toEqual([]);
+  }, 60_000);
+
+  // ==========================================================================
+  // SEC-118 review blocker 3 — the trigger must NOT fire on an org MERGE
+  // ==========================================================================
+  //
+  // An org merge repoints the loser's devices to the survivor set-based. That
+  // is an absorption, not a device leaving its tenant: the admitting authority
+  // survives, so cancelling every pending remediation — and stamping
+  // 'device_org_changed_before_dispatch', which would be a lie — destroys live
+  // work. Same fence every sibling detach in breeze_cascade_device_org_id()
+  // carries.
+  runDb('leaves pending CIS remediation alone when the source org is merging', async () => {
+    const adminDb = getTestDb();
+    const partner = await createPartner();
+    const losingOrg = await createOrganization({ partnerId: partner.id });
+    const survivingOrg = await createOrganization({ partnerId: partner.id });
+    const losingSite = await createSite({ orgId: losingOrg.id });
+    const survivingSite = await createSite({ orgId: survivingOrg.id });
+    const [device] = await adminDb.insert(devices).values({
+      orgId: losingOrg.id,
+      siteId: losingSite.id,
+      agentId: `authority-merge-${randomUUID()}`,
+      hostname: 'authority-merge',
+      osType: 'linux',
+      osVersion: 'test',
+      architecture: 'amd64',
+      agentVersion: 'test',
+      status: 'online',
+    }).returning();
+    const [pending] = await adminDb.insert(cisRemediationActions).values({
+      orgId: losingOrg.id,
+      deviceId: device!.id,
+      checkId: 'authority.merge',
+      action: 'synthetic',
+      status: 'pending_approval',
+      approvalStatus: 'pending',
+      details: { synthetic: true },
+    }).returning();
+
+    await adminDb.update(organizations)
+      .set({ status: 'merging' })
+      .where(eq(organizations.id, losingOrg.id));
+    await adminDb.update(devices)
+      .set({ orgId: survivingOrg.id, siteId: survivingSite.id })
+      .where(eq(devices.id, device!.id));
+
+    const [survived] = await adminDb
+      .select({
+        status: cisRemediationActions.status,
+        orgId: cisRemediationActions.orgId,
+        details: cisRemediationActions.details,
+      })
+      .from(cisRemediationActions)
+      .where(eq(cisRemediationActions.id, pending!.id));
+    // Not cancelled, no false reason, and re-stamped to the survivor by the
+    // existing breeze_cascade_device_org_id() loop.
+    expect(survived).toMatchObject({ status: 'pending_approval', orgId: survivingOrg.id });
+    expect((survived!.details as Record<string, unknown>).cancelledReason).toBeUndefined();
+
+    // Positive control on the SAME pair of orgs: with the merge fence lifted,
+    // the identical UPDATE does cancel. Without this the assertion above would
+    // also pass if the trigger were simply broken.
+    await adminDb.update(organizations)
+      .set({ status: 'active' })
+      .where(eq(organizations.id, survivingOrg.id));
+    await adminDb.update(devices)
+      .set({ orgId: losingOrg.id, siteId: losingSite.id })
+      .where(eq(devices.id, device!.id));
+    const [cancelled] = await adminDb
+      .select({ status: cisRemediationActions.status, details: cisRemediationActions.details })
+      .from(cisRemediationActions)
+      .where(eq(cisRemediationActions.id, pending!.id));
+    expect(cancelled).toMatchObject({
+      status: 'cancelled',
+      details: expect.objectContaining({ cancelledReason: 'device_org_changed_before_dispatch' }),
+    });
+  }, 30_000);
+
+  // ==========================================================================
+  // SEC-118 review blocker 2 — the CONFIG-POLICY sibling path
+  // ==========================================================================
+  //
+  // `targetDeviceIds` is frozen at enqueue time by automationWorker's
+  // enqueueConfigPolicyRun, and admitConfigPolicyAutomationRun validates the
+  // POLICY owner, not the devices. Before this change the dispatch loaded its
+  // targets with `inArray(devices.id, targetDeviceIds)` and NO org predicate,
+  // so SEC-118 survived here untouched.
+  runDb('does not action a config-policy target that left the policy org between enqueue and dispatch', async () => {
+    const adminDb = getTestDb();
+    const partner = await createPartner();
+    const policyOrg = await createOrganization({ partnerId: partner.id });
+    const otherOrg = await createOrganization({ partnerId: partner.id });
+    const policySite = await createSite({ orgId: policyOrg.id });
+    const otherSite = await createSite({ orgId: otherOrg.id });
+
+    const [stayingDevice, movedDevice] = await adminDb.insert(devices).values([
+      {
+        orgId: policyOrg.id,
+        siteId: policySite.id,
+        agentId: `cp-staying-${randomUUID()}`,
+        hostname: 'cp-staying',
+        osType: 'linux',
+        osVersion: 'test',
+        architecture: 'amd64',
+        agentVersion: 'test',
+        status: 'online',
+      },
+      {
+        orgId: policyOrg.id,
+        siteId: policySite.id,
+        agentId: `cp-moved-${randomUUID()}`,
+        hostname: 'cp-moved',
+        osType: 'linux',
+        osVersion: 'test',
+        architecture: 'amd64',
+        agentVersion: 'test',
+        status: 'online',
+      },
+    ]).returning();
+
+    const [policy] = await adminDb.insert(configurationPolicies)
+      .values({ orgId: policyOrg.id, name: `SEC118 policy ${randomUUID()}` })
+      .returning({ id: configurationPolicies.id });
+    const [link] = await adminDb.insert(configPolicyFeatureLinks)
+      .values({ configPolicyId: policy!.id, featureType: 'automation' })
+      .returning({ id: configPolicyFeatureLinks.id });
+    const [cpAutomation] = await adminDb.insert(configPolicyAutomations)
+      .values({
+        featureLinkId: link!.id,
+        name: `SEC118 policy automation ${randomUUID()}`,
+        triggerType: 'schedule',
+        cronExpression: '0 2 * * *',
+        timezone: 'UTC',
+        actions: [{ type: 'execute_command', command: 'synthetic-config-policy' }],
+      })
+      .returning();
+
+    // The move happens AFTER enqueue (targetDeviceIds is already frozen) and
+    // BEFORE dispatch.
+    await adminDb.update(devices)
+      .set({ orgId: otherOrg.id, siteId: otherSite.id })
+      .where(eq(devices.id, movedDevice!.id));
+
+    const outcome = await withSystemDbAccessContext(() => executeConfigPolicyAutomationRun(
+      cpAutomation!,
+      policy!.id,
+      [stayingDevice!.id, movedDevice!.id],
+      'sec118-integration',
+    ));
+
+    const commands = await adminDb
+      .select({ deviceId: deviceCommands.deviceId })
+      .from(deviceCommands)
+      .where(inArray(deviceCommands.deviceId, [stayingDevice!.id, movedDevice!.id]));
+    expect(commands).toEqual([{ deviceId: stayingDevice!.id }]);
+
+    const deviceResults = await adminDb
+      .select({
+        deviceId: automationRunDeviceResults.deviceId,
+        status: automationRunDeviceResults.status,
+        error: automationRunDeviceResults.error,
+      })
+      .from(automationRunDeviceResults)
+      .where(eq(automationRunDeviceResults.runId, outcome.runId));
+    expect(deviceResults).toHaveLength(2);
+    expect(deviceResults).toEqual(expect.arrayContaining([
+      expect.objectContaining({ deviceId: stayingDevice!.id }),
+      expect.objectContaining({
+        deviceId: movedDevice!.id,
+        status: 'failed',
+        error: expect.stringContaining('device_org_changed'),
+      }),
+    ]));
+    // The denial is also on the run's own log, so an operator reading the run
+    // sees why the target is missing. (`devicesFailed` on the RETURN value is
+    // deliberately 0 here: an accepted asynchronous dispatch makes the run
+    // nonterminal, and that branch zeroes both counters until reconciliation.)
+    const [runRow] = await adminDb
+      .select({ logs: automationRuns.logs })
+      .from(automationRuns)
+      .where(eq(automationRuns.id, outcome.runId));
+    expect(JSON.stringify(runRow?.logs)).toContain('device_org_changed');
+  }, 30_000);
+});

--- a/apps/api/src/jobs/cisJobs.remediationAuthority.test.ts
+++ b/apps/api/src/jobs/cisJobs.remediationAuthority.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { queueCommandMock, selectMock, updateMock } = vi.hoisted(() => ({
+  queueCommandMock: vi.fn(),
+  selectMock: vi.fn(),
+  updateMock: vi.fn(),
+}));
+
+vi.mock('bullmq', () => ({
+  Queue: class {},
+  Worker: class { close = vi.fn(); on = vi.fn(); },
+  Job: class {},
+}));
+
+vi.mock('../db', () => ({
+  db: { select: selectMock, update: updateMock },
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('../db/schema', () => ({
+  cisBaselines: {},
+  cisRemediationActions: {
+    id: 'cisRemediationActions.id',
+    orgId: 'cisRemediationActions.orgId',
+  },
+  devices: {
+    id: 'devices.id',
+    orgId: 'devices.orgId',
+  },
+  organizations: {},
+}));
+
+vi.mock('../services/commandQueue', () => ({ queueCommand: queueCommandMock }));
+vi.mock('../services/cisHardening', () => ({ normalizeCisSchedule: vi.fn() }));
+vi.mock('../services/cisCatalog', () => ({ seedDefaultCisCheckCatalog: vi.fn() }));
+vi.mock('../services/eventBus', () => ({ publishEvent: vi.fn() }));
+vi.mock('../services/redis', () => ({
+  getRedisConnection: vi.fn(() => ({})),
+  getBullMQConnection: vi.fn(() => ({ host: 'localhost', port: 6379 })),
+  isBullMQAvailable: vi.fn(() => true),
+}));
+vi.mock('../services/sentry', () => ({ captureException: vi.fn() }));
+
+import { __testOnly } from './cisJobs';
+
+const ACTION = {
+  id: 'action-1',
+  orgId: 'org-source',
+  deviceId: 'device-1',
+  baselineId: 'baseline-1',
+  baselineResultId: 'result-1',
+  checkId: 'check-1',
+  action: 'apply',
+  status: 'queued',
+  approvalStatus: 'approved',
+  requestedBy: 'user-1',
+  details: {},
+};
+
+function selectRows(rows: unknown[], lock = false) {
+  const where = vi.fn().mockReturnValue(lock
+    ? { for: vi.fn().mockResolvedValue(rows) }
+    : { limit: vi.fn().mockResolvedValue(rows) });
+  return { from: vi.fn().mockReturnValue({ where }) };
+}
+
+describe('CIS remediation device organization authority', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queueCommandMock.mockResolvedValue({ id: 'command-1' });
+    updateMock.mockReturnValue({
+      set: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
+    });
+  });
+
+  it('refuses a queued source-org action when the target device is now in another org', async () => {
+    selectMock
+      .mockReturnValueOnce(selectRows([ACTION]))
+      .mockReturnValueOnce(selectRows([{ id: ACTION.deviceId, orgId: 'org-destination' }], true))
+      .mockReturnValueOnce(selectRows([ACTION], true));
+
+    const result = await __testOnly.processRemediationAction({
+      type: 'remediate-action',
+      actionId: ACTION.id,
+    });
+
+    expect(result).toEqual({ actionId: ACTION.id, queued: false, commandId: null });
+    expect(queueCommandMock).not.toHaveBeenCalled();
+  });
+
+  it('queues an eligible action when the locked device still belongs to its admitted org', async () => {
+    selectMock
+      .mockReturnValueOnce(selectRows([ACTION]))
+      .mockReturnValueOnce(selectRows([{ id: ACTION.deviceId, orgId: ACTION.orgId }], true))
+      .mockReturnValueOnce(selectRows([ACTION], true));
+
+    const result = await __testOnly.processRemediationAction({
+      type: 'remediate-action',
+      actionId: ACTION.id,
+    });
+
+    expect(result).toEqual({ actionId: ACTION.id, queued: true, commandId: 'command-1' });
+    expect(queueCommandMock).toHaveBeenCalledOnce();
+    // The command it creates carries claim-time provenance (#5128). A row with
+    // both submitted_org_id and deliver_by NULL is read by
+    // commandClaimEligibility as a pre-#5128 LEGACY row and delivered
+    // unconditionally, which would leave this lane with no post-creation move
+    // fence at all.
+    expect(queueCommandMock).toHaveBeenCalledWith(
+      ACTION.deviceId,
+      expect.any(String),
+      expect.any(Object),
+      ACTION.requestedBy,
+      { submittedOrgId: ACTION.orgId },
+    );
+  });
+});

--- a/apps/api/src/jobs/cisJobs.ts
+++ b/apps/api/src/jobs/cisJobs.ts
@@ -20,13 +20,31 @@ import { attachWorkerObservability } from './workerObservability';
 
 const { db } = dbModule;
 
+/**
+ * THROWS rather than degrading, mirroring routes/auth/helpers.ts.
+ *
+ * `withSystemDbAccessContext` is what opens the transaction, so a fallback to a
+ * bare `fn()` does not merely lose the RLS context — it silently turns OFF the
+ * atomicity `processRemediationActionInContext` depends on. Its `FOR UPDATE`
+ * locks on the device and the action would each live only for the length of
+ * their own statement, releasing before the command insert and the status
+ * transition they exist to fence, which is precisely the SEC-118 window. A
+ * console.warn on the way past is not an acceptable trade for that.
+ *
+ * The `typeof` check only ever fired under a test mock of `../db` that omitted
+ * the wrapper; production always exports it. Nesting inside an existing context
+ * is unaffected — the real `withSystemDbAccessContext` short-circuits on its
+ * own and never reaches this branch.
+ */
 const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
   const withSystem = dbModule.withSystemDbAccessContext;
-  if (typeof withSystem === 'function') {
-    return withSystem(fn);
+  if (typeof withSystem !== 'function') {
+    const message =
+      '[CisJobs] runWithSystemDbAccess: withSystemDbAccessContext is unavailable; refusing to run CIS work with no DB access context or transaction';
+    console.error(message);
+    throw new Error(message);
   }
-  console.warn('[CisJobs] withSystemDbAccessContext not available, running without system context');
-  return fn();
+  return withSystem(fn);
 };
 
 const CIS_QUEUE = 'cis-hardening';
@@ -328,19 +346,38 @@ async function processAggregateScores(): Promise<{ orgsProcessed: number }> {
   return { orgsProcessed: rows.length };
 }
 
-async function processRemediationAction(data: RemediateActionJobData): Promise<{
+async function processRemediationActionInContext(data: RemediateActionJobData): Promise<{
   actionId: string;
   queued: boolean;
   commandId: string | null;
 }> {
-  const [action] = await db
+  // Locator read only. Lock the device BEFORE locking/re-reading the action so
+  // this path uses the same order as a device org move (device -> children)
+  // and cannot deadlock while establishing current authority.
+  const [candidate] = await db
     .select()
     .from(cisRemediationActions)
     .where(eq(cisRemediationActions.id, data.actionId))
     .limit(1);
 
-  if (!action) {
+  if (!candidate) {
     console.warn(`[CisJobs] processRemediationAction: action ${data.actionId} not found`);
+    return { actionId: data.actionId, queued: false, commandId: null };
+  }
+
+  const [device] = await db
+    .select({ id: devices.id, orgId: devices.orgId })
+    .from(devices)
+    .where(eq(devices.id, candidate.deviceId))
+    .for('update');
+  const [action] = await db
+    .select()
+    .from(cisRemediationActions)
+    .where(eq(cisRemediationActions.id, data.actionId))
+    .for('update');
+
+  if (!action) {
+    console.warn(`[CisJobs] processRemediationAction: action ${data.actionId} disappeared before dispatch`);
     return { actionId: data.actionId, queued: false, commandId: null };
   }
   if (action.status !== 'queued' || action.approvalStatus !== 'approved') {
@@ -348,6 +385,26 @@ async function processRemediationAction(data: RemediateActionJobData): Promise<{
       `[CisJobs] processRemediationAction: action ${data.actionId} not eligible (status=${action.status}, approvalStatus=${action.approvalStatus})`,
     );
     return { actionId: data.actionId, queued: false, commandId: null };
+  }
+  if (!device || device.orgId !== action.orgId) {
+    console.warn(
+      `[CisJobs] processRemediationAction: action ${data.actionId} target is no longer in its admitted organization`,
+    );
+    await db
+      .update(cisRemediationActions)
+      .set({
+        status: 'cancelled',
+        details: {
+          ...(action.details ?? {}),
+          cancelledReason: 'device_org_changed_before_dispatch',
+          cancelledAt: new Date().toISOString(),
+        },
+      })
+      .where(and(
+        eq(cisRemediationActions.id, action.id),
+        eq(cisRemediationActions.status, 'queued'),
+      ));
+    return { actionId: action.id, queued: false, commandId: null };
   }
 
   let command;
@@ -364,7 +421,14 @@ async function processRemediationAction(data: RemediateActionJobData): Promise<{
         action: action.action,
         details: action.details ?? {},
       },
-      action.requestedBy ?? undefined
+      action.requestedBy ?? undefined,
+      // #5128 claim-time provenance. Without it this row lands with
+      // `submitted_org_id = NULL` AND `deliver_by = NULL`, which
+      // commandClaimEligibility reads as a pre-#5128 LEGACY row and delivers
+      // unconditionally — so the CIS lane had no post-creation move fence at
+      // all. The device lock above stops a command being CREATED after a move;
+      // this stops one created BEFORE the move from being CLAIMED after it.
+      { submittedOrgId: action.orgId },
     );
   } catch (error) {
     console.error(`[CisJobs] processRemediationAction: failed to queue command for action ${action.id}:`, error);
@@ -400,6 +464,17 @@ async function processRemediationAction(data: RemediateActionJobData): Promise<{
     queued: true,
     commandId: command.id,
   };
+}
+
+async function processRemediationAction(data: RemediateActionJobData): Promise<{
+  actionId: string;
+  queued: boolean;
+  commandId: string | null;
+}> {
+  // The worker normally already supplies this context. Keeping the transaction
+  // boundary here as well makes the lock/re-read/command insert/state change an
+  // indivisible contract for every caller (including maintenance/test hooks).
+  return runWithSystemDbAccess(() => processRemediationActionInContext(data));
 }
 
 function createCisWorker(): Worker<CisJobData> {
@@ -608,3 +683,7 @@ export async function scheduleCisRemediation(actionIds: string[]): Promise<numbe
   }
   return result.queuedActionIds.length;
 }
+
+export const __testOnly = {
+  processRemediationAction,
+};

--- a/apps/api/src/services/automationRuntime.configPolicy.test.ts
+++ b/apps/api/src/services/automationRuntime.configPolicy.test.ts
@@ -54,7 +54,7 @@ vi.mock('../db/schema', () => ({
   configurationPolicies: { id: 'id', orgId: 'orgId', partnerId: 'partnerId' },
   organizations: { id: 'id', partnerId: 'partnerId', type: 'type' },
   automationResourceBindings: { automationId: 'automationId' },
-  devices: { id: 'id', hostname: 'hostname', osType: 'osType', status: 'status' },
+  devices: { id: 'id', orgId: 'orgId', hostname: 'hostname', osType: 'osType', status: 'status' },
   scripts: { id: 'id', deletedAt: 'deletedAt' },
   notificationChannels: { id: 'id', orgId: 'orgId' },
   automations: { id: 'id', runCount: 'runCount' },
@@ -182,6 +182,40 @@ function mockInsertCapturingValues(result: unknown[]) {
     values: valuesMock,
   } as any);
   return valuesMock;
+}
+
+/**
+ * Serves the three select shapes the standalone target-authority path uses:
+ *
+ *   `.where(...)`                        -> the unlocked locator reads
+ *   `.where(...).orderBy(...).for(...)`  -> `devices FOR NO KEY UPDATE`
+ *   `.where(...).limit(1).for(...)`      -> `organizations FOR SHARE`
+ *
+ * The organizations arm is derived from the device rows' own `orgId`s so the
+ * default is "every org these devices sit in exists and belongs to
+ * `partner-1`". That deliberately does NOT decide the test: the owner check in
+ * `lockCurrentAutomationTargetDevices` still compares the DEVICE row's orgId
+ * against the automation's owner, which is what the moved-target cases turn on.
+ * Pass `orgRows` to model an org that is missing, reassigned, or quick-support.
+ */
+function selectableRows(
+  rows: unknown[],
+  _options: { locked?: boolean; orgRows?: unknown[] } = {},
+) {
+  const orgRows = _options.orgRows ?? [
+    ...new Set(
+      (rows as Array<{ orgId?: string }>).map((row) => row?.orgId).filter(Boolean) as string[],
+    ),
+  ].map((id) => ({ id, partnerId: 'partner-1', type: 'standard' }));
+  const whereResult = Object.assign(Promise.resolve(rows), {
+    orderBy: vi.fn().mockReturnValue({ for: vi.fn().mockResolvedValue(rows) }),
+    limit: vi.fn().mockReturnValue({ for: vi.fn().mockResolvedValue(orgRows) }),
+  });
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue(whereResult),
+    }),
+  };
 }
 
 function mockSelectChain(result: unknown[]) {
@@ -747,7 +781,9 @@ describe('executeConfigPolicyAutomationRun', () => {
     });
     resolveOwnedAutomationReferencesMock.mockResolvedValue({
       ...emptyResolvedReferences(),
-      softwareCatalogsById: new Map([['catalog-1', { id: 'catalog-1', name: 'Tool' }]]),
+      softwareCatalogsById: new Map([['catalog-1', {
+        id: 'catalog-1', name: 'Tool', orgId: 'org-1', partnerId: null,
+      }]]),
       softwareVersionsByCatalogId: new Map([['catalog-1', {
         id: 'version-1', catalogId: 'catalog-1', version: '1.0.0', supportedOs: ['linux'],
       }]]),
@@ -1312,15 +1348,12 @@ describe('executeAutomationRun durable dispatch', () => {
           from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([]) }),
         } as any;
       }
-      return {
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockResolvedValue([{
-            id: 'dev-1', orgId: 'org-1', hostname: 'host-1', displayName: null,
-            osType: 'linux', status: 'online', agentId: 'agent-1', siteId: null,
-            customFields: null,
-          }]),
-        }),
-      } as any;
+      const rows = [{
+        id: 'dev-1', orgId: 'org-1', hostname: 'host-1', displayName: null,
+        osType: 'linux', status: 'online', agentId: 'agent-1', siteId: null,
+        customFields: null,
+      }];
+      return selectableRows(rows, { locked: selectCall >= 5 }) as any;
     });
     vi.mocked(db.insert).mockReturnValue({
       values: vi.fn().mockReturnValue({
@@ -1351,6 +1384,188 @@ describe('executeAutomationRun durable dispatch', () => {
       commandId: 'cmd-ordinary',
     }));
     expect(reconcileRunMock).toHaveBeenCalledWith(run.id);
+  });
+
+  it('re-locks the current owner boundary around a standalone software deployment batch', async () => {
+    const run = {
+      id: 'run-deploy-lock', automationId: 'auto-deploy-lock', status: 'running',
+      triggeredBy: 'scheduler', logs: [],
+    };
+    const automation = {
+      id: 'auto-deploy-lock', orgId: 'org-1', partnerId: null, name: 'Deploy lock',
+      trigger: { type: 'manual' }, conditions: null,
+      actions: [{ type: 'deploy_software', catalogId: 'catalog-1' }],
+      onFailure: 'stop', notificationTargets: null, createdBy: 'user-1',
+    };
+    const device = {
+      id: 'dev-1', orgId: 'org-1', hostname: 'host-1', displayName: null,
+      osType: 'linux', status: 'online', agentId: 'agent-1', siteId: null, customFields: null,
+    };
+    resolveOwnedAutomationReferencesMock.mockResolvedValue({
+      ...emptyResolvedReferences(),
+      softwareCatalogsById: new Map([['catalog-1', {
+        id: 'catalog-1', name: 'Tool', orgId: 'org-1', partnerId: null,
+      }]]),
+      softwareVersionsByCatalogId: new Map([['catalog-1', {
+        id: 'version-1', catalogId: 'catalog-1', version: '1.0.0', supportedOs: ['linux'],
+      }]]),
+    });
+    let selectCall = 0;
+    vi.mocked(db.select).mockImplementation(() => {
+      selectCall += 1;
+      if (selectCall === 1 || selectCall === 2) {
+        return { from: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue(selectCall === 1 ? [run] : [automation]),
+        }) }) } as any;
+      }
+      if (selectCall === 3) return selectableRows([{
+        resourceKind: 'software_catalog', resourceId: 'catalog-1', state: 'active',
+        expectedResourceOrgId: 'org-1', expectedResourcePartnerId: null,
+        expectedResourceIsSystem: false,
+      }]) as any;
+      return selectableRows([device]) as any;
+    });
+    vi.mocked(db.insert).mockReturnValue({
+      values: vi.fn().mockReturnValue({ onConflictDoNothing: vi.fn().mockResolvedValue(undefined) }),
+    } as any);
+    vi.mocked(db.update).mockReturnValue({
+      set: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
+    } as any);
+    isDeviceSoftwareCurrentMock.mockResolvedValue(false);
+    createSoftwareDeploymentMock.mockResolvedValue({
+      deploymentId: 'deployment-1', status: 'pending', dispatchedDeviceIds: [device.id],
+      deviceResults: [{
+        deviceId: device.id, deploymentResultId: 'result-1', status: 'pending',
+        deviceCommandId: 'command-1', message: null,
+      }],
+    });
+
+    await executeAutomationRun(run.id, [device.id]);
+
+    expect(createSoftwareDeploymentMock).toHaveBeenCalledWith(expect.objectContaining({
+      orgId: device.orgId,
+      deviceIds: [device.id],
+    }));
+    // Initial target load, per-action refresh, then the load-bearing locked
+    // refresh enclosing createSoftwareDeployment.
+    expect(selectCall).toBeGreaterThanOrEqual(6);
+  });
+
+  it('does not dispatch any action when a queued target has moved outside the automation owner org', async () => {
+    const run = {
+      id: 'run-moved',
+      automationId: 'auto-source-org',
+      status: 'running',
+      triggeredBy: 'scheduler',
+      logs: [],
+    };
+    const automation = {
+      id: 'auto-source-org',
+      orgId: 'org-source',
+      partnerId: null,
+      name: 'Source organization automation',
+      trigger: { type: 'manual' },
+      conditions: null,
+      actions: [{ type: 'execute_command', command: 'echo must-not-run' }],
+      onFailure: 'stop',
+      notificationTargets: null,
+      createdBy: 'user-1',
+    };
+    let selectCall = 0;
+    vi.mocked(db.select).mockImplementation(() => {
+      selectCall += 1;
+      if (selectCall === 1 || selectCall === 2) {
+        const rows = selectCall === 1 ? [run] : [automation];
+        return {
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(rows) }),
+          }),
+        } as any;
+      }
+      if (selectCall === 3) {
+        return { from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([]) }) } as any;
+      }
+      // Simulate the stale bare-id lookup returning the same device after an
+      // independently authorized move to another organization.
+      return selectableRows([{
+        id: 'dev-moved', orgId: 'org-destination', hostname: 'moved-host', displayName: null,
+        osType: 'linux', status: 'online', agentId: 'agent-moved', siteId: null,
+        customFields: null,
+      }]) as any;
+    });
+    vi.mocked(db.insert).mockReturnValue({
+      values: vi.fn().mockReturnValue({ onConflictDoNothing: vi.fn().mockResolvedValue(undefined) }),
+    } as any);
+    vi.mocked(db.update).mockReturnValue({
+      set: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
+    } as any);
+
+    await executeAutomationRun(run.id, ['dev-moved']);
+
+    expect(seedActionResultsMock).not.toHaveBeenCalled();
+    expect(recordActionDispatchMock).not.toHaveBeenCalled();
+    expect(dispatchScriptToDevice).not.toHaveBeenCalled();
+    expect(createSoftwareDeploymentMock).not.toHaveBeenCalled();
+  });
+
+  it('stops before the next action when a target moves outside the owner org during a run', async () => {
+    const run = {
+      id: 'run-mid-move', automationId: 'auto-mid-move', status: 'running',
+      triggeredBy: 'scheduler', logs: [],
+    };
+    const automation = {
+      id: 'auto-mid-move', orgId: 'org-source', partnerId: null,
+      name: 'Mid-run movement automation', trigger: { type: 'manual' }, conditions: null,
+      actions: [
+        { type: 'execute_command', command: 'echo first' },
+        { type: 'execute_command', command: 'echo second' },
+      ],
+      onFailure: 'stop', notificationTargets: null, createdBy: 'user-1',
+    };
+    const sourceDevice = {
+      id: 'dev-mid-move', orgId: 'org-source', hostname: 'source-host', displayName: null,
+      osType: 'linux', status: 'online', agentId: 'agent-source', siteId: null,
+      customFields: null,
+    };
+    const movedDevice = { ...sourceDevice, orgId: 'org-destination', agentId: 'agent-destination' };
+    let selectCall = 0;
+    vi.mocked(db.select).mockImplementation(() => {
+      selectCall += 1;
+      if (selectCall === 1 || selectCall === 2) {
+        const rows = selectCall === 1 ? [run] : [automation];
+        return { from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(rows) }),
+        }) } as any;
+      }
+      if (selectCall === 3) {
+        return { from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([]) }) } as any;
+      }
+      // Selects 4..8 are the admission load plus the WHOLE of action 0:
+      // per-action load (5), then the lock sequence — candidate org read (6),
+      // `organizations FOR SHARE` (7), `devices FOR NO KEY UPDATE` (8). The
+      // device moves only once action 0 has fully dispatched, so action 1's
+      // re-read at select 9 is the first to see it in the destination org.
+      const rows = selectCall <= 8 ? [sourceDevice] : [movedDevice];
+      return selectableRows(rows, { locked: selectCall === 8 }) as any;
+    });
+    vi.mocked(db.insert).mockReturnValue({
+      values: vi.fn().mockReturnValue({ onConflictDoNothing: vi.fn().mockResolvedValue(undefined) }),
+    } as any);
+    vi.mocked(db.update).mockReturnValue({
+      set: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
+    } as any);
+    vi.mocked(dispatchScriptToDevice).mockResolvedValue({
+      ok: true, commandId: 'cmd-first', executionId: null, delivered: true,
+      executedAt: new Date(), ignoredParameters: [],
+    } as any);
+
+    await executeAutomationRun(run.id, [sourceDevice.id]);
+
+    expect(dispatchScriptToDevice).toHaveBeenCalledOnce();
+    expect(recordActionDispatchMock).toHaveBeenCalledWith(expect.objectContaining({
+      runId: run.id, deviceId: sourceDevice.id, actionIndex: 1, status: 'failed',
+      message: expect.stringContaining('no longer belongs'),
+    }));
   });
 
   // #3525 W05 — the dispatch fence. A BullMQ job is not permission to

--- a/apps/api/src/services/automationRuntime.ts
+++ b/apps/api/src/services/automationRuntime.ts
@@ -2339,6 +2339,208 @@ export async function executeDeploySoftwareActions(args: {
 
 type OrderedAutomationDevice = ActionExecutionContext['device'];
 
+const AUTOMATION_TARGET_AUTHORITY_LOST =
+  'Target device no longer belongs to an organization owned by this automation';
+
+/**
+ * Config-policy sibling of `AUTOMATION_TARGET_AUTHORITY_LOST`. Deliberately a
+ * different string: the boundary that rejected the device is the POLICY's org,
+ * not an automation owner set, and an operator reading the run needs to know
+ * which one moved.
+ */
+const CONFIG_POLICY_TARGET_ORG_CHANGED =
+  'device_org_changed: target device left the organization this configuration policy run was admitted for';
+
+/**
+ * Resolve the current device rows through the automation's CURRENT owner
+ * boundary. A queued device id is only a locator: it is never authority to
+ * cross an organization move. Re-reading the full row also prevents later
+ * actions in a long run from reusing stale org/site/agent metadata.
+ */
+async function loadCurrentAutomationTargetDevices(
+  automation: AutomationRow,
+  targetDeviceIds: readonly string[],
+): Promise<OrderedAutomationDevice[]> {
+  return (await loadAutomationTargetAdmission(automation, targetDeviceIds)).admitted;
+}
+
+type AutomationTargetAdmission = {
+  admitted: OrderedAutomationDevice[];
+  /**
+   * Targets that still EXIST but no longer sit in the automation's current
+   * owner org set. Kept separately so the caller can record them as FAILED
+   * instead of letting them vanish from a run that still counts them in
+   * `devicesTargeted`.
+   *
+   * Devices that no longer exist at all are deliberately absent: an
+   * `automation_run_device_results` row needs a live `device_id` FK target, so
+   * there is nowhere to record them. They remain a log line only.
+   */
+  movedOut: OrderedAutomationDevice[];
+};
+
+/**
+ * The partitioning form of `loadCurrentAutomationTargetDevices`: same owner
+ * boundary, but it also returns the targets the boundary REJECTED so a caller
+ * can make that rejection visible.
+ */
+async function loadAutomationTargetAdmission(
+  automation: AutomationRow,
+  targetDeviceIds: readonly string[],
+): Promise<AutomationTargetAdmission> {
+  if (targetDeviceIds.length === 0) return { admitted: [], movedOut: [] };
+  const requested = new Set(targetDeviceIds);
+
+  const rows = await db
+    .select({
+      id: devices.id,
+      orgId: devices.orgId,
+      hostname: devices.hostname,
+      displayName: devices.displayName,
+      osType: devices.osType,
+      status: devices.status,
+      agentId: devices.agentId,
+      siteId: devices.siteId,
+      customFields: devices.customFields,
+    })
+    .from(devices)
+    .where(inArray(devices.id, [...targetDeviceIds]));
+
+  // The owner-org filter is in process rather than an `inArray(devices.orgId,
+  // ownerOrgIds)` SQL predicate precisely because this function must SEE the
+  // rejects. Set membership on the exact same id list is no weaker than the
+  // predicate was; what it is not is a second, independent check, so nothing
+  // below may treat a row as admitted without consulting `allowedOrgs`.
+  const ownerOrgIds = await automationOwnerOrgIds(automation);
+  const allowedOrgs = new Set(ownerOrgIds);
+  const admitted: OrderedAutomationDevice[] = [];
+  const movedOut: OrderedAutomationDevice[] = [];
+  for (const row of rows) {
+    if (!requested.has(row.id)) continue;
+    (allowedOrgs.has(row.orgId) ? admitted : movedOut).push(row);
+  }
+  return { admitted, movedOut };
+}
+
+/**
+ * Lock the organizations this authority check will decide against, `FOR SHARE`,
+ * in ascending UUID order, sequentially.
+ *
+ * This MUST be the first locking statement of the caller's transaction. It is
+ * the repo-wide cross-org lock order (#3778): `organizations FOR SHARE
+ * (ascending) -> devices -> children`, the same prefix
+ * `readOrgStampingDefaultsMany` (services/orgCurrencyCore.ts) gives the device
+ * move (routes/devices/moveOrg.ts) and the ticket move
+ * (services/ticketService.ts). Taking devices first and organizations second —
+ * which this helper used to do for partner-owned automations — is the exact
+ * AB-BA that Postgres resolves by killing one side with 40P01, i.e. a dispatch
+ * concurrent with a move of one of its own targets would abort at random.
+ *
+ * Sequential on purpose, for the same reason the currency helper is: a
+ * `Promise.all` lets postgres.js interleave the lock requests and loses the
+ * ascending order the rule exists to give.
+ *
+ * `FOR SHARE`, not `FOR NO KEY UPDATE`: two dispatches for the same partner
+ * must not serialize against each other, and the move takes these same rows
+ * `FOR SHARE` too. What this lock buys is that the org's `partner_id` and
+ * `type` cannot be rewritten between this read and the device decision below.
+ *
+ * TOLERANT of a missing org: the id is simply absent from the returned map, and
+ * every device sitting in it then fails closed at the membership re-check.
+ */
+async function lockOrganizationsForAuthority(
+  orgIds: Iterable<string>,
+): Promise<Map<string, { partnerId: string | null; type: string }>> {
+  const ordered = [...new Set(orgIds)].sort();
+  const locked = new Map<string, { partnerId: string | null; type: string }>();
+  for (const orgId of ordered) {
+    const [org] = await db
+      .select({ id: organizations.id, partnerId: organizations.partnerId, type: organizations.type })
+      .from(organizations)
+      .where(eq(organizations.id, orgId))
+      .limit(1)
+      .for('share');
+    if (org) locked.set(org.id, { partnerId: org.partnerId, type: org.type });
+  }
+  return locked;
+}
+
+/**
+ * Lock the exact current target rows before an action sink. Device ids in a
+ * queued run are locators, not authority: the device lock serializes against
+ * org moves, and the organization lock taken first means a concurrent partner
+ * reassignment cannot widen the worker after admission. Call only inside one
+ * transaction that stays open across the corresponding action effect.
+ *
+ * ORDER: organizations `FOR SHARE` (ascending) -> devices `FOR NO KEY UPDATE`
+ * -> membership re-check against the LOCKED organization rows. The first
+ * statement is an UNLOCKED locator read whose only job is to discover which
+ * organizations this transaction is about to need; it takes no locks and
+ * decides nothing.
+ *
+ * A device that moves into an organization we did not lock in step 2 — because
+ * it was not there during step 1 — is rejected rather than admitted. Fail
+ * closed: an unlocked org is an org whose ownership we cannot vouch for.
+ *
+ * `NO KEY UPDATE` on devices is deliberate. It conflicts with ANY concurrent
+ * `UPDATE devices SET org_id = ...` (two `NO KEY UPDATE` requests on one row
+ * conflict with each other), which is the ownership change this fence exists to
+ * serialize against, while still permitting the sink's child-row foreign-key
+ * checks to take the compatible `KEY SHARE`. `FOR UPDATE` self-blocks the
+ * deploy-software path, because that sink creates its deployment/result rows in
+ * the established independent system transaction while this authority
+ * transaction is still open.
+ */
+async function lockCurrentAutomationTargetDevices(
+  automation: AutomationRow,
+  targetDeviceIds: readonly string[],
+): Promise<OrderedAutomationDevice[]> {
+  if (targetDeviceIds.length === 0) return [];
+  const requested = new Set(targetDeviceIds);
+
+  // 1. Unlocked locator read. Discovers the org set only — never authority.
+  const candidateOrgRows = await db
+    .select({ orgId: devices.orgId })
+    .from(devices)
+    .where(inArray(devices.id, [...targetDeviceIds]));
+  const orgIdsToLock = new Set(candidateOrgRows.map((row) => row.orgId));
+  // An org-owned automation can only ever admit its OWN org, so lock that one
+  // too even when no candidate currently sits in it: the device may move back.
+  if (automation.orgId) orgIdsToLock.add(automation.orgId);
+  if (orgIdsToLock.size === 0) return [];
+
+  // 2. organizations FOR SHARE, ascending — the first lock this tx takes.
+  const lockedOrgs = await lockOrganizationsForAuthority(orgIdsToLock);
+
+  // 3. devices FOR NO KEY UPDATE, ascending by id.
+  const rows = await db
+    .select({
+      id: devices.id,
+      orgId: devices.orgId,
+      hostname: devices.hostname,
+      displayName: devices.displayName,
+      osType: devices.osType,
+      status: devices.status,
+      agentId: devices.agentId,
+      siteId: devices.siteId,
+      customFields: devices.customFields,
+    })
+    .from(devices)
+    .where(inArray(devices.id, [...targetDeviceIds]))
+    .orderBy(devices.id)
+    .for('no key update');
+
+  // 4. Membership re-check against the rows locked in step 2.
+  return rows.filter((row) => {
+    if (!requested.has(row.id)) return false;
+    const org = lockedOrgs.get(row.orgId);
+    if (!org) return false;
+    if (automation.orgId) return row.orgId === automation.orgId;
+    if (!automation.partnerId) return false;
+    return org.partnerId === automation.partnerId && org.type !== 'quick_support';
+  });
+}
+
 async function executeAutomationActionsInOrder(args: {
   actions: AutomationAction[];
   devices: OrderedAutomationDevice[];
@@ -2352,6 +2554,10 @@ async function executeAutomationActionsInOrder(args: {
   notificationTargets?: NotificationTargets;
   createdBy: string | null;
   resolvedReferences: ResolvedAutomationReferences;
+  /** Standalone queued runs carry locator-only target ids and must refresh the
+   * automation owner boundary before every action. Config-policy runs have a
+   * separate assignment/winner authority path and do not use this switch. */
+  reauthorizeStandaloneTargets?: boolean;
 }): Promise<{
   logs: AutomationLogEntry[];
   devicesSucceeded: number;
@@ -2402,13 +2608,33 @@ async function executeAutomationActionsInOrder(args: {
     }
   };
 
+  const handleAuthorityLost = async (
+    device: OrderedAutomationDevice,
+    actionIndex: number,
+  ): Promise<void> => {
+    failedDeviceIds.add(device.id);
+    activeDeviceIds.delete(device.id);
+    await recordAutomationRuntimeActionDispatch({
+      runId: args.runId,
+      deviceId: device.id,
+      actionIndex,
+      status: 'failed',
+      message: AUTOMATION_TARGET_AUTHORITY_LOST,
+    });
+    await skipTrailingAutomationActions(args.runId, device.id, args.actions, actionIndex);
+    logs.push(logEntry(AUTOMATION_TARGET_AUTHORITY_LOST, 'error', {
+      actionIndex,
+      deviceId: device.id,
+    }));
+  };
+
   // Execute action-major, not device-major. Deployment dispatch is batched
   // across the still-active devices for one normalized action at a time. This
   // preserves both batching and stop/notify ordering: a refusal at action N is
   // known before action N+1 can dispatch on that device.
   for (const [actionIndex, action] of args.actions.entries()) {
-    const activeDevices = args.devices.filter((device) => activeDeviceIds.has(device.id));
-    if (activeDevices.length === 0) break;
+    const candidateDevices = args.devices.filter((device) => activeDeviceIds.has(device.id));
+    if (candidateDevices.length === 0) break;
 
     // Fence, once per action: a long run stops between actions, not only
     // between devices. Checked before the deployment batch too, which
@@ -2424,23 +2650,58 @@ async function executeAutomationActionsInOrder(args: {
       break;
     }
 
+    // A multi-action run can outlive a device move. Refresh the owner boundary
+    // immediately before EVERY action, not merely when the run starts. Missing
+    // rows include deletion and moves outside an org/partner automation's
+    // current owner set; both fail closed before an action-specific sink.
+    const activeDevices = args.reauthorizeStandaloneTargets
+      ? await withAutomationRuntimeDb(() =>
+        loadCurrentAutomationTargetDevices(args.automation, candidateDevices.map((device) => device.id)))
+      : candidateDevices;
+    const currentIds = new Set(activeDevices.map((device) => device.id));
+    for (const stale of candidateDevices) {
+      if (currentIds.has(stale.id)) continue;
+      await handleAuthorityLost(stale, actionIndex);
+    }
+    if (activeDevices.length === 0) continue;
+
     if (action.type === 'deploy_software') {
       try {
-        const deployOutcome = await executeDeploySoftwareActions({
-          actions: args.actions,
-          actionIndexes: new Set([actionIndex]),
-          devices: activeDevices.map((device) => ({
-            id: device.id,
-            osType: device.osType,
-            orgId: device.orgId,
-          })),
-          createdBy: args.createdBy,
-          runId: args.runId,
-          resolvedReferences: args.resolvedReferences,
+        const { deployOutcome, lockedDevices } = await withAutomationRuntimeDb(async () => {
+          const lockedDevices = args.reauthorizeStandaloneTargets
+            ? await lockCurrentAutomationTargetDevices(
+              args.automation,
+              activeDevices.map((device) => device.id),
+            )
+            : activeDevices;
+          const deployOutcome = lockedDevices.length > 0
+            ? await executeDeploySoftwareActions({
+              actions: args.actions,
+              actionIndexes: new Set([actionIndex]),
+              devices: lockedDevices.map((device) => ({
+                id: device.id,
+                osType: device.osType,
+                orgId: device.orgId,
+              })),
+              createdBy: args.createdBy,
+              runId: args.runId,
+              resolvedReferences: args.resolvedReferences,
+            })
+            : {
+              logs: [],
+              deployedDeviceIds: new Set<string>(),
+              failedDeviceIds: new Set<string>(),
+              failed: false,
+            };
+          return { deployOutcome, lockedDevices };
         });
+        const lockedIds = new Set(lockedDevices.map((device) => device.id));
+        for (const stale of activeDevices) {
+          if (!lockedIds.has(stale.id)) await handleAuthorityLost(stale, actionIndex);
+        }
         logs.push(...deployOutcome.logs);
         if (deployOutcome.deployedDeviceIds.size > 0) hasNonterminalActions = true;
-        for (const device of activeDevices) {
+        for (const device of lockedDevices) {
           if (deployOutcome.failedDeviceIds.has(device.id)) {
             await handleFailure(device, actionIndex, 'Software deployment dispatch failed');
           }
@@ -2472,23 +2733,35 @@ async function executeAutomationActionsInOrder(args: {
         // Fence, per device: a run cancelled while the previous device was
         // being dispatched must not reach this one.
         await assertRunNotCancelledInRuntime(args.runId);
-        const result = await withAutomationRuntimeDb(() => executeAction(action, actionIndex, buildActionExecutionContext({
-          automation: args.automation,
-          runId: args.runId,
-          scriptsById: args.scriptsById,
-          channelsById: args.channelsById,
-          variableScope: args.variableScope,
-          trigger: args.trigger,
-        }, device)));
+        const admitted = await withAutomationRuntimeDb(async () => {
+          const [currentDevice] = args.reauthorizeStandaloneTargets
+            ? await lockCurrentAutomationTargetDevices(args.automation, [device.id])
+            : [device];
+          if (!currentDevice) return null;
+          const result = await executeAction(action, actionIndex, buildActionExecutionContext({
+            automation: args.automation,
+            runId: args.runId,
+            scriptsById: args.scriptsById,
+            channelsById: args.channelsById,
+            variableScope: args.variableScope,
+            trigger: args.trigger,
+          }, currentDevice));
+          return { currentDevice, result };
+        });
+        if (!admitted) {
+          await handleAuthorityLost(device, actionIndex);
+          return;
+        }
+        const { currentDevice, result } = admitted;
         logs.push(result.log);
-        await persistActionExecutionOutcome(args.runId, device.id, actionIndex, result);
-        const compensation = await cancelDispatchIfRunCancelled(args.runId, device.id, result);
+        await persistActionExecutionOutcome(args.runId, currentDevice.id, actionIndex, result);
+        const compensation = await cancelDispatchIfRunCancelled(args.runId, currentDevice.id, result);
         if (compensation !== 'not_needed') {
           cancelled = true;
           const line = DISPATCH_COMPENSATION_LOG[compensation];
           logs.push(logEntry(line.message, line.level, {
             actionIndex,
-            deviceId: device.id,
+            deviceId: currentDevice.id,
           }));
           return;
         }
@@ -2500,7 +2773,7 @@ async function executeAutomationActionsInOrder(args: {
           hasNonterminalActions = true;
         }
         if (result.outcome.status === 'failed') {
-          await handleFailure(device, actionIndex, result.log.message);
+          await handleFailure(currentDevice, actionIndex, result.log.message);
         }
       } catch (err) {
         if (isRunCancelledError(err)) {
@@ -2679,6 +2952,44 @@ async function seedAutomationDeviceResults(
 }
 
 /**
+ * Record a target that was denied BEFORE the run's first action as a terminal
+ * `failed` device result carrying the reason.
+ *
+ * Without this a pre-run denial is invisible: the device is filtered out of
+ * `deviceRows`, never seeded, and the run still reports `devicesTargeted` = N.
+ * An operator sees a run that targeted three devices, shows two, and explains
+ * nothing about the third — which is indistinguishable from the bug this whole
+ * change exists to close.
+ *
+ * `org_id` is the device's CURRENT org, matching `seedAutomationDeviceResults`
+ * and the `automation_run_device_results` denormalization contract (the device
+ * move re-stamps this column anyway, so any other choice would be transient).
+ */
+async function recordPreRunDeniedDeviceResults(
+  runId: string,
+  deniedDevices: DeviceExecutionRow[],
+  reason: string,
+): Promise<void> {
+  if (deniedDevices.length === 0) return;
+  const now = new Date();
+  await db
+    .insert(automationRunDeviceResults)
+    .values(
+      deniedDevices.map((device) => ({
+        runId,
+        deviceId: device.id,
+        orgId: device.orgId,
+        status: 'failed' as const,
+        error: reason,
+        completedAt: now,
+      })),
+    )
+    .onConflictDoNothing({
+      target: [automationRunDeviceResults.runId, automationRunDeviceResults.deviceId],
+    });
+}
+
+/**
  * Best-effort recovery when executeAutomationRun throws (#2023): a run left in
  * `running` (and its seeded device rows left `pending`/`running`) would show as
  * a perpetually in-progress run in the history UI and keep the client poller
@@ -2811,25 +3122,10 @@ async function executeAutomationRunInner(
     })
     .where(eq(automationRuns.id, run.id)));
 
-  const deviceRows = targetDeviceIds.length > 0
-    ? await withAutomationRuntimeDb(() => db
-      .select({
-        id: devices.id,
-        orgId: devices.orgId,
-        hostname: devices.hostname,
-        displayName: devices.displayName,
-        osType: devices.osType,
-        status: devices.status,
-        agentId: devices.agentId,
-        // #3409 PR3 P3 — sourced parameters (`builtin` / `deviceCustomField`)
-        // resolve against these. Selected once here with the rest of the run's
-        // device snapshot; see ActionExecutionContext.device.
-        siteId: devices.siteId,
-        customFields: devices.customFields,
-      })
-      .from(devices)
-      .where(inArray(devices.id, targetDeviceIds)))
-    : [];
+  const targetAdmission = await withAutomationRuntimeDb(() =>
+    loadAutomationTargetAdmission(automation, targetDeviceIds));
+  const deviceRows = targetAdmission.admitted;
+  const preRunDeniedDevices = targetAdmission.movedOut;
 
   const scriptsById = resolvedReferences.scriptsById;
   const channelsById = resolvedReferences.notificationChannelsById;
@@ -2850,6 +3146,13 @@ async function executeAutomationRunInner(
   for (const device of deviceRows) {
     await seedDeviceAutomationActions(run.id, device, normalized.actions);
   }
+  // Targets the owner boundary rejected BEFORE the first action get a terminal
+  // failed row with the reason, not silence (see recordPreRunDeniedDeviceResults).
+  await withAutomationRuntimeDb(() => recordPreRunDeniedDeviceResults(
+    run.id,
+    preRunDeniedDevices,
+    AUTOMATION_TARGET_AUTHORITY_LOST,
+  ));
 
   const existingLogs = getExistingLogs(run.logs);
   const logs: AutomationLogEntry[] = [...existingLogs];
@@ -2874,9 +3177,21 @@ async function executeAutomationRunInner(
     onFailure: normalized.onFailure,
     notificationTargets: normalized.notificationTargets,
     resolvedReferences,
+    reauthorizeStandaloneTargets: true,
   });
   logs.push(...actionOutcome.logs);
-  const { devicesSucceeded, devicesFailed, hasNonterminalActions } = actionOutcome;
+  const { devicesSucceeded, hasNonterminalActions } = actionOutcome;
+  // Pre-run denials count as failures. They are real, recorded, terminal device
+  // results, and `devicesTargeted` already includes them.
+  const devicesFailed = actionOutcome.devicesFailed + preRunDeniedDevices.length;
+  if (preRunDeniedDevices.length > 0) {
+    logs.push(logEntry(AUTOMATION_TARGET_AUTHORITY_LOST, 'error', {
+      details: {
+        deviceIds: preRunDeniedDevices.map((device) => device.id),
+        phase: 'pre_run',
+      },
+    }));
+  }
 
   logs.push(logEntry('Automation dispatch phase finished', devicesFailed > 0 ? 'warning' : 'info', {
     details: {
@@ -2890,9 +3205,10 @@ async function executeAutomationRunInner(
   await withAutomationRuntimeDb(() => reconcileAutomationRun(run.id));
   if (deviceRows.length === 0 || normalized.actions.length === 0) {
     await withAutomationRuntimeDb(() => db.update(automationRuns).set({
-      status: 'completed',
+      // A run whose ONLY targets were denied is not a clean no-op completion.
+      status: preRunDeniedDevices.length > 0 ? 'failed' : 'completed',
       devicesSucceeded: 0,
-      devicesFailed: 0,
+      devicesFailed: preRunDeniedDevices.length,
       completedAt: new Date(),
     }).where(and(eq(automationRuns.id, run.id), eq(automationRuns.status, 'running'))));
   }
@@ -3115,7 +3431,21 @@ export async function executeConfigPolicyAutomationRun(
 
   const onFailure = automation.onFailure ?? 'stop';
 
-  // Load target devices
+  // Load target devices.
+  //
+  // SEC-118, sibling path. `targetDeviceIds` was frozen at ENQUEUE time by
+  // automationWorker's `enqueueConfigPolicyRun`, and `admitConfigPolicyAutomationRun`
+  // above validates the POLICY owner, not the devices. So this read is the only
+  // place the device side of the boundary can be enforced, and without
+  // `eq(devices.orgId, orgId)` a device moved to another tenant between enqueue
+  // and dispatch is still actioned by the source org's policy automation.
+  //
+  // Intersecting against the live org here is the same shape
+  // services/softwareDeployment.ts uses for its own queued-target re-check.
+  // Config-policy runs keep their separate assignment/effective-winner
+  // authority and deliberately do NOT take the standalone per-action
+  // `reauthorizeStandaloneTargets` path; this is the admission-time clamp that
+  // path's absence would otherwise leave open.
   const deviceRows = targetDeviceIds.length > 0
     ? await withAutomationRuntimeDb(() => db
       .select({
@@ -3132,7 +3462,24 @@ export async function executeConfigPolicyAutomationRun(
         customFields: devices.customFields,
       })
       .from(devices)
-      .where(inArray(devices.id, targetDeviceIds)))
+      .where(and(inArray(devices.id, targetDeviceIds), eq(devices.orgId, orgId))))
+    : [];
+  // Targets that still exist but have left the policy's org. Recorded as failed
+  // rather than dropped, for the reason in recordPreRunDeniedDeviceResults.
+  const admittedIds = new Set(deviceRows.map((device) => device.id));
+  const deniedDeviceIds = targetDeviceIds.filter((id) => !admittedIds.has(id));
+  const deniedDevices = deniedDeviceIds.length > 0
+    ? await withAutomationRuntimeDb(() => db
+      .select({
+        id: devices.id,
+        orgId: devices.orgId,
+        hostname: devices.hostname,
+        displayName: devices.displayName,
+        osType: devices.osType,
+        status: devices.status,
+      })
+      .from(devices)
+      .where(inArray(devices.id, deniedDeviceIds)))
     : [];
   // #3525 W05 fence — see the standalone runner. Config-policy runs are out of
   // scope for the cancel ROUTE (OD10-B: automation_runs' config-policy RLS arm
@@ -3149,6 +3496,11 @@ export async function executeConfigPolicyAutomationRun(
   for (const device of deviceRows) {
     await seedDeviceAutomationActions(run.id, device, actions);
   }
+  await withAutomationRuntimeDb(() => recordPreRunDeniedDeviceResults(
+    run.id,
+    deniedDevices,
+    CONFIG_POLICY_TARGET_ORG_CHANGED,
+  ));
 
   const notificationChannelIds = new Set<string>();
   for (const action of actions) {
@@ -3197,7 +3549,13 @@ export async function executeConfigPolicyAutomationRun(
     resolvedReferences: admission.resolvedReferences,
   });
   logs.push(...actionOutcome.logs);
-  const { devicesSucceeded, devicesFailed, hasNonterminalActions } = actionOutcome;
+  const { devicesSucceeded, hasNonterminalActions } = actionOutcome;
+  const devicesFailed = actionOutcome.devicesFailed + deniedDeviceIds.length;
+  if (deniedDeviceIds.length > 0) {
+    logs.push(logEntry(CONFIG_POLICY_TARGET_ORG_CHANGED, 'error', {
+      details: { deviceIds: [...deniedDeviceIds], phase: 'pre_run' },
+    }));
+  }
 
   logs.push(logEntry('Config policy automation dispatch phase finished', devicesFailed > 0 ? 'warning' : 'info', {
     details: {
@@ -3211,9 +3569,9 @@ export async function executeConfigPolicyAutomationRun(
   await withAutomationRuntimeDb(() => reconcileAutomationRun(run.id));
   if (deviceRows.length === 0 || actions.length === 0) {
     await withAutomationRuntimeDb(() => db.update(automationRuns).set({
-      status: 'completed',
+      status: deniedDeviceIds.length > 0 ? 'failed' : 'completed',
       devicesSucceeded: 0,
-      devicesFailed: 0,
+      devicesFailed: deniedDeviceIds.length,
       completedAt: new Date(),
     }).where(and(eq(automationRuns.id, run.id), eq(automationRuns.status, 'running'))));
   }
@@ -3246,4 +3604,5 @@ export const __testOnly = {
   // a script that keeps running) is provable without driving a full mocked run.
   cancelDispatchIfRunCancelled,
   executeAutomationActionsInOrder,
+  lockCurrentAutomationTargetDevices,
 };


### PR DESCRIPTION
## Summary

**SEC-118 (Medium) — a queued device id was treated as standing authority to act on that device.**

An operator legitimately enqueues a standalone automation run, a config-policy automation run, or a CIS remediation against a device in org A. A separately authorized operator then moves that exact device to org B. The system worker still created a raw command / script dispatch / software deployment for that device under **org A's** authority, because the run's target device ids were captured at admission and never re-checked. For CIS the leak was worse: the device-move cascade re-stamps `cis_remediation_actions.org_id` to org B, so the command the worker later created carried no evidence of its org A admission at all.

The invariant this PR enforces is that **a queued device id is only a locator, never authority**:

- **Standalone automation runs re-resolve their targets through the automation's *current* owner org set immediately before every action** (`loadCurrentAutomationTargetDevices`), not only at run start — a multi-action run can outlive a move. Targets that moved or were deleted fail closed: a `failed` action result with `Target device no longer belongs to an organization owned by this automation`, plus the trailing actions skipped for that device. Targets already outside the boundary when the run starts get a **terminal failed device result naming the reason** (`recordPreRunDeniedDeviceResults`) rather than silently vanishing from a run that still counts them in `devices_targeted`.
- **The boundary is locked in the repo-wide cross-org order (#3778)** — `organizations FOR SHARE` ascending and sequential, *then* `devices FOR NO KEY UPDATE`, then the membership re-check **against the locked organization rows** (`lockOrganizationsForAuthority` + `lockCurrentAutomationTargetDevices`). A device that moved into an org the transaction did not lock is rejected, not admitted. The lock is **held across** the sink — for `deploy_software` the sink deliberately creates its deployment/result rows in a separate, independent system transaction, so the authority lock is held *across* that transaction rather than enclosing its writes. `NO KEY UPDATE` is the right strength because **two `NO KEY UPDATE` requests on one row conflict with each other**, so it conflicts with any concurrent `UPDATE devices SET org_id = …` (and with `organizations.partner_id`), while still leaving the sink's child-row FK checks free to take the compatible `KEY SHARE`; plain `FOR UPDATE` self-blocks that separate deployment transaction.
- **Config-policy runs** — whose `targetDeviceIds` are frozen at enqueue time by `automationWorker`'s `enqueueConfigPolicyRun`, and whose `admitConfigPolicyAutomationRun` validates the *policy owner*, not the devices — now intersect their targets against a live `eq(devices.orgId, admission.context.orgId)` at load and record the dropped ones as failed with reason `device_org_changed`. They deliberately keep their separate assignment / effective-winner authority and do **not** take the standalone per-action `reauthorizeStandaloneTargets` path; this is the admission-time clamp that path's absence would otherwise leave open.
- **The CIS remediation worker locks device → action** (the same order a device move takes, so it cannot deadlock), re-reads under that lock, and **cancels** the action with `cancelledReason: 'device_org_changed_before_dispatch'` instead of queueing a command when the device has left its admitted org.
- **Migration `2026-10-15-160140-cancel-cis-remediation-on-device-org-move.sql`** installs a `BEFORE UPDATE OF org_id` trigger on `devices` that cancels `pending_approval` / `queued` CIS actions for the moved device **before** the existing `AFTER` trigger `breeze_cascade_device_org_id()` re-stamps their `org_id`. It fences itself off while the source org is `merging` (an org merge is an absorption — the admitting authority survives, so cancelling would destroy live work and stamp a reason that is untrue), and keys its `UPDATE` on `(org_id, device_id)` so it uses `cis_remediation_org_device_status_idx` rather than scanning per row.

**On `moveOrg.ts`:** it carries **no app-layer mirror of this cancel, by design.** Unlike the `ai_operator_tasks` / `action_intents` detaches — which exist in both the route and the trigger because the route needs them for its own ordering — the CIS cancel is trigger-only. `devices.org_id` also changes through paths that are not the route (fix-up scripts, the org-merge repoint, any future service path), and the trigger covers all of them uniformly. A route-side duplicate would add a second place to keep the merge fence in sync for no coverage gain.

**On CIS vs. `expectedOrgId` (#5264):** the declarative gate added by #5264 lives in `precheckCommandExecution` / `dispatchDeviceCommand`, which the CIS worker does not use — it calls the raw `queueCommand` insert path, whose only tenancy knob is `submittedOrgId`. So the hand-rolled `FOR UPDATE` here is not a duplicate of `expectedOrgId`; it is the only creation-time gate available on that path, and it also has to do something `expectedOrgId` cannot: **hold** the device against the move for the duration of the action's state transition, not merely compare once. This PR does close the other half by passing `submittedOrgId: action.orgId`. That matters more than it looks: `commandClaimEligibility` reads a row with *both* `submitted_org_id` and `deliver_by` NULL as a **pre-#5128 legacy row and delivers it unconditionally**, so the CIS lane previously had no post-creation move fence at all. **They should converge** — the right end state is for CIS to go through `dispatchDeviceCommand` and inherit `expectedOrgId`, the offline-queue policy and the trust/edition gates, rather than keeping a second enqueue path. That is a larger refactor of the CIS worker than a security fix should carry, so it is called out here rather than done.

**Deliberately out of scope** (unchanged, and not claimed fixed):
- A command already created and delivered before the move. This is a *pre-command* fence; it cannot recall an execution already handed to an endpoint. (`submittedOrgId` narrows this for CIS to "created but not yet claimed".)
- `FOR NO KEY UPDATE` depends on `devices.org_id` remaining a plain column update. Future schema work must preserve that conflict or replace it with an explicit generation/CAS contract.

## Ported from

Local commit `71c7bab6332dc51d1f5bf3b778eff63a65e7bc8b` ("fix(automation): fence targets across organization moves"), authored against a base ~200 commits behind current `main`, cherry-picked with `git cherry-pick -x`, then revised under review and squashed into one commit.

Changed vs. the original:

- **Migration renamed** `2026-10-12-110000-…` → `2026-10-15-160140-cancel-cis-remediation-on-device-org-move.sql` so it sorts after the newest shipped migration (`2026-10-15-160010-backup-snapshots-layout-manifest.sql`).
- **Lock order corrected.** The original locked `devices` first and `organizations` second for partner-owned automations — the AB-BA against `moveOrg.ts` / `readOrgStampingDefaultsMany`, which take organizations first. Now organizations-then-devices, with a deterministic test pinning the order.
- **Config-policy path fixed.** The original left it untouched; SEC-118 survived there in full.
- **Pre-run denials made visible** instead of being filtered out silently.
- **Merge fence and `org_id` index predicate added** to the trigger.
- **`submittedOrgId` added** to the CIS `queueCommand` call.

Otherwise the cherry-pick applied with zero conflicts: `automationRuntime.ts` and `cisJobs.ts` hunks landed byte-identical against current `main` (line offsets only). Nothing was dropped as already-on-main. Checks made before concluding that (*verified*): `moveOrg.ts` has no `cis_remediation_actions` statement; `cis_remediation_actions` carries `device_id uuid` + `org_id uuid` and is **not** excluded from `breeze_device_child_orgid_tables()`, so it *is* in the re-stamp loop the new trigger fences; no new column, so `CORE_TENANT_EXPORT_POLICY` needs no entry, and the table is already registered in `tenantCascade.ts`, `CORE_DEVICE_CASCADE_DELETE_TABLES`, `CORE_DEVICE_ORG_DENORMALIZED_TABLES` and `tenantExportPolicyRegistry.ts`; no immutability trigger, no `REVOKE DELETE`; `cancelled` is a valid `cis_remediation_status`; `withSystemDbAccessContext` short-circuits on a live context (`if (dbContextStorage.getStore()) return fn()`), so the wrapper around `processRemediationAction` reuses the worker's transaction rather than opening a second pooled one.

## Verification

All commands run in the worktree against the private ephemeral test stack, on a **freshly recreated database** (the migration changed, so the stack was torn down and brought back up to replay it), after `git rebase origin/main` (base `2f6986fb75`). Counts *verified* unless labelled otherwise.

### Red-first

**Round 1 — the original fix.** Ported tests against main's source:

```sh
git checkout origin/main -- apps/api/src/services/automationRuntime.ts apps/api/src/jobs/cisJobs.ts
cd apps/api && npx vitest run --pool=threads --maxWorkers=2 \
  src/services/automationRuntime.configPolicy.test.ts src/jobs/cisJobs.remediationAuthority.test.ts
# 5 failed | 22 passed (27)   -> restored: 27 passed (27)
```

**Round 2 — each review fix proved to discriminate.** The pre-review implementation was restored (lock order inverted, config-policy org predicate removed, pre-run denial recording removed) and the suite re-run:

| Fix | Control | Result on the pre-fix code |
|---|---|---|
| Lock order (blocker 1) | `takes organizations before devices, so a concurrent move cannot deadlock it` | **FAIL** — `expected 'blocked' to be 'acquired'`: the dispatch already held `devices`, so an independent `FOR UPDATE` probe could not get the row |
| Config-policy clamp (blocker 2) | `does not action a config-policy target that left the policy org between enqueue and dispatch` | **FAIL** — `expected [ 2 commands ] to deeply equal [ 1 command ]`: the moved device *was* actioned |
| Merge fence (blocker 3) | `leaves pending CIS remediation alone when the source org is merging` | **FAIL** — `expected { status: 'cancelled' } to match { status: 'pending_approval' }` (pre-fix trigger body applied directly to the test DB with `CREATE OR REPLACE`, then the migration re-applied) |
| Pre-run denial visible (blocker 5) | `denies the moved target, preserves an allowed control, and cancels CIS before child restamp` | **FAIL** — `expected [ … ] to have a length of 2 but got 1`: the denied device vanished |
| `submittedOrgId` (CIS claim fence) | `queues an eligible action when the locked device still belongs to its admitted org` | **FAIL** — `queueCommand` not called with `{ submittedOrgId }` |

**Index predicate (blocker 4)** was proved by plan, not by a test — `EXPLAIN` on the test database, default planner settings:

```
WITH org_id (fixed):   Index Scan using cis_remediation_org_device_status_idx
                       Index Cond: ((org_id = …) AND (device_id = …))      cost=0.14..8.16
WITHOUT org_id (pre):  Seq Scan on cis_remediation_actions                 cost=0.00..11.65
```

**One control is honestly weak and is labelled as such in the test itself.** `never deadlocks a partner-owned dispatch against the real move-org route` — the end-to-end `POST /devices/:id/move-org` race — **did not reliably go red** on the inverted lock order (six attempts produced no 40P01 in an isolated run). It is a regression net that also proves a losing dispatch loses closed; the *deterministic* proof of the lock order is the `takes organizations before devices` test above. Do not read the e2e test as the discriminator.

### Suites

```sh
# Unit — touched families + migration/cascade guards
cd apps/api && npx vitest run --pool=threads --maxWorkers=2 \
  src/services/automationRuntime src/jobs/cisJobs src/routes/devices/moveOrg \
  src/db/autoMigrate.test.ts src/db/migrationRlsScope.test.ts moveOrg.coverage cascadeDelete
# 18 files passed — 390 passed (390)

# Integration — automation / CIS / device-move / device-command families + tenancy contracts
cd apps/api && npx vitest run --config vitest.integration.config.ts --pool=threads --maxWorkers=2 \
  automation Automation cis Cis moveOrg MoveOrg deviceMove DeviceMove deviceCommand \
  integration-suite-coverage rls-coverage tenant-export-policy tenantCascade tenantExportErasureRoundtrip
# 32 files passed — 228 passed (228)

# The SEC-118 suite itself, on the freshly migrated database
cd apps/api && npx vitest run --config vitest.integration.config.ts --pool=threads --maxWorkers=2 \
  src/__tests__/integration/automationDeviceMoveAuthority.integration.test.ts
# 1 file passed — 9 passed (9)   (4 original + 5 added under review)

# Dedicated contract configs
cd apps/api && npm run test:integration-suite-coverage   # 1 file, 5/5 passed
cd apps/api && npm run test:rls-coverage                 # 1 file, 102/102 passed
cd apps/api && npm run test:site-scope-coverage          # 1 file, 7/7 passed

# Guards
bash scripts/check-migration-naming.sh                                    # OK
cd apps/api && NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit    # exit 0, no output
cd apps/api && npx eslint <the 5 touched files>                           # clean
```

**Not checked** (*labelled honestly*): no real endpoint executed a script or a software install — agent delivery is mocked. No multi-replica, load or chaos exercise. `apps/web`, `apps/portal` and `packages/shared` are untouched and were not re-tested. The e2e move-org race test is a net, not a control (above).

**One behaviour observed and deliberately not changed:** when a device leaves mid-flight, the run can fail at its own seeding step via the pre-existing `Automation action result device organization mismatch` guard in `seedAutomationActionResults`. That is fail-closed — no command is created — and the e2e test asserts exactly that (device ended in the destination org, zero commands). It is a pre-existing sharp edge in the seeding path, not introduced here.

## Operator impact

- **Migration + application must ship together.** The trigger is the fail-closed half of the CIS fence; the worker check is the other half.
- The migration is idempotent (`CREATE OR REPLACE FUNCTION`, `DROP TRIGGER IF EXISTS` then `CREATE TRIGGER`), contains no DML of its own, and needs no backfill. Re-applying it is a no-op.
- **Moving a device to another organization now cancels that device's `pending_approval` / `queued` CIS remediation actions**, stamping `details.cancelledReason = 'device_org_changed_before_dispatch'`. Previously those actions silently followed the device into the destination org and could still dispatch there. **An org merge does not do this** — remediations survive the absorption and are re-stamped to the survivor.
- **A standalone automation run whose target device moves now records a failed device** (`Target device no longer belongs to an organization owned by this automation`) and skips that device's remaining actions. A config-policy run whose target moved between enqueue and dispatch records it failed with `device_org_changed`. Runs that would previously have shown as fully successful across a move will now show a failed device.
- A CIS remediation command created just before a move is now **cancelled at claim time** rather than delivered to the endpoint in its new tenant.
- No durable data rewrite, no configuration change, no customer action identified. Suggested release note: *"Automation and CIS dispatch now revalidate and serialize current device ownership before creating endpoint work."*

## Follow-ups

- **The config-policy path keeps a narrower TOCTOU** and is deliberately not closed here (tracked on **#5567**). Its clamp is an *unlocked* read in its own short transaction — `eq(devices.orgId, admission.context.orgId)` inside a `withAutomationRuntimeDb` that commits before the sinks run — and, unlike the standalone path, it has **no per-action re-check**: `reauthorizeStandaloneTargets` is deliberately off for config-policy runs. So a device that leaves the policy org *after* the target load but *before* an action can still be actioned by that run. That is a much smaller window than the one this PR closes (enqueue → dispatch, potentially minutes) and closing it properly means giving config-policy runs the same locked per-action boundary, which needs their separate assignment / effective-winner authority reconciled with it first.
- **CIS should converge on `dispatchDeviceCommand`** rather than keeping a second raw-`queueCommand` enqueue path — see the `expectedOrgId` note in the Summary.
- **Same unfixed shape elsewhere** (queued device id reused as authority after a move), noted by review and filed separately: `jobs/backupWorker.ts:582-586` / `:916`, `jobs/softwareRemediationWorker.ts:243-247` / `:522` (auto branch), `routes/backup/verificationService.ts:683`, `jobs/sensitiveDataJobs.ts:456` (manual branch).
- **`seedAutomationActionResults` runs on unlocked rows outside the authority transaction**, so a mid-flight move fails the whole run through its org-mismatch guard rather than failing just that device. Fail-closed, pre-existing, worth tidying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Tugfg88kFiowD7E5xQFpU
