### PR TITLE
fix(installer): OS-floor search property must be public (WIX0012)

### DIFF
--- a/agent/installer/breeze.wxs
+++ b/agent/installer/breeze.wxs
@@ -113,7 +113,7 @@
     <Launch Condition="NOT OTHEREDITIONFOUND" Message="A different edition of the Breeze Agent is already installed. Uninstall it before installing this edition." />
     <!-- Stock InstallExecuteSequence numbers are LaunchConditions 100,
          FindRelatedProducts 200, AppSearch 400, so on a silent install
-         OTHEREDITIONFOUND (above) and WindowsCurrentMajorVersion (below)
+         OTHEREDITIONFOUND (above) and WINDOWS_CURRENT_MAJOR_VERSION (below)
          would both still be empty when the Launch conditions are evaluated
          — the cross-edition guard would never fire and the OS floor would
          refuse everything. (InstallUISequence already puts AppSearch at 50,
@@ -156,22 +156,22 @@
          So "the value exists" is exactly the Windows-10/Server-2016 floor.
          `Installed OR` keeps repair/upgrade/uninstall of an already-installed
          product from ever being blocked by this check (WiX guidance for
-         OS-floor launch conditions). The property is deliberately PRIVATE
-         (mixed case): a public one could be preset on the msiexec command
-         line to defeat the floor, and AppSearch does not clear a preset
-         value when the search finds nothing. Both LaunchConditions
-         evaluations are client-side immediate, so it never needs to cross
-         into the elevated server process. If the HKLM read itself fails
-         (locked-down ACL), the user sees this same legacy-OS message. -->
-    <Property Id="WindowsCurrentMajorVersion">
-      <RegistrySearch Id="WindowsCurrentMajorVersionSearch"
+         OS-floor launch conditions). The property must be PUBLIC (all
+         uppercase): WiX refuses a lowercase search property (WIX0012),
+         because AppSearch can only populate public properties. That means
+         `msiexec /i ... WINDOWS_CURRENT_MAJOR_VERSION=1` can satisfy the
+         floor by hand — an admin bypassing a guard on their own machine,
+         accepted. If the HKLM read itself fails (locked-down ACL), the user
+         sees this same legacy-OS message. -->
+    <Property Id="WINDOWS_CURRENT_MAJOR_VERSION">
+      <RegistrySearch Id="WINDOWS_CURRENT_MAJOR_VERSIONSearch"
                       Root="HKLM"
                       Key="SOFTWARE\Microsoft\Windows NT\CurrentVersion"
                       Name="CurrentMajorVersionNumber"
                       Type="raw"
                       Bitness="always64" />
     </Property>
-    <Launch Condition="Installed OR WindowsCurrentMajorVersion" Message="Breeze Agent requires Windows 10 or Windows Server 2016 or later. Legacy Windows versions (7, 8, 8.1, Server 2008 R2 through 2012 R2) are not supported." />
+    <Launch Condition="Installed OR WINDOWS_CURRENT_MAJOR_VERSION" Message="Breeze Agent requires Windows 10 or Windows Server 2016 or later. Legacy Windows versions (7, 8, 8.1, Server 2008 R2 through 2012 R2) are not supported." />
     <Launch Condition="(NOT SERVER_URL AND NOT ENROLLMENT_KEY) OR (SERVER_URL AND ENROLLMENT_KEY)" Message="SERVER_URL and ENROLLMENT_KEY must be provided together." />
 
     <?ifdef ServerUrlDefault ?>

--- a/agent/installer/wxs_test.go
+++ b/agent/installer/wxs_test.go
@@ -58,14 +58,16 @@ func TestOsFloorDoesNotUseShimmedVersionProperties(t *testing.T) {
 	// The RegistrySearch must sit directly under a <Property>, and that
 	// property's Id must be what the Launch condition reads; otherwise the
 	// condition evaluates an always-empty property and refuses every install.
-	propRe := regexp.MustCompile(`(?s)<Property\s+Id="([A-Za-z_0-9]+)"[^>]*>\s*<RegistrySearch\s+[^>]*Key="SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion"[^>]*Name="CurrentMajorVersionNumber"`)
+	propRe := regexp.MustCompile(`(?s)<Property\s+Id="([A-Z_0-9]+)"[^>]*>\s*<RegistrySearch\s+[^>]*Key="SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion"[^>]*Name="CurrentMajorVersionNumber"`)
 	pm := propRe.FindStringSubmatch(wxs)
 	if pm == nil {
 		t.Fatal("expected a <Property> wrapping a RegistrySearch on HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\CurrentMajorVersionNumber to provide the Windows 10 / Server 2016 floor")
 	}
 	prop := pm[1]
-	if strings.ToUpper(prop) == prop {
-		t.Errorf("property %q is public (all uppercase) and could be preset on the msiexec command line to defeat the floor; use a private mixed-case Id", prop)
+	// WiX (WIX0012) requires a search property to be public, i.e. all
+	// uppercase; a mixed-case id fails the release build (v0.112.0 tag).
+	if strings.ToUpper(prop) != prop {
+		t.Errorf("property %q must be all uppercase: AppSearch can only populate public properties (WIX0012)", prop)
 	}
 	found := false
 	for _, c := range conds {

--- a/apps/api/src/config/agentInstallerOsFloor.test.ts
+++ b/apps/api/src/config/agentInstallerOsFloor.test.ts
@@ -40,15 +40,16 @@ describe('agent installer minimum-OS LaunchCondition (#4608)', () => {
     // Windows 11 24H2 (2026-09-10). CurrentMajorVersionNumber exists only on
     // Windows 10 / Server 2016+, and registry reads bypass the shim.
     const prop = wxs.match(
-      /<Property\s+Id="([A-Za-z_0-9]+)"[^>]*>\s*<RegistrySearch\s+[^>]*Key="SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion"[^>]*Name="CurrentMajorVersionNumber"/s,
+      /<Property\s+Id="([A-Z_0-9]+)"[^>]*>\s*<RegistrySearch\s+[^>]*Key="SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion"[^>]*Name="CurrentMajorVersionNumber"/s,
     )?.[1];
     expect(prop, 'a <Property> wrapping the CurrentMajorVersionNumber RegistrySearch').toBeDefined();
     const launchConditions = [...wxs.matchAll(/<Launch\s+Condition="([^"]*)"/g)].map((m) => m[1] ?? "");
     // The Launch condition must read the property the search fills, and
     // `Installed OR` keeps repair/upgrade/uninstall unblocked.
     expect(launchConditions).toContain(`Installed OR ${prop}`);
-    // Private (mixed-case) so it cannot be preset on the msiexec command line.
-    expect(prop).not.toBe(prop?.toUpperCase());
+    // WiX WIX0012: a search property must be public (all uppercase); a
+    // mixed-case id failed the v0.112.0 release build.
+    expect(prop).toBe(prop?.toUpperCase());
     for (const cond of launchConditions) {
       // VersionNT64 (bitness) is the only allowed use, however escaped.
       const stripped = cond.replaceAll('VersionNT64', '');
@@ -69,7 +70,7 @@ describe('agent installer minimum-OS LaunchCondition (#4608)', () => {
   });
 
   it('gives a clear message naming the supported floor', () => {
-    const match = wxs.match(/<Launch\s+Condition="Installed OR WindowsCurrentMajorVersion"\s+Message="([^"]+)"/);
+    const match = wxs.match(/<Launch\s+Condition="Installed OR WINDOWS_CURRENT_MAJOR_VERSION"\s+Message="([^"]+)"/);
     expect(match).not.toBeNull();
     const message = match?.[1] ?? '';
     expect(message).toContain('Windows 10');


### PR DESCRIPTION
The v0.112.0 release build failed at `Build unsigned self-host MSI` (run 34546197147):

```
breeze.wxs(166) : error WIX0012: The Property/@Id attribute's value, 'WindowsCurrentMajorVersion', cannot contain lowercase characters. Since this is a search property, it must also be a public property.
```

AppSearch can only populate public properties, so the review-round change in #5525 to a private mixed-case id was invalid WiX. This restores `WINDOWS_CURRENT_MAJOR_VERSION`, documents the accepted consequence (an admin can preset the property on the msiexec command line to bypass the floor on their own machine), and flips both guard tests (`agent/installer/wxs_test.go`, `agentInstallerOsFloor.test.ts`) to assert the id is all uppercase. Rest of #5525 (RegistrySearch, `Installed OR`, AppSearch scheduling) unchanged.

Go + vitest guards pass. Release will be re-cut after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T2XMLdsXt3sYzM5fD4Qbsc