### PR TITLE
docs(billing): service deliverables, org documents and key dates — spec + W01–W05 plans (#5573)

### DIFF
--- a/docs/superpowers/plans/billing/2026-09-10-service-deliverables-w01-schema-core.md
+++ b/docs/superpowers/plans/billing/2026-09-10-service-deliverables-w01-schema-core.md
@@ -1,0 +1,1453 @@
+---
+tracking_issue: LanternOps/breeze#5573
+---
+# Service Deliverables W01: Schema, Core Services, Contract and Org Record Surfaces — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the tenant tables, pure recurrence and state-machine modules, services, REST routes and MSP web surfaces for service deliverables, occurrences, report-run evidence and org key dates, so W02 (sweep), W03 (documents), W04 (portal) and W05 (templates) build on fixed names.
+
+**Architecture:** Three idempotent hand-written migrations create `service_deliverables`, `service_deliverable_occurrences`, `service_deliverable_evidence`, `organization_key_dates` (all RLS shape 1, direct `org_id`) and add `tickets.work_kind`. Two pure modules (`services/recurrence.ts`, `services/serviceDeliverableState.ts`) hold every date and status rule with no I/O. `services/serviceDeliverableService.ts` and `services/orgKeyDateService.ts` are the only writers; Hono routes under `/orgs/:orgId/…` and `/contracts/:id/deliverables` are thin. The web adds a section to the contract detail page, a Service tab and a Key dates card to the organization record.
+
+**Tech Stack:** PostgreSQL + hand-written SQL migrations, Drizzle ORM, Hono + Zod (`@breeze/shared` validators), Vitest (API unit with Drizzle mocks; API integration on real Postgres), Astro + React islands, react-i18next, Testing Library.
+
+**Spec:** `docs/superpowers/specs/billing/2026-09-10-service-deliverables-portal-design.md` (approved 2026-09-10). Sections 4.1–4.3, 4.5, 4.8, 4.9, 7, 9, 10 (non-portal), 12, 13 are this wave. Where this plan is more specific than the spec (function names, file names, one extra column `delivered_via`), the plan wins and the spec's §4.2 is amended in Task 1.
+
+## Global Constraints
+
+- Every tenant-scoped table: RLS enabled + forced + four shape-1 policies (`breeze_has_org_access(org_id)`) in the creating migration. Never deferred.
+- Every composite FK that references an `org_id` column is `DEFERRABLE INITIALLY IMMEDIATE`.
+- Migrations are idempotent (`IF NOT EXISTS`, `DO $$ … EXCEPTION WHEN duplicate_object`), have no inner `BEGIN`/`COMMIT`, and write no rows (so no `breeze.scope` election is needed; if a later edit adds DML, put `SELECT set_config('breeze.scope','system',true);` first).
+- Migration filenames sort after the newest committed migration. As of 2026-09-10 that is `2026-10-15-160010-backup-snapshots-layout-manifest.sql`. This plan uses `2026-10-15-170000-…`, `-170100-…`, `-170200-…`. Re-check with `ls apps/api/migrations | sort | tail -1` before every commit and rename upward if needed.
+- Every new `org_id` table is registered in the same PR in: `CORE_ORG_CASCADE_DELETE_ORDER` (`apps/api/src/services/tenantCascade.ts`), `CORE_TENANT_EXPORT_POLICY` (`apps/api/src/services/tenantExportPolicyRegistry.ts`), and `apps/api/src/services/orgMergeRegistry.ts`. Adding a column to a registered table (`tickets`, `report_runs`) updates its export-policy entry.
+- Org access in services: `actor.accessibleOrgIds !== null && !actor.accessibleOrgIds.includes(orgId)` ⇒ 404 `NOT_FOUND` (never 403, no existence leak). The check has the same shape as `requireOrgAccess` in `apps/api/src/services/contractService.ts:56`, but that helper throws 403 `ORG_DENIED`; do not copy its status, spec §12 requires 404 here.
+- Dates are ISO `YYYY-MM-DD` strings everywhere in code; Postgres `date` columns. Month arithmetic only through `addMonthsClamped` / `addDaysISO` from `apps/api/src/services/contractMath.ts`.
+- Web mutations go through `runAction` (`apps/web/src/lib/runAction.ts`). Org-record requests use the record's `orgFetch` (`orgRecordFetch.ts`), never ambient `fetchWithAuth`.
+- New i18n namespace `deliverables.json` in all 8 locales (`apps/web/src/locales/{en,de-DE,es-419,fr-CA,fr-FR,it-IT,pt-BR,tr-TR}/`) with real translations; `apps/web/src/lib/i18n/translationCoverage.test.ts` caps exact-English duplicates.
+- Run one test file as `cd apps/api && npx vitest run <path>` (never `pnpm … test -- --run`).
+- Branch: `feature/<parent#>-service-deliverables/wave-<W01 sub-issue#>`; PR body `Closes #<W01 sub-issue>`.
+
+---
+
+## File structure
+
+| Path | Responsibility |
+|---|---|
+| `apps/api/migrations/2026-10-15-170000-service-deliverables.sql` | enums, three deliverable tables, `report_runs (id, report_id)` unique, RLS |
+| `apps/api/migrations/2026-10-15-170100-tickets-work-kind.sql` | `ticket_work_kind` enum + `tickets.work_kind` |
+| `apps/api/migrations/2026-10-15-170200-organization-key-dates.sql` | `org_key_date_kind` enum, `organization_key_dates`, RLS |
+| `apps/api/src/db/schema/serviceDeliverables.ts` | Drizzle tables + enums for the three deliverable tables |
+| `apps/api/src/db/schema/orgKeyDates.ts` | Drizzle table + enum for key dates |
+| `apps/api/src/db/schema/portal.ts` | add `ticketWorkKindEnum`, `tickets.workKind` |
+| `apps/api/src/db/schema/reports.ts` | add `report_runs_id_report_id_uniq` |
+| `apps/api/src/db/schema/index.ts` | export the two new modules |
+| `apps/api/src/services/recurrence.ts` (+ `.test.ts`) | pure cadence/period/plan math |
+| `apps/api/src/services/serviceDeliverableState.ts` (+ `.test.ts`) | pure occurrence state machine |
+| `apps/api/src/services/serviceDeliverableService.ts` (+ `.test.ts`) | deliverable + occurrence + evidence writes/reads |
+| `apps/api/src/services/orgKeyDateService.ts` (+ `.test.ts`) | key dates CRUD + read-model union with contract end dates |
+| `packages/shared/src/validators/serviceDeliverables.ts` (+ `.test.ts`) | Zod schemas and TS types shared by API and web |
+| `packages/shared/src/validators/orgKeyDates.ts` (+ `.test.ts`) | Zod schemas for key dates |
+| `apps/api/src/routes/serviceDeliverables.ts` (+ `.test.ts`) | `/orgs/:orgId/deliverables…` |
+| `apps/api/src/routes/contracts/deliverables.ts` (+ `.test.ts`) | `/contracts/:id/deliverables` filtered view |
+| `apps/api/src/routes/orgKeyDates.ts` (+ `.test.ts`) | `/orgs/:orgId/key-dates…` |
+| `apps/api/src/index.ts` | mount the three routers |
+| `apps/api/src/services/tenantCascade.ts`, `tenantExportPolicyRegistry.ts`, `orgMergeRegistry.ts` | registrations |
+| `apps/api/src/__tests__/integration/serviceDeliverablesRls.integration.test.ts` | cross-org forge, deferrable FK, evidence ownership chain |
+| `apps/web/src/lib/api/serviceDeliverables.ts`, `orgKeyDates.ts` | typed fetch wrappers |
+| `apps/web/src/components/deliverables/DeliverableTable.tsx`, `DeliverableForm.tsx`, `OccurrenceDrawer.tsx` | shared MSP UI |
+| `apps/web/src/components/contracts/ContractDeliverablesSection.tsx` | section on the contract detail page |
+| `apps/web/src/components/organizations/record/OrgServiceTab.tsx`, `OrgKeyDatesCard.tsx` | org record surfaces |
+| `apps/web/src/components/organizations/record/orgRecordTabs.ts`, `OrganizationRecordPage.tsx`, `OrgOverviewTab.tsx` | wire the tab and card |
+| `apps/web/src/locales/*/deliverables.json` | i18n |
+
+---
+
+### Task 1: Migration 1 — deliverable tables
+
+**Files:**
+- Create: `apps/api/migrations/2026-10-15-170000-service-deliverables.sql`
+- Modify: `docs/superpowers/specs/billing/2026-09-10-service-deliverables-portal-design.md` (§4.2 table: add the `delivered_via` row)
+
+**Interfaces:**
+- Produces: tables `service_deliverables`, `service_deliverable_occurrences`, `service_deliverable_evidence`; enums `deliverable_cadence`, `deliverable_completion_mode`, `deliverable_occurrence_status`, `deliverable_evidence_kind`; unique `report_runs_id_report_id_uniq (id, report_id)`.
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- Service deliverables (spec docs/superpowers/specs/billing/2026-09-10-service-deliverables-portal-design.md §4.1–4.3).
+-- Idempotent throughout. DDL only: no rows are written, so no breeze.scope election.
+
+-- 1. Enums
+DO $$ BEGIN
+  CREATE TYPE deliverable_cadence AS ENUM ('monthly','quarterly','semiannual','annual','one_time');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN
+  CREATE TYPE deliverable_completion_mode AS ENUM ('explicit','on_ticket_resolve');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN
+  CREATE TYPE deliverable_occurrence_status AS ENUM ('scheduled','open','awaiting_evidence','delivered','missed','waived');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN
+  CREATE TYPE deliverable_evidence_kind AS ENUM ('document','report_run');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+-- 2. report_runs needs a (id, report_id) key so evidence can prove a run belongs to a report
+--    that belongs to the org (report_runs has no org_id of its own).
+CREATE UNIQUE INDEX IF NOT EXISTS report_runs_id_report_id_uniq ON report_runs (id, report_id);
+
+-- 3. service_deliverables
+CREATE TABLE IF NOT EXISTS service_deliverables (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id UUID NOT NULL REFERENCES organizations(id),
+  contract_id UUID,
+  name VARCHAR(200) NOT NULL,
+  description TEXT,
+  cadence deliverable_cadence NOT NULL,
+  anchor_due_date DATE NOT NULL,
+  effective_from DATE NOT NULL,
+  effective_until DATE,
+  lead_days INTEGER NOT NULL DEFAULT 7,
+  grace_days INTEGER NOT NULL DEFAULT 14,
+  artifact_required BOOLEAN NOT NULL DEFAULT TRUE,
+  completion_mode deliverable_completion_mode NOT NULL DEFAULT 'on_ticket_resolve',
+  auto_evidence_report_id UUID,
+  owner_user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+  ticket_category_id UUID REFERENCES ticket_categories(id) ON DELETE SET NULL,
+  portal_visible BOOLEAN NOT NULL DEFAULT TRUE,
+  active BOOLEAN NOT NULL DEFAULT TRUE,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+DO $$ BEGIN
+  ALTER TABLE service_deliverables ADD CONSTRAINT service_deliverables_contract_org_fk
+    FOREIGN KEY (contract_id, org_id) REFERENCES contracts(id, org_id)
+    ON DELETE SET NULL (contract_id) DEFERRABLE INITIALLY IMMEDIATE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN
+  ALTER TABLE service_deliverables ADD CONSTRAINT service_deliverables_auto_report_org_fk
+    FOREIGN KEY (auto_evidence_report_id, org_id) REFERENCES reports(id, org_id)
+    ON DELETE SET NULL (auto_evidence_report_id) DEFERRABLE INITIALLY IMMEDIATE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN
+  ALTER TABLE service_deliverables ADD CONSTRAINT service_deliverables_effective_chk
+    CHECK (effective_until IS NULL OR effective_until >= effective_from);
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN
+  ALTER TABLE service_deliverables ADD CONSTRAINT service_deliverables_days_chk
+    CHECK (lead_days >= 0 AND grace_days >= 0);
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+CREATE UNIQUE INDEX IF NOT EXISTS service_deliverables_id_org_uq ON service_deliverables (id, org_id);
+CREATE UNIQUE INDEX IF NOT EXISTS service_deliverables_org_contract_name_uq
+  ON service_deliverables (org_id, COALESCE(contract_id, '00000000-0000-0000-0000-000000000000'::uuid), name);
+CREATE INDEX IF NOT EXISTS service_deliverables_org_idx ON service_deliverables (org_id);
+CREATE INDEX IF NOT EXISTS service_deliverables_contract_idx ON service_deliverables (contract_id) WHERE contract_id IS NOT NULL;
+
+ALTER TABLE service_deliverables ENABLE ROW LEVEL SECURITY;
+ALTER TABLE service_deliverables FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS breeze_org_isolation_select ON service_deliverables;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON service_deliverables;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON service_deliverables;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON service_deliverables;
+CREATE POLICY breeze_org_isolation_select ON service_deliverables FOR SELECT USING (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_insert ON service_deliverables FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_update ON service_deliverables FOR UPDATE USING (public.breeze_has_org_access(org_id)) WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_delete ON service_deliverables FOR DELETE USING (public.breeze_has_org_access(org_id));
+
+-- 4. service_deliverable_occurrences
+CREATE TABLE IF NOT EXISTS service_deliverable_occurrences (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id UUID NOT NULL REFERENCES organizations(id),
+  deliverable_id UUID NOT NULL,
+  name_snapshot VARCHAR(200) NOT NULL,
+  period_start DATE NOT NULL,
+  period_end DATE NOT NULL,
+  due_at DATE NOT NULL,
+  original_due_at DATE NOT NULL,
+  status deliverable_occurrence_status NOT NULL DEFAULT 'scheduled',
+  ticket_id UUID,
+  delivered_at TIMESTAMPTZ,
+  delivered_by_user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+  delivered_via TEXT,
+  delivery_note TEXT,
+  waived_at TIMESTAMPTZ,
+  waived_by_user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+  waived_reason TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+DO $$ BEGIN
+  ALTER TABLE service_deliverable_occurrences ADD CONSTRAINT sd_occ_deliverable_org_fk
+    FOREIGN KEY (deliverable_id, org_id) REFERENCES service_deliverables(id, org_id)
+    ON DELETE CASCADE DEFERRABLE INITIALLY IMMEDIATE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN
+  ALTER TABLE service_deliverable_occurrences ADD CONSTRAINT sd_occ_ticket_org_fk
+    FOREIGN KEY (ticket_id, org_id) REFERENCES tickets(id, org_id)
+    ON DELETE SET NULL (ticket_id) DEFERRABLE INITIALLY IMMEDIATE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN
+  ALTER TABLE service_deliverable_occurrences ADD CONSTRAINT sd_occ_delivered_via_chk
+    CHECK (delivered_via IS NULL OR delivered_via IN ('explicit','ticket'));
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN
+  ALTER TABLE service_deliverable_occurrences ADD CONSTRAINT sd_occ_period_chk
+    CHECK (period_start <= period_end);
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+CREATE UNIQUE INDEX IF NOT EXISTS sd_occ_id_org_uq ON service_deliverable_occurrences (id, org_id);
+CREATE UNIQUE INDEX IF NOT EXISTS sd_occ_deliverable_period_uq ON service_deliverable_occurrences (deliverable_id, period_start);
+CREATE INDEX IF NOT EXISTS sd_occ_org_status_due_idx ON service_deliverable_occurrences (org_id, status, due_at);
+CREATE INDEX IF NOT EXISTS sd_occ_ticket_idx ON service_deliverable_occurrences (ticket_id) WHERE ticket_id IS NOT NULL;
+
+ALTER TABLE service_deliverable_occurrences ENABLE ROW LEVEL SECURITY;
+ALTER TABLE service_deliverable_occurrences FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS breeze_org_isolation_select ON service_deliverable_occurrences;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON service_deliverable_occurrences;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON service_deliverable_occurrences;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON service_deliverable_occurrences;
+CREATE POLICY breeze_org_isolation_select ON service_deliverable_occurrences FOR SELECT USING (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_insert ON service_deliverable_occurrences FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_update ON service_deliverable_occurrences FOR UPDATE USING (public.breeze_has_org_access(org_id)) WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_delete ON service_deliverable_occurrences FOR DELETE USING (public.breeze_has_org_access(org_id));
+
+-- 5. service_deliverable_evidence (document_id FK is added by W03 when org_documents exists)
+CREATE TABLE IF NOT EXISTS service_deliverable_evidence (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id UUID NOT NULL REFERENCES organizations(id),
+  occurrence_id UUID NOT NULL,
+  kind deliverable_evidence_kind NOT NULL,
+  document_id UUID,
+  report_id UUID,
+  report_run_id UUID,
+  created_by_user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+DO $$ BEGIN
+  ALTER TABLE service_deliverable_evidence ADD CONSTRAINT sd_evidence_occurrence_org_fk
+    FOREIGN KEY (occurrence_id, org_id) REFERENCES service_deliverable_occurrences(id, org_id)
+    ON DELETE CASCADE DEFERRABLE INITIALLY IMMEDIATE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN
+  ALTER TABLE service_deliverable_evidence ADD CONSTRAINT sd_evidence_report_org_fk
+    FOREIGN KEY (report_id, org_id) REFERENCES reports(id, org_id)
+    ON DELETE CASCADE DEFERRABLE INITIALLY IMMEDIATE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN
+  ALTER TABLE service_deliverable_evidence ADD CONSTRAINT sd_evidence_report_run_fk
+    FOREIGN KEY (report_run_id, report_id) REFERENCES report_runs(id, report_id)
+    ON DELETE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN
+  ALTER TABLE service_deliverable_evidence ADD CONSTRAINT sd_evidence_kind_chk CHECK (
+    (kind = 'document'   AND document_id IS NOT NULL AND report_id IS NULL AND report_run_id IS NULL) OR
+    (kind = 'report_run' AND document_id IS NULL AND report_id IS NOT NULL AND report_run_id IS NOT NULL)
+  );
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+CREATE INDEX IF NOT EXISTS sd_evidence_occurrence_idx ON service_deliverable_evidence (occurrence_id);
+CREATE INDEX IF NOT EXISTS sd_evidence_org_idx ON service_deliverable_evidence (org_id);
+
+ALTER TABLE service_deliverable_evidence ENABLE ROW LEVEL SECURITY;
+ALTER TABLE service_deliverable_evidence FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS breeze_org_isolation_select ON service_deliverable_evidence;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON service_deliverable_evidence;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON service_deliverable_evidence;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON service_deliverable_evidence;
+CREATE POLICY breeze_org_isolation_select ON service_deliverable_evidence FOR SELECT USING (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_insert ON service_deliverable_evidence FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_update ON service_deliverable_evidence FOR UPDATE USING (public.breeze_has_org_access(org_id)) WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_delete ON service_deliverable_evidence FOR DELETE USING (public.breeze_has_org_access(org_id));
+```
+
+`tickets_id_org_uq (id, org_id)` already exists (`apps/api/migrations/2026-09-25-ai-agents-ticket-triage.sql:34`), so the ticket FK above resolves without a new index.
+
+- [ ] **Step 2: Amend the spec §4.2 table**
+
+Add after the `delivered_by_user_id` row:
+
+```markdown
+| delivered_via | text null | `explicit \| ticket`; an `explicit` delivery is never undone by a ticket reopen (§6) |
+```
+
+- [ ] **Step 3: Run the naming and RLS-scope guards**
+
+Run: `scripts/check-migration-naming.sh --against-ref origin/main && cd apps/api && npx vitest run src/db/autoMigrate.test.ts src/db/migrationRlsScope.test.ts`
+Expected: both PASS (the new file writes no rows, so it is not an offender).
+
+- [ ] **Step 4: Apply against the worktree test stack**
+
+Run: `pnpm test-stack up` (once for the wave), then `cd apps/api && DATABASE_URL=$(grep DATABASE_URL .env.test | cut -d= -f2-) pnpm db:migrate` twice.
+Expected: second run is a no-op with no errors (idempotency).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/migrations/2026-10-15-170000-service-deliverables.sql docs/superpowers/specs/billing/2026-09-10-service-deliverables-portal-design.md
+git commit -m "feat(deliverables): service deliverable tables with shape-1 RLS (W01)"
+```
+
+---
+
+### Task 2: Migrations 2 and 3 — `tickets.work_kind` and `organization_key_dates`
+
+**Files:**
+- Create: `apps/api/migrations/2026-10-15-170100-tickets-work-kind.sql`
+- Create: `apps/api/migrations/2026-10-15-170200-organization-key-dates.sql`
+
+**Interfaces:**
+- Produces: enum `ticket_work_kind ('support','deliverable','project_task')`, column `tickets.work_kind NOT NULL DEFAULT 'support'`; enum `org_key_date_kind`; table `organization_key_dates`.
+
+- [ ] **Step 1: Write migration 2**
+
+```sql
+-- tickets.work_kind (spec §4.8). Typed discriminator for planned work; replaces a tag string.
+DO $$ BEGIN
+  CREATE TYPE ticket_work_kind AS ENUM ('support','deliverable','project_task');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+ALTER TABLE tickets ADD COLUMN IF NOT EXISTS work_kind ticket_work_kind NOT NULL DEFAULT 'support';
+CREATE INDEX IF NOT EXISTS tickets_org_work_kind_idx ON tickets (org_id, work_kind) WHERE work_kind <> 'support';
+```
+
+- [ ] **Step 2: Write migration 3**
+
+```sql
+-- organization_key_dates (spec §4.5). Shape 1 RLS. DDL only.
+DO $$ BEGIN
+  CREATE TYPE org_key_date_kind AS ENUM ('insurance_renewal','vendor_contract_end','compliance_deadline','audit','other');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE TABLE IF NOT EXISTS organization_key_dates (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id UUID NOT NULL REFERENCES organizations(id),
+  label VARCHAR(200) NOT NULL,
+  kind org_key_date_kind NOT NULL DEFAULT 'other',
+  date DATE NOT NULL,
+  recurs_annually BOOLEAN NOT NULL DEFAULT FALSE,
+  remind_days_before INTEGER,
+  owner_user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+  reminded_for_date DATE,
+  reminder_ticket_id UUID,
+  portal_visible BOOLEAN NOT NULL DEFAULT FALSE,
+  notes TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+DO $$ BEGIN
+  ALTER TABLE organization_key_dates ADD CONSTRAINT org_key_dates_reminder_ticket_org_fk
+    FOREIGN KEY (reminder_ticket_id, org_id) REFERENCES tickets(id, org_id)
+    ON DELETE SET NULL (reminder_ticket_id) DEFERRABLE INITIALLY IMMEDIATE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN
+  ALTER TABLE organization_key_dates ADD CONSTRAINT org_key_dates_remind_chk
+    CHECK (remind_days_before IS NULL OR remind_days_before >= 0);
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+CREATE INDEX IF NOT EXISTS org_key_dates_org_date_idx ON organization_key_dates (org_id, date);
+
+ALTER TABLE organization_key_dates ENABLE ROW LEVEL SECURITY;
+ALTER TABLE organization_key_dates FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS breeze_org_isolation_select ON organization_key_dates;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON organization_key_dates;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON organization_key_dates;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON organization_key_dates;
+CREATE POLICY breeze_org_isolation_select ON organization_key_dates FOR SELECT USING (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_insert ON organization_key_dates FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_update ON organization_key_dates FOR UPDATE USING (public.breeze_has_org_access(org_id)) WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_delete ON organization_key_dates FOR DELETE USING (public.breeze_has_org_access(org_id));
+```
+
+- [ ] **Step 3: Guards + apply twice**
+
+Run: `scripts/check-migration-naming.sh --against-ref origin/main && cd apps/api && npx vitest run src/db/autoMigrate.test.ts src/db/migrationRlsScope.test.ts && pnpm db:migrate && pnpm db:migrate` (with the test-stack `DATABASE_URL`).
+Expected: PASS, second migrate is a no-op.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/migrations/2026-10-15-170100-tickets-work-kind.sql apps/api/migrations/2026-10-15-170200-organization-key-dates.sql
+git commit -m "feat(deliverables): tickets.work_kind and organization_key_dates (W01)"
+```
+
+---
+
+### Task 3: Drizzle schema modules
+
+**Files:**
+- Create: `apps/api/src/db/schema/serviceDeliverables.ts`
+- Create: `apps/api/src/db/schema/orgKeyDates.ts`
+- Modify: `apps/api/src/db/schema/portal.ts` (tickets table, near `ticketSourceEnum` at line 8)
+- Modify: `apps/api/src/db/schema/reports.ts:86-92` (`report_runs` table indexes)
+- Modify: `apps/api/src/db/schema/index.ts:128` area (exports)
+
+**Interfaces:**
+- Produces (exact export names): `deliverableCadenceEnum`, `deliverableCompletionModeEnum`, `deliverableOccurrenceStatusEnum`, `deliverableEvidenceKindEnum`, `serviceDeliverables`, `serviceDeliverableOccurrences`, `serviceDeliverableEvidence`, `orgKeyDateKindEnum`, `organizationKeyDates`, `ticketWorkKindEnum`; column `tickets.workKind`.
+
+- [ ] **Step 1: Write `serviceDeliverables.ts`**
+
+```ts
+import { pgTable, pgEnum, uuid, varchar, text, date, integer, boolean, timestamp, index, uniqueIndex } from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
+import { organizations } from './orgs';
+import { users } from './users';
+import { contracts } from './contracts';
+import { tickets } from './portal';
+import { ticketCategories } from './tickets';
+import { reports, reportRuns } from './reports';
+
+export const deliverableCadenceEnum = pgEnum('deliverable_cadence', ['monthly', 'quarterly', 'semiannual', 'annual', 'one_time']);
+export const deliverableCompletionModeEnum = pgEnum('deliverable_completion_mode', ['explicit', 'on_ticket_resolve']);
+export const deliverableOccurrenceStatusEnum = pgEnum('deliverable_occurrence_status', ['scheduled', 'open', 'awaiting_evidence', 'delivered', 'missed', 'waived']);
+export const deliverableEvidenceKindEnum = pgEnum('deliverable_evidence_kind', ['document', 'report_run']);
+
+/** Spec §4.1. Org-owned; contract link optional (D1). Composite FKs are declared in SQL only
+ *  (Drizzle cannot express DEFERRABLE); the single-column references here are for typing. */
+export const serviceDeliverables = pgTable('service_deliverables', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  contractId: uuid('contract_id').references(() => contracts.id),
+  name: varchar('name', { length: 200 }).notNull(),
+  description: text('description'),
+  cadence: deliverableCadenceEnum('cadence').notNull(),
+  anchorDueDate: date('anchor_due_date').notNull(),
+  effectiveFrom: date('effective_from').notNull(),
+  effectiveUntil: date('effective_until'),
+  leadDays: integer('lead_days').notNull().default(7),
+  graceDays: integer('grace_days').notNull().default(14),
+  artifactRequired: boolean('artifact_required').notNull().default(true),
+  completionMode: deliverableCompletionModeEnum('completion_mode').notNull().default('on_ticket_resolve'),
+  autoEvidenceReportId: uuid('auto_evidence_report_id').references(() => reports.id),
+  ownerUserId: uuid('owner_user_id').references(() => users.id, { onDelete: 'set null' }),
+  ticketCategoryId: uuid('ticket_category_id').references(() => ticketCategories.id, { onDelete: 'set null' }),
+  portalVisible: boolean('portal_visible').notNull().default(true),
+  active: boolean('active').notNull().default(true),
+  sortOrder: integer('sort_order').notNull().default(0),
+  createdBy: uuid('created_by').references(() => users.id, { onDelete: 'set null' }),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+}, (t) => [
+  uniqueIndex('service_deliverables_id_org_uq').on(t.id, t.orgId),
+  uniqueIndex('service_deliverables_org_contract_name_uq').on(t.orgId, sql`COALESCE(${t.contractId}, '00000000-0000-0000-0000-000000000000'::uuid)`, t.name),
+  index('service_deliverables_org_idx').on(t.orgId),
+]);
+
+/** Spec §4.2. UNIQUE (deliverable_id, period_start) is the sweep's idempotency claim. */
+export const serviceDeliverableOccurrences = pgTable('service_deliverable_occurrences', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  deliverableId: uuid('deliverable_id').notNull().references(() => serviceDeliverables.id, { onDelete: 'cascade' }),
+  nameSnapshot: varchar('name_snapshot', { length: 200 }).notNull(),
+  periodStart: date('period_start').notNull(),
+  periodEnd: date('period_end').notNull(),
+  dueAt: date('due_at').notNull(),
+  originalDueAt: date('original_due_at').notNull(),
+  status: deliverableOccurrenceStatusEnum('status').notNull().default('scheduled'),
+  ticketId: uuid('ticket_id').references(() => tickets.id, { onDelete: 'set null' }),
+  deliveredAt: timestamp('delivered_at', { withTimezone: true }),
+  deliveredByUserId: uuid('delivered_by_user_id').references(() => users.id, { onDelete: 'set null' }),
+  deliveredVia: text('delivered_via').$type<'explicit' | 'ticket'>(),
+  deliveryNote: text('delivery_note'),
+  waivedAt: timestamp('waived_at', { withTimezone: true }),
+  waivedByUserId: uuid('waived_by_user_id').references(() => users.id, { onDelete: 'set null' }),
+  waivedReason: text('waived_reason'),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+}, (t) => [
+  uniqueIndex('sd_occ_id_org_uq').on(t.id, t.orgId),
+  uniqueIndex('sd_occ_deliverable_period_uq').on(t.deliverableId, t.periodStart),
+  index('sd_occ_org_status_due_idx').on(t.orgId, t.status, t.dueAt),
+]);
+
+/** Spec §4.3. `document_id`'s FK to org_documents is added by W03. */
+export const serviceDeliverableEvidence = pgTable('service_deliverable_evidence', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  occurrenceId: uuid('occurrence_id').notNull().references(() => serviceDeliverableOccurrences.id, { onDelete: 'cascade' }),
+  kind: deliverableEvidenceKindEnum('kind').notNull(),
+  documentId: uuid('document_id'),
+  reportId: uuid('report_id').references(() => reports.id, { onDelete: 'cascade' }),
+  reportRunId: uuid('report_run_id').references(() => reportRuns.id, { onDelete: 'cascade' }),
+  createdByUserId: uuid('created_by_user_id').references(() => users.id, { onDelete: 'set null' }),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+}, (t) => [
+  index('sd_evidence_occurrence_idx').on(t.occurrenceId),
+  index('sd_evidence_org_idx').on(t.orgId),
+]);
+
+export type ServiceDeliverableRow = typeof serviceDeliverables.$inferSelect;
+export type ServiceDeliverableOccurrenceRow = typeof serviceDeliverableOccurrences.$inferSelect;
+export type ServiceDeliverableEvidenceRow = typeof serviceDeliverableEvidence.$inferSelect;
+```
+
+Verified export names: `tickets` (`schema/portal.ts:104`), `ticketCategories` (`schema/tickets.ts:15`), `reports` (`schema/reports.ts:51`), `reportRuns` (`schema/reports.ts:96`).
+
+- [ ] **Step 2: Write `orgKeyDates.ts`**
+
+```ts
+import { pgTable, pgEnum, uuid, varchar, text, date, integer, boolean, timestamp, index } from 'drizzle-orm/pg-core';
+import { organizations } from './orgs';
+import { users } from './users';
+import { tickets } from './portal';
+
+export const orgKeyDateKindEnum = pgEnum('org_key_date_kind', ['insurance_renewal', 'vendor_contract_end', 'compliance_deadline', 'audit', 'other']);
+
+/** Spec §4.5. Typed org-level dates that drive reminders (W02) and the portal (W04). */
+export const organizationKeyDates = pgTable('organization_key_dates', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  label: varchar('label', { length: 200 }).notNull(),
+  kind: orgKeyDateKindEnum('kind').notNull().default('other'),
+  date: date('date').notNull(),
+  recursAnnually: boolean('recurs_annually').notNull().default(false),
+  remindDaysBefore: integer('remind_days_before'),
+  ownerUserId: uuid('owner_user_id').references(() => users.id, { onDelete: 'set null' }),
+  remindedForDate: date('reminded_for_date'),
+  reminderTicketId: uuid('reminder_ticket_id').references(() => tickets.id, { onDelete: 'set null' }),
+  portalVisible: boolean('portal_visible').notNull().default(false),
+  notes: text('notes'),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+}, (t) => [index('org_key_dates_org_date_idx').on(t.orgId, t.date)]);
+
+export type OrganizationKeyDateRow = typeof organizationKeyDates.$inferSelect;
+```
+
+- [ ] **Step 3: Add `workKind` to tickets and the report_runs unique index**
+
+In `portal.ts`, next to `ticketSourceEnum`:
+
+```ts
+export const ticketWorkKindEnum = pgEnum('ticket_work_kind', ['support', 'deliverable', 'project_task']);
+```
+
+and in the `tickets` table definition, after `source`:
+
+```ts
+  // Spec §4.8 (service deliverables D3/D14): planned work is typed, not tagged.
+  workKind: ticketWorkKindEnum('work_kind').notNull().default('support'),
+```
+
+In `reports.ts`, add to the `report_runs` table's index callback:
+
+```ts
+  reportRunsIdReportIdUniq: uniqueIndex('report_runs_id_report_id_uniq').on(table.id, table.reportId),
+```
+
+Add `export * from './serviceDeliverables'; export * from './orgKeyDates';` to `schema/index.ts` next to the contracts export.
+
+- [ ] **Step 4: Typecheck and drift check**
+
+Run: `cd apps/api && npx tsc --noEmit -p tsconfig.json && pnpm db:check-drift` (test-stack `DATABASE_URL`).
+Expected: no type errors; drift check reports no differences for the four tables and two columns. If drift names the COALESCE index expression, match the migration's expression text exactly.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/db/schema
+git commit -m "feat(deliverables): drizzle schema for deliverables, key dates, tickets.work_kind (W01)"
+```
+
+---
+
+### Task 4: Tenancy registrations
+
+**Files:**
+- Modify: `apps/api/src/services/tenantCascade.ts` (`CORE_ORG_CASCADE_DELETE_ORDER`, ~line 228 onward)
+- Modify: `apps/api/src/services/tenantExportPolicyRegistry.ts` (`CORE_TENANT_EXPORT_POLICY`, ~line 41 onward)
+- Modify: `apps/api/src/services/orgMergeRegistry.ts` (repoint list ~line 580 onward and the SPECIAL map)
+
+- [ ] **Step 1: Cascade order**
+
+Insert, alphabetically by `localeCompare`, `"organization_key_dates"`, `"service_deliverable_evidence"`, `"service_deliverable_occurrences"`, `"service_deliverables"`. Then confirm children precede parents: `service_deliverable_evidence` < `service_deliverable_occurrences` < `service_deliverables` (localeCompare orders `"service_deliverable_evidence"` before `"service_deliverable_occurrences"` because `e` < `o`, and both before `"service_deliverables"` because `_` sorts before `s` under localeCompare; the test asserts it, do not assume).
+
+- [ ] **Step 2: Export policy**
+
+Add entries (adjust `reports.ts`/`tickets` entries too):
+
+```ts
+  "organization_key_dates": tablePolicy("org_id", {"included":["id","org_id","label","kind","date","recurs_annually","remind_days_before","owner_user_id","reminded_for_date","reminder_ticket_id","portal_visible","notes","created_at","updated_at"],"reviewedIncluded":[],"excludedSensitive":[],"excludedOpen":[]}),
+  "service_deliverable_evidence": tablePolicy("org_id", {"included":["id","org_id","occurrence_id","kind","document_id","report_id","report_run_id","created_by_user_id","created_at"],"reviewedIncluded":[],"excludedSensitive":[],"excludedOpen":[]}),
+  "service_deliverable_occurrences": tablePolicy("org_id", {"included":["id","org_id","deliverable_id","name_snapshot","period_start","period_end","due_at","original_due_at","status","ticket_id","delivered_at","delivered_by_user_id","delivered_via","delivery_note","waived_at","waived_by_user_id","waived_reason","created_at","updated_at"],"reviewedIncluded":[],"excludedSensitive":[],"excludedOpen":[]}),
+  "service_deliverables": tablePolicy("org_id", {"included":["id","org_id","contract_id","name","description","cadence","anchor_due_date","effective_from","effective_until","lead_days","grace_days","artifact_required","completion_mode","auto_evidence_report_id","owner_user_id","ticket_category_id","portal_visible","active","sort_order","created_by","created_at","updated_at"],"reviewedIncluded":[],"excludedSensitive":[],"excludedOpen":[]}),
+```
+
+And append `"work_kind"` to the `tickets` entry's `included` array.
+
+- [ ] **Step 3: Merge registry**
+
+Add `"organization_key_dates"`, `"service_deliverable_evidence"`, `"service_deliverable_occurrences"` to the plain repoint list (alphabetical). Add to the SPECIAL map:
+
+```ts
+  service_deliverables: { kind: 'repoint-dedupe', key: ['contract_id', 'name'] }, // verified: service_deliverables_org_contract_name_uq (org_id, COALESCE(contract_id, nil), name)
+```
+
+(Check how other `repoint-dedupe` entries express a COALESCE key; if the engine cannot, use `kind: 'custom'` with a note and implement the dedupe in `orgMergeCustomExecutors.ts` by suffixing the loser's `name` with ` (merged)` on collision.)
+
+- [ ] **Step 4: Run the four contract suites**
+
+Run (test-stack up): `cd apps/api && npx vitest run --config vitest.integration.config.ts src/__tests__/integration/rls-coverage.integration.test.ts src/__tests__/integration/tenantCascade.integration.test.ts src/__tests__/integration/tenant-export-policy.integration.test.ts src/__tests__/integration/tenantExportErasureRoundtrip.integration.test.ts src/__tests__/integration/orgLifecycleFoundations.integration.test.ts`
+Expected: all PASS. A failure names the missing table or column; fix the registration, not the test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/tenantCascade.ts apps/api/src/services/tenantExportPolicyRegistry.ts apps/api/src/services/orgMergeRegistry.ts
+git commit -m "chore(tenancy): register service deliverable and key date tables in cascade, export, merge (W01)"
+```
+
+---
+
+### Task 5: `services/recurrence.ts` (pure)
+
+**Files:**
+- Create: `apps/api/src/services/recurrence.ts`
+- Test: `apps/api/src/services/recurrence.test.ts`
+
+**Interfaces:**
+- Consumes: `addMonthsClamped(iso, months)`, `addDaysISO(iso, days)` from `./contractMath`.
+- Produces:
+
+```ts
+export type Cadence = 'monthly' | 'quarterly' | 'semiannual' | 'annual' | 'one_time';
+export function cadenceMonths(cadence: Cadence): number | null;            // one_time → null
+export function coveredPeriod(dueAt: string, cadence: Cadence): { periodStart: string; periodEnd: string };
+export function nthDueDate(anchorDueDate: string, cadence: Cadence, n: number): string | null; // n ≥ 0; one_time: n>0 → null
+export interface PlanInput { anchorDueDate: string; cadence: Cadence; effectiveFrom: string; effectiveUntil: string | null; leadDays: number; graceDays: number; today: string; existingDueDates: readonly string[]; cap?: number }
+export interface PlannedOccurrence { periodStart: string; periodEnd: string; dueAt: string; initialStatus: 'scheduled' | 'missed' }
+export function planOccurrences(input: PlanInput): PlannedOccurrence[];
+export function isInLeadWindow(dueAt: string, leadDays: number, today: string): boolean;  // dueAt − leadDays ≤ today
+export function isPastGrace(dueAt: string, graceDays: number, today: string): boolean;    // dueAt + graceDays < today
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { cadenceMonths, coveredPeriod, nthDueDate, planOccurrences, isInLeadWindow, isPastGrace } from './recurrence';
+
+describe('recurrence', () => {
+  it('maps cadence to months', () => {
+    expect(cadenceMonths('monthly')).toBe(1);
+    expect(cadenceMonths('quarterly')).toBe(3);
+    expect(cadenceMonths('semiannual')).toBe(6);
+    expect(cadenceMonths('annual')).toBe(12);
+    expect(cadenceMonths('one_time')).toBeNull();
+  });
+
+  it('clamps a 31st anchor to month ends', () => {
+    expect(nthDueDate('2026-01-31', 'monthly', 1)).toBe('2026-02-28');
+    expect(nthDueDate('2026-01-31', 'monthly', 2)).toBe('2026-03-31');
+    expect(nthDueDate('2026-01-31', 'quarterly', 1)).toBe('2026-04-30');
+  });
+
+  it('one_time has a single due date', () => {
+    expect(nthDueDate('2026-06-01', 'one_time', 0)).toBe('2026-06-01');
+    expect(nthDueDate('2026-06-01', 'one_time', 1)).toBeNull();
+  });
+
+  it('covered period ends on the due date and spans one cadence', () => {
+    expect(coveredPeriod('2026-03-31', 'monthly')).toEqual({ periodStart: '2026-03-01', periodEnd: '2026-03-31' });
+    expect(coveredPeriod('2026-06-30', 'quarterly')).toEqual({ periodStart: '2026-04-01', periodEnd: '2026-06-30' });
+    expect(coveredPeriod('2026-06-01', 'one_time')).toEqual({ periodStart: '2026-06-01', periodEnd: '2026-06-01' });
+  });
+
+  it('plans only occurrences inside the lead window and effective range', () => {
+    const plan = planOccurrences({
+      anchorDueDate: '2026-10-31', cadence: 'monthly', effectiveFrom: '2026-10-01', effectiveUntil: null,
+      leadDays: 7, graceDays: 14, today: '2026-10-25', existingDueDates: [],
+    });
+    expect(plan).toEqual([{ periodStart: '2026-10-01', periodEnd: '2026-10-31', dueAt: '2026-10-31', initialStatus: 'scheduled' }]);
+  });
+
+  it('skips due dates already materialized', () => {
+    const plan = planOccurrences({
+      anchorDueDate: '2026-10-31', cadence: 'monthly', effectiveFrom: '2026-10-01', effectiveUntil: null,
+      leadDays: 7, graceDays: 14, today: '2026-11-25', existingDueDates: ['2026-10-31'],
+    });
+    expect(plan.map((p) => p.dueAt)).toEqual(['2026-11-30']);
+  });
+
+  it('marks catch-up occurrences past grace as missed and caps at 12', () => {
+    const plan = planOccurrences({
+      anchorDueDate: '2025-01-31', cadence: 'monthly', effectiveFrom: '2025-01-01', effectiveUntil: null,
+      leadDays: 7, graceDays: 14, today: '2026-10-25', existingDueDates: [],
+    });
+    expect(plan).toHaveLength(12);
+    expect(plan[0]!.dueAt).toBe('2025-01-31');
+    expect(plan[0]!.initialStatus).toBe('missed');
+  });
+
+  it('stops at effective_until', () => {
+    const plan = planOccurrences({
+      anchorDueDate: '2026-10-31', cadence: 'monthly', effectiveFrom: '2026-10-01', effectiveUntil: '2026-11-15',
+      leadDays: 30, graceDays: 14, today: '2026-12-01', existingDueDates: [],
+    });
+    expect(plan.map((p) => p.dueAt)).toEqual(['2026-10-31']);
+  });
+
+  it('never plans a due date before effective_from', () => {
+    const plan = planOccurrences({
+      anchorDueDate: '2026-01-31', cadence: 'monthly', effectiveFrom: '2026-06-01', effectiveUntil: null,
+      leadDays: 7, graceDays: 14, today: '2026-06-28', existingDueDates: [],
+    });
+    expect(plan.map((p) => p.dueAt)).toEqual(['2026-06-30']);
+  });
+
+  it('window predicates', () => {
+    expect(isInLeadWindow('2026-10-31', 7, '2026-10-24')).toBe(true);
+    expect(isInLeadWindow('2026-10-31', 7, '2026-10-23')).toBe(false);
+    expect(isPastGrace('2026-10-31', 14, '2026-11-14')).toBe(false);
+    expect(isPastGrace('2026-10-31', 14, '2026-11-15')).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/api && npx vitest run src/services/recurrence.test.ts`
+Expected: FAIL, module not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+import { addMonthsClamped, addDaysISO } from './contractMath';
+
+export type Cadence = 'monthly' | 'quarterly' | 'semiannual' | 'annual' | 'one_time';
+
+const MONTHS: Record<Exclude<Cadence, 'one_time'>, number> = { monthly: 1, quarterly: 3, semiannual: 6, annual: 12 };
+
+export function cadenceMonths(cadence: Cadence): number | null {
+  return cadence === 'one_time' ? null : MONTHS[cadence];
+}
+
+export function nthDueDate(anchorDueDate: string, cadence: Cadence, n: number): string | null {
+  if (n < 0) throw new RangeError('n must be >= 0');
+  const months = cadenceMonths(cadence);
+  if (months === null) return n === 0 ? anchorDueDate : null;
+  // Always step from the anchor (not from the previous clamped date) so a 31st anchor
+  // returns to the 31st in long months instead of drifting to the 28th forever.
+  return addMonthsClamped(anchorDueDate, months * n);
+}
+
+export function coveredPeriod(dueAt: string, cadence: Cadence): { periodStart: string; periodEnd: string } {
+  const months = cadenceMonths(cadence);
+  if (months === null) return { periodStart: dueAt, periodEnd: dueAt };
+  return { periodStart: addDaysISO(addMonthsClamped(dueAt, -months), 1), periodEnd: dueAt };
+}
+
+export function isInLeadWindow(dueAt: string, leadDays: number, today: string): boolean {
+  return addDaysISO(dueAt, -leadDays) <= today;
+}
+
+export function isPastGrace(dueAt: string, graceDays: number, today: string): boolean {
+  return addDaysISO(dueAt, graceDays) < today;
+}
+
+export interface PlanInput {
+  anchorDueDate: string; cadence: Cadence; effectiveFrom: string; effectiveUntil: string | null;
+  leadDays: number; graceDays: number; today: string; existingDueDates: readonly string[]; cap?: number;
+}
+export interface PlannedOccurrence { periodStart: string; periodEnd: string; dueAt: string; initialStatus: 'scheduled' | 'missed' }
+
+/** Every due date d with effectiveFrom ≤ d ≤ effectiveUntil, d − leadDays ≤ today, not yet materialized; oldest first; capped. */
+export function planOccurrences(input: PlanInput): PlannedOccurrence[] {
+  const cap = input.cap ?? 12;
+  const existing = new Set(input.existingDueDates);
+  const out: PlannedOccurrence[] = [];
+  for (let n = 0; out.length < cap; n++) {
+    const due = nthDueDate(input.anchorDueDate, input.cadence, n);
+    if (due === null) break;
+    if (!isInLeadWindow(due, input.leadDays, input.today)) break;
+    if (input.effectiveUntil !== null && due > input.effectiveUntil) break;
+    if (due < input.effectiveFrom || existing.has(due)) continue;
+    out.push({ ...coveredPeriod(due, input.cadence), dueAt: due, initialStatus: isPastGrace(due, input.graceDays, input.today) ? 'missed' : 'scheduled' });
+  }
+  return out;
+}
+```
+
+Both helpers accept negative arguments: `addDaysISO` builds `Date.UTC(y, m-1, d+days)` (`contractMath.ts:62`) and `addMonthsClamped` normalises with `(zeroBased % 12 + 12) % 12` (`contractMath.ts:21-27`).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd apps/api && npx vitest run src/services/recurrence.test.ts`
+Expected: PASS (10 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/recurrence.ts apps/api/src/services/recurrence.test.ts
+git commit -m "feat(deliverables): pure recurrence module (W01)"
+```
+
+---
+
+### Task 6: `services/serviceDeliverableState.ts` (pure state machine)
+
+**Files:**
+- Create: `apps/api/src/services/serviceDeliverableState.ts`
+- Test: `apps/api/src/services/serviceDeliverableState.test.ts`
+
+**Interfaces:**
+- Produces:
+
+```ts
+export type OccurrenceStatus = 'scheduled' | 'open' | 'awaiting_evidence' | 'delivered' | 'missed' | 'waived';
+export type OccurrenceEvent =
+  | { type: 'open' }
+  | { type: 'deliver'; hasEvidence: boolean; artifactRequired: boolean }
+  | { type: 'evidence_added' }
+  | { type: 'ticket_resolved'; hasEvidence: boolean; artifactRequired: boolean; completionMode: 'explicit' | 'on_ticket_resolve' }
+  | { type: 'ticket_reopened'; deliveredVia: 'explicit' | 'ticket' | null }
+  | { type: 'miss' }
+  | { type: 'waive' }
+  | { type: 'reopen' };
+export type Transition = { next: OccurrenceStatus } | { next: null; reason: string };  // next null = no-op
+export function transition(current: OccurrenceStatus, event: OccurrenceEvent): Transition;
+export class InvalidTransitionError extends Error { constructor(current: OccurrenceStatus, event: OccurrenceEvent['type']) }
+```
+
+`transition` returns `{ next: null, reason }` for benign no-ops (idempotent sweep/subscriber events) and **throws** `InvalidTransitionError` for user actions that are illegal (e.g. `deliver` on `waived`).
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { transition, InvalidTransitionError } from './serviceDeliverableState';
+
+describe('occurrence state machine (spec §4.2)', () => {
+  it('scheduled → open on open', () => expect(transition('scheduled', { type: 'open' })).toEqual({ next: 'open' }));
+  it('open on open is a no-op', () => expect(transition('open', { type: 'open' }).next).toBeNull());
+
+  it('deliver requires evidence when artifact_required', () => {
+    expect(() => transition('open', { type: 'deliver', hasEvidence: false, artifactRequired: true })).toThrow(InvalidTransitionError);
+    expect(transition('open', { type: 'deliver', hasEvidence: true, artifactRequired: true })).toEqual({ next: 'delivered' });
+    expect(transition('open', { type: 'deliver', hasEvidence: false, artifactRequired: false })).toEqual({ next: 'delivered' });
+  });
+
+  it('missed → delivered (late) is allowed', () =>
+    expect(transition('missed', { type: 'deliver', hasEvidence: true, artifactRequired: true })).toEqual({ next: 'delivered' }));
+
+  it('ticket resolve with on_ticket_resolve: awaiting_evidence when evidence missing, delivered otherwise', () => {
+    expect(transition('open', { type: 'ticket_resolved', hasEvidence: false, artifactRequired: true, completionMode: 'on_ticket_resolve' })).toEqual({ next: 'awaiting_evidence' });
+    expect(transition('open', { type: 'ticket_resolved', hasEvidence: true, artifactRequired: true, completionMode: 'on_ticket_resolve' })).toEqual({ next: 'delivered' });
+    expect(transition('open', { type: 'ticket_resolved', hasEvidence: false, artifactRequired: false, completionMode: 'on_ticket_resolve' })).toEqual({ next: 'delivered' });
+  });
+
+  it('ticket resolve with explicit mode changes nothing', () =>
+    expect(transition('open', { type: 'ticket_resolved', hasEvidence: true, artifactRequired: false, completionMode: 'explicit' }).next).toBeNull());
+
+  it('evidence_added completes awaiting_evidence only', () => {
+    expect(transition('awaiting_evidence', { type: 'evidence_added' })).toEqual({ next: 'delivered' });
+    expect(transition('open', { type: 'evidence_added' }).next).toBeNull();
+  });
+
+  it('ticket reopen undoes a ticket-driven delivery but never an explicit one', () => {
+    expect(transition('delivered', { type: 'ticket_reopened', deliveredVia: 'ticket' })).toEqual({ next: 'open' });
+    expect(transition('delivered', { type: 'ticket_reopened', deliveredVia: 'explicit' }).next).toBeNull();
+  });
+
+  it('miss applies to open and awaiting_evidence only', () => {
+    expect(transition('open', { type: 'miss' })).toEqual({ next: 'missed' });
+    expect(transition('awaiting_evidence', { type: 'miss' })).toEqual({ next: 'missed' });
+    expect(transition('delivered', { type: 'miss' }).next).toBeNull();
+  });
+
+  it('waive from open, awaiting_evidence, missed; not from delivered', () => {
+    expect(transition('missed', { type: 'waive' })).toEqual({ next: 'waived' });
+    expect(() => transition('delivered', { type: 'waive' })).toThrow(InvalidTransitionError);
+  });
+
+  it('reopen from delivered or waived only', () => {
+    expect(transition('delivered', { type: 'reopen' })).toEqual({ next: 'open' });
+    expect(transition('waived', { type: 'reopen' })).toEqual({ next: 'open' });
+    expect(() => transition('open', { type: 'reopen' })).toThrow(InvalidTransitionError);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/api && npx vitest run src/services/serviceDeliverableState.test.ts`
+Expected: FAIL, module not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+export type OccurrenceStatus = 'scheduled' | 'open' | 'awaiting_evidence' | 'delivered' | 'missed' | 'waived';
+export type OccurrenceEvent =
+  | { type: 'open' }
+  | { type: 'deliver'; hasEvidence: boolean; artifactRequired: boolean }
+  | { type: 'evidence_added' }
+  | { type: 'ticket_resolved'; hasEvidence: boolean; artifactRequired: boolean; completionMode: 'explicit' | 'on_ticket_resolve' }
+  | { type: 'ticket_reopened'; deliveredVia: 'explicit' | 'ticket' | null }
+  | { type: 'miss' }
+  | { type: 'waive' }
+  | { type: 'reopen' };
+export type Transition = { next: OccurrenceStatus } | { next: null; reason: string };
+
+export class InvalidTransitionError extends Error {
+  readonly status = 409;
+  readonly code = 'INVALID_OCCURRENCE_TRANSITION';
+  constructor(readonly current: OccurrenceStatus, readonly event: OccurrenceEvent['type']) {
+    super(`Cannot ${event} an occurrence in status ${current}`);
+  }
+}
+
+const noop = (reason: string): Transition => ({ next: null, reason });
+const ACTIVE: ReadonlySet<OccurrenceStatus> = new Set(['open', 'awaiting_evidence', 'missed']);
+
+export function transition(current: OccurrenceStatus, event: OccurrenceEvent): Transition {
+  switch (event.type) {
+    case 'open':
+      return current === 'scheduled' ? { next: 'open' } : noop('already opened');
+    case 'deliver':
+      if (!ACTIVE.has(current)) throw new InvalidTransitionError(current, event.type);
+      if (event.artifactRequired && !event.hasEvidence) throw new InvalidTransitionError(current, event.type);
+      return { next: 'delivered' };
+    case 'evidence_added':
+      return current === 'awaiting_evidence' ? { next: 'delivered' } : noop('evidence recorded, status unchanged');
+    case 'ticket_resolved':
+      if (event.completionMode === 'explicit') return noop('explicit completion mode');
+      if (current !== 'open' && current !== 'missed') return noop('not open');
+      return event.artifactRequired && !event.hasEvidence ? { next: 'awaiting_evidence' } : { next: 'delivered' };
+    case 'ticket_reopened':
+      return current === 'delivered' && event.deliveredVia === 'ticket' ? { next: 'open' } : noop('not a ticket-driven delivery');
+    case 'miss':
+      return current === 'open' || current === 'awaiting_evidence' ? { next: 'missed' } : noop('not missable');
+    case 'waive':
+      if (!ACTIVE.has(current)) throw new InvalidTransitionError(current, event.type);
+      return { next: 'waived' };
+    case 'reopen':
+      if (current !== 'delivered' && current !== 'waived') throw new InvalidTransitionError(current, event.type);
+      return { next: 'open' };
+  }
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd apps/api && npx vitest run src/services/serviceDeliverableState.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/serviceDeliverableState.ts apps/api/src/services/serviceDeliverableState.test.ts
+git commit -m "feat(deliverables): pure occurrence state machine (W01)"
+```
+
+---
+
+### Task 7: Shared validators
+
+**Files:**
+- Create: `packages/shared/src/validators/serviceDeliverables.ts`, `packages/shared/src/validators/serviceDeliverables.test.ts`
+- Create: `packages/shared/src/validators/orgKeyDates.ts`, `packages/shared/src/validators/orgKeyDates.test.ts`
+- Modify: `packages/shared/src/validators/index.ts` (export both)
+
+**Interfaces:**
+- Produces (exact names): `deliverableCadenceSchema`, `createDeliverableSchema`, `updateDeliverableSchema`, `listDeliverablesQuerySchema`, `deliverOccurrenceSchema`, `waiveOccurrenceSchema`, `rescheduleOccurrenceSchema`, `addEvidenceSchema`, `listOccurrencesQuerySchema`; `createKeyDateSchema`, `updateKeyDateSchema`; and `z.infer` types `CreateDeliverableInput`, `UpdateDeliverableInput`, `DeliverOccurrenceInput`, `WaiveOccurrenceInput`, `RescheduleOccurrenceInput`, `AddEvidenceInput`, `CreateKeyDateInput`, `UpdateKeyDateInput`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { createDeliverableSchema, updateDeliverableSchema, deliverOccurrenceSchema, addEvidenceSchema, rescheduleOccurrenceSchema } from './serviceDeliverables';
+
+const base = { name: 'Sign-in log review', cadence: 'monthly', anchorDueDate: '2026-10-31', effectiveFrom: '2026-10-01' };
+
+describe('serviceDeliverables validators', () => {
+  it('accepts a minimal create payload with defaults', () => {
+    const r = createDeliverableSchema.parse(base);
+    expect(r.leadDays).toBe(7); expect(r.graceDays).toBe(14); expect(r.artifactRequired).toBe(true);
+    expect(r.completionMode).toBe('on_ticket_resolve'); expect(r.portalVisible).toBe(true);
+  });
+  it('rejects effectiveUntil before effectiveFrom', () =>
+    expect(createDeliverableSchema.safeParse({ ...base, effectiveUntil: '2026-09-01' }).success).toBe(false));
+  it('rejects unknown cadence and negative days', () => {
+    expect(createDeliverableSchema.safeParse({ ...base, cadence: 'continuous' }).success).toBe(false);
+    expect(createDeliverableSchema.safeParse({ ...base, leadDays: -1 }).success).toBe(false);
+  });
+  it('update forbids changing cadence (spec §16: history is not rewritten)', () =>
+    expect(updateDeliverableSchema.safeParse({ cadence: 'annual' }).success).toBe(false));
+  it('deliver accepts note and report-run evidence refs only in W01', () => {
+    expect(deliverOccurrenceSchema.parse({ note: 'done', evidence: [{ kind: 'report_run', reportRunId: '11111111-1111-4111-8111-111111111111' }] }).evidence).toHaveLength(1);
+    expect(deliverOccurrenceSchema.safeParse({ evidence: [{ kind: 'document', documentId: '11111111-1111-4111-8111-111111111111' }] }).success).toBe(false);
+  });
+  it('addEvidence requires a guid', () => expect(addEvidenceSchema.safeParse({ kind: 'report_run', reportRunId: 'nope' }).success).toBe(false));
+  it('reschedule requires an ISO date', () => expect(rescheduleOccurrenceSchema.safeParse({ dueAt: '31/10/2026' }).success).toBe(false));
+});
+```
+
+And for key dates:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { createKeyDateSchema, updateKeyDateSchema } from './orgKeyDates';
+
+describe('orgKeyDates validators', () => {
+  it('accepts a renewal with reminder', () => {
+    const r = createKeyDateSchema.parse({ label: 'Cyber insurance renewal', kind: 'insurance_renewal', date: '2027-03-01', recursAnnually: true, remindDaysBefore: 60 });
+    expect(r.portalVisible).toBe(false);
+  });
+  it('rejects negative reminder days and bad dates', () => {
+    expect(createKeyDateSchema.safeParse({ label: 'x', date: '2027-03-01', remindDaysBefore: -1 }).success).toBe(false);
+    expect(createKeyDateSchema.safeParse({ label: 'x', date: 'March 1' }).success).toBe(false);
+  });
+  it('update is partial', () => expect(updateKeyDateSchema.parse({ notes: 'renewed' })).toEqual({ notes: 'renewed' }));
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd packages/shared && npx vitest run src/validators/serviceDeliverables.test.ts src/validators/orgKeyDates.test.ts`
+Expected: FAIL, module not found.
+
+- [ ] **Step 3: Implement**
+
+`serviceDeliverables.ts`:
+
+```ts
+import { z } from 'zod';
+
+const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'YYYY-MM-DD');
+export const deliverableCadenceSchema = z.enum(['monthly', 'quarterly', 'semiannual', 'annual', 'one_time']);
+export const deliverableCompletionModeSchema = z.enum(['explicit', 'on_ticket_resolve']);
+
+const deliverableFields = {
+  contractId: z.string().guid().nullable().optional(),
+  name: z.string().min(1).max(200),
+  description: z.string().max(2000).nullable().optional(),
+  cadence: deliverableCadenceSchema,
+  anchorDueDate: isoDate,
+  effectiveFrom: isoDate,
+  effectiveUntil: isoDate.nullable().optional(),
+  leadDays: z.number().int().min(0).max(365).default(7),
+  graceDays: z.number().int().min(0).max(365).default(14),
+  artifactRequired: z.boolean().default(true),
+  completionMode: deliverableCompletionModeSchema.default('on_ticket_resolve'),
+  autoEvidenceReportId: z.string().guid().nullable().optional(),
+  ownerUserId: z.string().guid().nullable().optional(),
+  ticketCategoryId: z.string().guid().nullable().optional(),
+  portalVisible: z.boolean().default(true),
+  sortOrder: z.number().int().min(0).default(0),
+};
+const effectiveRange = (d: { effectiveFrom?: string; effectiveUntil?: string | null }) =>
+  d.effectiveUntil == null || d.effectiveFrom == null || d.effectiveUntil >= d.effectiveFrom;
+
+export const createDeliverableSchema = z.object(deliverableFields).refine(effectiveRange, { message: 'effectiveUntil must be on or after effectiveFrom', path: ['effectiveUntil'] });
+export const updateDeliverableSchema = z.object({
+  ...Object.fromEntries(Object.entries(deliverableFields).filter(([k]) => !['cadence', 'anchorDueDate'].includes(k)).map(([k, v]) => [k, (v as z.ZodTypeAny).optional()])),
+  active: z.boolean().optional(),
+}).strict().refine(effectiveRange, { message: 'effectiveUntil must be on or after effectiveFrom', path: ['effectiveUntil'] });
+export const listDeliverablesQuerySchema = z.object({
+  contractId: z.string().guid().optional(),
+  includeInactive: z.coerce.boolean().optional(),
+});
+
+export const reportRunEvidenceRefSchema = z.object({ kind: z.literal('report_run'), reportRunId: z.string().guid() });
+// W03 widens this union with { kind: 'document', documentId }.
+export const evidenceRefSchema = z.discriminatedUnion('kind', [reportRunEvidenceRefSchema]);
+export const addEvidenceSchema = evidenceRefSchema;
+export const deliverOccurrenceSchema = z.object({ note: z.string().max(4000).optional(), evidence: z.array(evidenceRefSchema).max(20).optional() });
+export const waiveOccurrenceSchema = z.object({ reason: z.string().min(1).max(2000) });
+export const rescheduleOccurrenceSchema = z.object({ dueAt: isoDate });
+export const listOccurrencesQuerySchema = z.object({ limit: z.coerce.number().int().min(1).max(100).default(24) });
+
+export type CreateDeliverableInput = z.infer<typeof createDeliverableSchema>;
+export type UpdateDeliverableInput = z.infer<typeof updateDeliverableSchema>;
+export type DeliverOccurrenceInput = z.infer<typeof deliverOccurrenceSchema>;
+export type WaiveOccurrenceInput = z.infer<typeof waiveOccurrenceSchema>;
+export type RescheduleOccurrenceInput = z.infer<typeof rescheduleOccurrenceSchema>;
+export type AddEvidenceInput = z.infer<typeof addEvidenceSchema>;
+export type EvidenceRef = z.infer<typeof evidenceRefSchema>;
+```
+
+If the `Object.fromEntries` construction fights the type-checker, write `updateDeliverableSchema` out longhand with each field `.optional()`; readability beats cleverness here.
+
+`orgKeyDates.ts`:
+
+```ts
+import { z } from 'zod';
+const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'YYYY-MM-DD');
+export const keyDateKindSchema = z.enum(['insurance_renewal', 'vendor_contract_end', 'compliance_deadline', 'audit', 'other']);
+export const createKeyDateSchema = z.object({
+  label: z.string().min(1).max(200),
+  kind: keyDateKindSchema.default('other'),
+  date: isoDate,
+  recursAnnually: z.boolean().default(false),
+  remindDaysBefore: z.number().int().min(0).max(365).nullable().optional(),
+  ownerUserId: z.string().guid().nullable().optional(),
+  portalVisible: z.boolean().default(false),
+  notes: z.string().max(4000).nullable().optional(),
+});
+export const updateKeyDateSchema = createKeyDateSchema.partial().strict();
+export type CreateKeyDateInput = z.infer<typeof createKeyDateSchema>;
+export type UpdateKeyDateInput = z.infer<typeof updateKeyDateSchema>;
+```
+
+Export both from `packages/shared/src/validators/index.ts`.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd packages/shared && npx vitest run src/validators/serviceDeliverables.test.ts src/validators/orgKeyDates.test.ts && npx tsc --noEmit`
+Expected: PASS, no type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/shared/src/validators
+git commit -m "feat(shared): service deliverable and key date validators (W01)"
+```
+
+---
+
+### Task 8: `serviceDeliverableService.ts`
+
+**Files:**
+- Create: `apps/api/src/services/serviceDeliverableService.ts`
+- Test: `apps/api/src/services/serviceDeliverableService.test.ts`
+
+**Interfaces:**
+- Consumes: schema from Task 3, `transition` from Task 6, `coveredPeriod` from Task 5, validators from Task 7.
+- Produces (exact signatures; W02–W05 import these):
+
+```ts
+export interface DeliverableActor { userId: string | null; partnerId: string | null; accessibleOrgIds: string[] | null }
+export class DeliverableServiceError extends Error { constructor(message: string, readonly status: number, readonly code: string, readonly details?: unknown) }
+
+export function listDeliverables(orgId: string, q: { contractId?: string; includeInactive?: boolean }, actor: DeliverableActor): Promise<DeliverableSummary[]>;
+export function getDeliverable(orgId: string, id: string, actor: DeliverableActor): Promise<DeliverableSummary>;
+export function createDeliverable(orgId: string, input: CreateDeliverableInput, actor: DeliverableActor): Promise<ServiceDeliverableRow>;
+export function updateDeliverable(orgId: string, id: string, patch: UpdateDeliverableInput, actor: DeliverableActor): Promise<ServiceDeliverableRow>;
+export function deactivateDeliverable(orgId: string, id: string, actor: DeliverableActor): Promise<void>;   // sets active=false
+export function listOccurrences(orgId: string, deliverableId: string, q: { limit: number }, actor: DeliverableActor): Promise<OccurrenceView[]>;
+export function deliverOccurrence(orgId: string, occurrenceId: string, input: DeliverOccurrenceInput, actor: DeliverableActor): Promise<OccurrenceView>;
+export function waiveOccurrence(orgId: string, occurrenceId: string, input: WaiveOccurrenceInput, actor: DeliverableActor): Promise<OccurrenceView>;
+export function reopenOccurrence(orgId: string, occurrenceId: string, actor: DeliverableActor): Promise<OccurrenceView>;
+export function rescheduleOccurrence(orgId: string, occurrenceId: string, input: RescheduleOccurrenceInput, actor: DeliverableActor): Promise<OccurrenceView>;
+export function addEvidence(orgId: string, occurrenceId: string, ref: EvidenceRef, actor: DeliverableActor): Promise<OccurrenceView>;
+export function removeEvidence(orgId: string, occurrenceId: string, evidenceId: string, actor: DeliverableActor): Promise<OccurrenceView>;
+
+// Reserved for W02 (system callers, no actor; run inside withSystemDbAccessContext). Declared here as
+// exported stubs that throw 'not implemented (W02)' so W02 replaces bodies, not names:
+export function materializeOccurrences(deliverableId: string, today: string): Promise<ServiceDeliverableOccurrenceRow[]>;
+export function openOccurrence(occurrenceId: string, ticketId: string | null): Promise<void>;
+export function markOccurrenceMissed(occurrenceId: string): Promise<void>;
+export function applyTicketStatusChange(args: { ticketId: string; orgId: string; to: string; actorUserId: string | null; resolutionNote: string | null }): Promise<void>;
+
+export interface DeliverableSummary extends ServiceDeliverableRow { contractName: string | null; nextDue: string | null; lastDelivered: { at: string; late: boolean; note: string | null } | null; openCount: number; status: 'on_track' | 'due_soon' | 'late' | 'missed' | 'inactive' }
+export interface OccurrenceView extends ServiceDeliverableOccurrenceRow { late: boolean; evidence: Array<{ id: string; kind: 'document' | 'report_run'; documentId: string | null; reportId: string | null; reportRunId: string | null; createdAt: string }> }
+```
+
+Rules the service enforces (each has a test):
+
+- `requireOrgAccess(actor, orgId)` → 404 `NOT_FOUND` on foreign org.
+- `contractId` must belong to `orgId` (select `contracts` where `id` and `orgId`) → 400 `CONTRACT_NOT_IN_ORG`.
+- `ownerUserId` must exist and hold access to the org's partner (`users.partnerId = organizations.partnerId`) → 400 `OWNER_NOT_ALLOWED`. `ticketCategoryId` must belong to the org's partner → 400 `CATEGORY_NOT_ALLOWED`.
+- `autoEvidenceReportId` must be a `reports` row of the org → 404 `NOT_FOUND`.
+- Duplicate `(org, contract, name)` → 409 `DUPLICATE_NAME`.
+- `addEvidence` with `report_run`: the run's `report_id` must be a report of the org → 404 `NOT_FOUND` (never 403); stores `reportId` alongside `reportRunId`.
+- `deliverOccurrence`: insert evidence refs first, then `transition(current, {type:'deliver', hasEvidence, artifactRequired})`; `InvalidTransitionError` with missing evidence → 400 `EVIDENCE_REQUIRED`; other invalid → 409 `INVALID_OCCURRENCE_TRANSITION`. Sets `deliveredAt=now`, `deliveredByUserId=actor.userId`, `deliveredVia='explicit'`, `deliveryNote`.
+- `addEvidence` on `awaiting_evidence` runs `transition(current, {type:'evidence_added'})` and, on `delivered`, stamps `deliveredVia='ticket'` (the ticket resolution started it).
+- `waive` stamps `waivedAt`, `waivedByUserId`, `waivedReason`; `reopen` clears all delivery and waiver fields.
+- `reschedule` only on `scheduled | open | awaiting_evidence | missed`; keeps `originalDueAt`; recomputes `status` to `open` if it was `missed` and the new due date is not past grace.
+- `DeliverableSummary.status`: `inactive` when `!active` or today outside the effective range; else `missed` if any occurrence is `missed`; `late` if any `open|awaiting_evidence` past `dueAt`; `due_soon` if any open within lead window; else `on_track`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Use the Drizzle mock pattern from the `breeze-testing` skill (chainable `select/from/where/limit` mocks via `vi.hoisted`). Cover at minimum:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const dbMocks = vi.hoisted(() => ({ rows: [] as unknown[], inserted: [] as unknown[], updated: [] as unknown[] }));
+vi.mock('../db', () => {
+  const chain = () => {
+    const c: any = {};
+    for (const m of ['select', 'from', 'where', 'limit', 'orderBy', 'innerJoin', 'leftJoin', 'insert', 'values', 'update', 'set', 'delete', 'returning']) {
+      c[m] = vi.fn(() => c);
+    }
+    c.then = (res: (v: unknown) => void) => res(dbMocks.rows.shift() ?? []);
+    return c;
+  };
+  return { db: chain(), withDbAccessContext: (_: unknown, fn: () => unknown) => fn() };
+});
+import { createDeliverable, deliverOccurrence, DeliverableServiceError } from './serviceDeliverableService';
+
+const actor = { userId: 'u1', partnerId: 'p1', accessibleOrgIds: ['org1'] };
+const base = { name: 'Sign-in log review', cadence: 'monthly' as const, anchorDueDate: '2026-10-31', effectiveFrom: '2026-10-01', leadDays: 7, graceDays: 14, artifactRequired: true, completionMode: 'on_ticket_resolve' as const, portalVisible: true, sortOrder: 0 };
+
+describe('serviceDeliverableService', () => {
+  beforeEach(() => { dbMocks.rows.length = 0; });
+
+  it('404s a foreign org without touching the db', async () => {
+    await expect(createDeliverable('org2', base, actor)).rejects.toMatchObject({ status: 404, code: 'NOT_FOUND' });
+  });
+
+  it('rejects a contract from another org', async () => {
+    dbMocks.rows.push([]); // contract lookup returns nothing
+    await expect(createDeliverable('org1', { ...base, contractId: '11111111-1111-4111-8111-111111111111' }, actor))
+      .rejects.toMatchObject({ status: 400, code: 'CONTRACT_NOT_IN_ORG' });
+  });
+
+  it('deliver without required evidence → 400 EVIDENCE_REQUIRED', async () => {
+    dbMocks.rows.push([{ id: 'o1', orgId: 'org1', status: 'open', deliverableId: 'd1', artifactRequired: true }]); // occurrence+deliverable join
+    dbMocks.rows.push([]); // evidence count
+    await expect(deliverOccurrence('org1', 'o1', {}, actor)).rejects.toMatchObject({ status: 400, code: 'EVIDENCE_REQUIRED' });
+  });
+});
+```
+
+Add tests for `DUPLICATE_NAME` (unique violation `23505` mapped to 409), `waive` requires reason, `reopen` clears fields, `reschedule` on `waived` → 409, `addEvidence` with a run of another org's report → 404, `removeEvidence` on `delivered` with `artifactRequired` leaving zero evidence → 409 `EVIDENCE_REQUIRED` (delivery would become unsupported), summary `status` derivation (pure helper `summarizeStatus(...)` exported for testing).
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/api && npx vitest run src/services/serviceDeliverableService.test.ts`
+Expected: FAIL, module not found.
+
+- [ ] **Step 3: Implement the service**
+
+Skeleton (fill every function; no TODOs):
+
+```ts
+import { and, desc, eq, inArray, sql } from 'drizzle-orm';
+import { db } from '../db';
+import { serviceDeliverables, serviceDeliverableOccurrences, serviceDeliverableEvidence, type ServiceDeliverableRow, type ServiceDeliverableOccurrenceRow } from '../db/schema/serviceDeliverables';
+import { contracts } from '../db/schema/contracts';
+import { organizations } from '../db/schema/orgs';
+import { users } from '../db/schema/users';
+import { reports, reportRuns } from '../db/schema/reports';
+import { ticketCategories } from '../db/schema/portal';
+import type { CreateDeliverableInput, UpdateDeliverableInput, DeliverOccurrenceInput, WaiveOccurrenceInput, RescheduleOccurrenceInput, EvidenceRef } from '@breeze/shared';
+import { transition, InvalidTransitionError, type OccurrenceStatus } from './serviceDeliverableState';
+import { isInLeadWindow, isPastGrace } from './recurrence';
+
+export interface DeliverableActor { userId: string | null; partnerId: string | null; accessibleOrgIds: string[] | null }
+export class DeliverableServiceError extends Error {
+  constructor(message: string, readonly status: number, readonly code: string, readonly details?: unknown) { super(message); }
+}
+function requireOrgAccess(actor: DeliverableActor, orgId: string): void {
+  if (actor.accessibleOrgIds !== null && !actor.accessibleOrgIds.includes(orgId)) throw new DeliverableServiceError('Not found', 404, 'NOT_FOUND');
+}
+const todayISO = () => new Date().toISOString().slice(0, 10);
+
+export function summarizeStatus(d: { active: boolean; effectiveFrom: string; effectiveUntil: string | null; leadDays: number }, occ: Array<{ status: OccurrenceStatus; dueAt: string }>, today = todayISO()): DeliverableSummary['status'] {
+  if (!d.active || today < d.effectiveFrom || (d.effectiveUntil !== null && today > d.effectiveUntil)) return 'inactive';
+  if (occ.some((o) => o.status === 'missed')) return 'missed';
+  const open = occ.filter((o) => o.status === 'open' || o.status === 'awaiting_evidence');
+  if (open.some((o) => o.dueAt < today)) return 'late';
+  if (open.some((o) => isInLeadWindow(o.dueAt, d.leadDays, today))) return 'due_soon';
+  return 'on_track';
+}
+// … listDeliverables / getDeliverable / createDeliverable / updateDeliverable / deactivateDeliverable
+// … listOccurrences / loadOccurrence (joins deliverable for artifactRequired + completionMode; 404 if org mismatch)
+// … deliverOccurrence / waiveOccurrence / reopenOccurrence / rescheduleOccurrence / addEvidence / removeEvidence
+// … W02 stubs:
+export async function materializeOccurrences(_deliverableId: string, _today: string): Promise<ServiceDeliverableOccurrenceRow[]> { throw new Error('not implemented (W02)'); }
+export async function openOccurrence(_occurrenceId: string, _ticketId: string | null): Promise<void> { throw new Error('not implemented (W02)'); }
+export async function markOccurrenceMissed(_occurrenceId: string): Promise<void> { throw new Error('not implemented (W02)'); }
+export async function applyTicketStatusChange(_args: { ticketId: string; orgId: string; to: string; actorUserId: string | null; resolutionNote: string | null }): Promise<void> { throw new Error('not implemented (W02)'); }
+```
+
+Map Postgres unique violations (`err.code === '23505'`) on `service_deliverables_org_contract_name_uq` to 409 `DUPLICATE_NAME`. Every write of an occurrence also sets `updatedAt: new Date()`. Mutations that touch two tables (deliver = evidence insert + occurrence update) run in `db.transaction`.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd apps/api && npx vitest run src/services/serviceDeliverableService.test.ts && npx tsc --noEmit`
+Expected: PASS; no type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/serviceDeliverableService.ts apps/api/src/services/serviceDeliverableService.test.ts
+git commit -m "feat(deliverables): deliverable and occurrence service (W01)"
+```
+
+---
+
+### Task 9: `orgKeyDateService.ts`
+
+**Files:**
+- Create: `apps/api/src/services/orgKeyDateService.ts`
+- Test: `apps/api/src/services/orgKeyDateService.test.ts`
+
+**Interfaces:**
+- Produces:
+
+```ts
+export interface KeyDateView { source: 'key_date' | 'contract_end'; id: string; label: string; kind: string; date: string; recursAnnually: boolean; remindDaysBefore: number | null; ownerUserId: string | null; portalVisible: boolean; notes: string | null; contractId: string | null }
+export function listKeyDates(orgId: string, actor: DeliverableActor, opts?: { includeContractEnds?: boolean }): Promise<KeyDateView[]>;  // sorted by date asc
+export function createKeyDate(orgId: string, input: CreateKeyDateInput, actor: DeliverableActor): Promise<OrganizationKeyDateRow>;
+export function updateKeyDate(orgId: string, id: string, patch: UpdateKeyDateInput, actor: DeliverableActor): Promise<OrganizationKeyDateRow>;
+export function deleteKeyDate(orgId: string, id: string, actor: DeliverableActor): Promise<void>;
+```
+
+Contract-end rows: `source='contract_end'`, `id=contract.id`, `label=contract.name`, `kind='contract_end'`, `date=contract.endDate`, only where `endDate >= today` and `status NOT IN ('draft','cancelled')`, `portalVisible=true`.
+
+- [ ] **Step 1: Failing tests** — foreign org 404; `listKeyDates` unions and sorts contract ends; `updateKeyDate` clearing the date rejects (date is required); `deleteKeyDate` of a missing id → 404.
+- [ ] **Step 2: Run** `cd apps/api && npx vitest run src/services/orgKeyDateService.test.ts` → FAIL.
+- [ ] **Step 3: Implement** with the same `requireOrgAccess` and `DeliverableServiceError` (import from `serviceDeliverableService.ts`).
+- [ ] **Step 4: Run** → PASS; `npx tsc --noEmit`.
+- [ ] **Step 5: Commit** `git commit -m "feat(deliverables): org key date service (W01)"`.
+
+---
+
+### Task 10: REST routes and mounting
+
+**Files:**
+- Create: `apps/api/src/routes/serviceDeliverables.ts`, `apps/api/src/routes/serviceDeliverables.test.ts`
+- Create: `apps/api/src/routes/contracts/deliverables.ts`, `apps/api/src/routes/contracts/deliverables.test.ts`
+- Create: `apps/api/src/routes/orgKeyDates.ts`, `apps/api/src/routes/orgKeyDates.test.ts`
+- Modify: `apps/api/src/routes/contracts/index.ts` (mount `contractDeliverableRoutes` before `/:id` catch-alls)
+- Modify: `apps/api/src/index.ts:834-837` (add `api.route('/orgs', serviceDeliverableRoutes); api.route('/orgs', orgKeyDateRoutes);`)
+
+**Interfaces:**
+- Produces routes (all `requireScope('partner','system')`, permissions `contracts:read` for GET and `contracts:write` for mutations; every response `{ data }`):
+
+```
+GET    /orgs/:orgId/deliverables?contractId&includeInactive
+POST   /orgs/:orgId/deliverables
+GET    /orgs/:orgId/deliverables/:id
+PATCH  /orgs/:orgId/deliverables/:id
+DELETE /orgs/:orgId/deliverables/:id              (deactivate; 200 {data:{ok:true}})
+GET    /orgs/:orgId/deliverables/:id/occurrences?limit
+POST   /orgs/:orgId/deliverables/occurrences/:oId/deliver
+POST   /orgs/:orgId/deliverables/occurrences/:oId/waive
+POST   /orgs/:orgId/deliverables/occurrences/:oId/reopen
+POST   /orgs/:orgId/deliverables/occurrences/:oId/reschedule
+POST   /orgs/:orgId/deliverables/occurrences/:oId/evidence
+DELETE /orgs/:orgId/deliverables/occurrences/:oId/evidence/:eId
+GET    /contracts/:id/deliverables                 (resolves the contract's org, then listDeliverables(orgId,{contractId}))
+GET    /orgs/:orgId/key-dates
+POST   /orgs/:orgId/key-dates
+PATCH  /orgs/:orgId/key-dates/:id
+DELETE /orgs/:orgId/key-dates/:id
+```
+
+Actor construction: copy `contractActorFrom` shape from `routes/contracts/contracts.ts:36-51` into a local `deliverableActorFrom(c)` returning `{ userId, partnerId, accessibleOrgIds }`. Error handler: `DeliverableServiceError` → `c.json({ error, code, details? }, status)`; `InvalidTransitionError` → 409; rethrow others.
+
+- [ ] **Step 1: Write the failing route tests** following `apps/api/src/routes/contracts/periods.test.ts` (mock `../middleware/auth`, hoist service mocks, assert 401 / 403 / 404-cross-tenant / 200 envelope / 400 on invalid body / 409 mapping). One test per route minimum; for `deliver` assert the body is validated by `deliverOccurrenceSchema` (a `document` evidence kind → 400).
+- [ ] **Step 2: Run** `cd apps/api && npx vitest run src/routes/serviceDeliverables.test.ts src/routes/contracts/deliverables.test.ts src/routes/orgKeyDates.test.ts` → FAIL.
+- [ ] **Step 3: Implement the three routers and mount them.** Keep each handler to `try { return c.json({ data: await svc(...) }) } catch (err) { return handleDeliverableError(c, err) }`.
+- [ ] **Step 4: Run** the three route tests and `npx tsc --noEmit` → PASS. Boot the API against the test stack (`pnpm --filter @breeze/api dev` with `.env.test`) and `curl -sf -H "Authorization: Bearer <partner token>" localhost:3001/api/v1/orgs/<orgId>/deliverables` → `{"data":[]}`.
+- [ ] **Step 5: Commit** `git commit -m "feat(deliverables): REST routes for deliverables, occurrences, key dates (W01)"`.
+
+---
+
+### Task 11: Integration test — RLS, deferrable FKs, evidence ownership
+
+**Files:**
+- Create: `apps/api/src/__tests__/integration/serviceDeliverablesRls.integration.test.ts`
+
+Follow the header pattern of the existing `*Rls.integration.test.ts` files (`import './setup'`, `createPartner`, `createOrganization`, `createUser`, `withDbAccessContext(orgContext(orgId), …)`).
+
+- [ ] **Step 1: Write the tests**
+
+1. **Cross-org forge**: as org A's context, `INSERT INTO service_deliverables (org_id, …) VALUES (<org B>, …)` → rejects with SQLSTATE `42501`. Repeat for occurrences, evidence and key dates.
+2. **Cross-org read**: org B inserts a deliverable under system context; org A's context `SELECT count(*)` → 0.
+3. **Positive control**: org A inserts and reads back its own row (1 row), so the forge test cannot pass vacuously.
+4. **Evidence ownership chain**: report R_B belongs to org B with run RR_B; as system context, `INSERT INTO service_deliverable_evidence (org_id=A, occurrence_id=<A's occurrence>, kind='report_run', report_id=R_B, report_run_id=RR_B)` → rejects with `23503` (composite FK `(report_id, org_id) → reports(id, org_id)`).
+5. **Deferrable re-point** (merge contract): under system context in one transaction, `SET CONSTRAINTS ALL DEFERRED`, update `organizations`-side rows and the child `org_id` in separate statements, commit → succeeds. Mirror the shape used by `orgLifecycleFoundations.integration.test.ts` for one FK.
+6. **Cascade**: deleting a deliverable removes its occurrences and evidence (`ON DELETE CASCADE`).
+
+- [ ] **Step 2: Run** `cd apps/api && npx vitest run --config vitest.integration.config.ts src/__tests__/integration/serviceDeliverablesRls.integration.test.ts` → PASS. Confirm in the output that 6 tests ran (a `0 tests` line is a stall, not green).
+- [ ] **Step 3: Commit** `git commit -m "test(deliverables): RLS, deferrable FK and evidence ownership integration suite (W01)"`.
+
+---
+
+### Task 12: Web API clients and i18n namespace
+
+**Files:**
+- Create: `apps/web/src/lib/api/serviceDeliverables.ts`, `apps/web/src/lib/api/orgKeyDates.ts`
+- Create: `apps/web/src/locales/{en,de-DE,es-419,fr-CA,fr-FR,it-IT,pt-BR,tr-TR}/deliverables.json`
+
+**Interfaces:**
+- Produces (web): types `Deliverable` (= `DeliverableSummary` JSON), `Occurrence` (= `OccurrenceView` JSON), `KeyDate` (= `KeyDateView`); functions taking an `OrgFetch`-compatible fetcher as the first argument so both the contract page (`fetchWithAuth`) and the org record (`orgFetch`) can use them:
+
+```ts
+export type Fetcher = (path: string, init?: RequestInit & { orgIdOverride?: string }) => Promise<Response>;
+export function listDeliverables(f: Fetcher, orgId: string, q?: { contractId?: string; includeInactive?: boolean }): Promise<Deliverable[]>;
+export function createDeliverable(f: Fetcher, orgId: string, body: CreateDeliverableInput): Promise<Deliverable>;
+export function updateDeliverable(f: Fetcher, orgId: string, id: string, body: UpdateDeliverableInput): Promise<Deliverable>;
+export function deactivateDeliverable(f: Fetcher, orgId: string, id: string): Promise<void>;
+export function listOccurrences(f: Fetcher, orgId: string, deliverableId: string, limit?: number): Promise<Occurrence[]>;
+export function deliverOccurrence(f: Fetcher, orgId: string, oId: string, body: DeliverOccurrenceInput): Promise<Occurrence>;
+export function waiveOccurrence(f: Fetcher, orgId: string, oId: string, body: WaiveOccurrenceInput): Promise<Occurrence>;
+export function reopenOccurrence(f: Fetcher, orgId: string, oId: string): Promise<Occurrence>;
+export function rescheduleOccurrence(f: Fetcher, orgId: string, oId: string, body: RescheduleOccurrenceInput): Promise<Occurrence>;
+export function addEvidence(f: Fetcher, orgId: string, oId: string, body: AddEvidenceInput): Promise<Occurrence>;
+export function removeEvidence(f: Fetcher, orgId: string, oId: string, eId: string): Promise<Occurrence>;
+// orgKeyDates.ts
+export function listKeyDates(f, orgId): Promise<KeyDate[]>; createKeyDate(f, orgId, body); updateKeyDate(f, orgId, id, body); deleteKeyDate(f, orgId, id);
+```
+
+Each function throws `new ActionError(...)` (from `apps/web/src/lib/runAction.ts`) on `!res.ok`, following `lib/api/contractDocuments.ts`.
+
+- [ ] **Step 1: Write the clients** (no test file needed for thin wrappers; they are exercised by component tests in Tasks 13–14).
+- [ ] **Step 2: Write `en/deliverables.json`** with keys: `section.title`, `section.empty`, `table.name`, `table.cadence`, `table.nextDue`, `table.lastDelivered`, `table.status`, `table.portal`, `cadence.monthly|quarterly|semiannual|annual|one_time`, `status.on_track|due_soon|late|missed|inactive`, `occurrence.status.scheduled|open|awaiting_evidence|delivered|missed|waived`, `actions.add|edit|deactivate|deliver|waive|reopen|reschedule|addEvidence|removeEvidence|save|cancel`, `form.*` labels for every deliverable field, `drawer.title`, `drawer.evidence`, `drawer.noEvidence`, `drawer.late`, `drawer.rescheduledFrom`, `errors.evidenceRequired`, `errors.duplicateName`, `keyDates.title|empty|add|label|kind|date|recursAnnually|remindDaysBefore|portalVisible|contractEnd`, `keyDates.kind.insurance_renewal|vendor_contract_end|compliance_deadline|audit|other`, `toast.saved|delivered|waived|reopened|rescheduled|evidenceAdded|deactivated`.
+- [ ] **Step 3: Translate into the seven other locales** with real translations (not English copies); keep product nouns (`Breeze`) untranslated. Consult `apps/web/src/locales/TERMINOLOGY.md` for fixed terms.
+- [ ] **Step 4: Run** `cd apps/web && npx vitest run src/lib/i18n` → PASS (parity + coverage).
+- [ ] **Step 5: Commit** `git commit -m "feat(web): deliverables API clients and i18n namespace (W01)"`.
+
+---
+
+### Task 13: Shared MSP components and the contract section
+
+**Files:**
+- Create: `apps/web/src/components/deliverables/DeliverableTable.tsx`, `DeliverableForm.tsx`, `OccurrenceDrawer.tsx`, `DeliverableTable.test.tsx`, `OccurrenceDrawer.test.tsx`
+- Create: `apps/web/src/components/contracts/ContractDeliverablesSection.tsx`, `ContractDetail.deliverables.test.tsx`
+- Modify: `apps/web/src/components/contracts/ContractDetail.tsx:482` (render `<ContractDeliverablesSection contractId={contract.id} orgId={contract.orgId} />` directly after `ContractDocumentsSection`)
+
+**Interfaces:**
+- `DeliverableTable({ fetcher, orgId, contractId?, onSelect(deliverable) })` renders `Deliverable[]` with name, cadence, next due, last delivered (date + "late" pill), status pill, portal toggle (PATCH `portalVisible`), row actions edit / deactivate.
+- `DeliverableForm({ fetcher, orgId, contractId?, initial?: Deliverable, onSaved, onCancel })` create/edit; `cadence` and `anchorDueDate` disabled in edit mode.
+- `OccurrenceDrawer({ fetcher, orgId, deliverable, onClose })` lists `listOccurrences` (24) with status, period, due, evidence chips; actions Deliver (note + optional report-run id picker fed by `GET /reports/runs?orgId=` if that endpoint exists, else a plain guid input), Waive (reason required), Reopen, Reschedule (date input), Remove evidence. Every action via `runAction`.
+
+- [ ] **Step 1: Write failing component tests** (Testing Library, mock `fetchWithAuth` as in `ContractDetail.documents.test.tsx`):
+  - table renders rows and status pills from a mocked list; deactivate calls `DELETE …/deliverables/:id` through `runAction` and shows the toast;
+  - drawer: Deliver with `artifactRequired` and no evidence surfaces the 400 `EVIDENCE_REQUIRED` message from the response (not a generic error); Waive disables Save until a reason is typed;
+  - `ContractDetail` renders the section under the documents section with the contract's `orgId` passed through.
+- [ ] **Step 2: Run** `cd apps/web && npx vitest run src/components/deliverables src/components/contracts/ContractDetail.deliverables.test.tsx` → FAIL.
+- [ ] **Step 3: Implement** the components with the repo's Tailwind + `rounded-lg border bg-card` conventions; `data-testid` on the section root (`contract-deliverables`), table (`deliverables-table`), drawer (`occurrence-drawer`) and each action button.
+- [ ] **Step 4: Run** the tests, then `npx vitest run src/lib/__tests__/no-silent-mutations.test.ts` and `npx astro check` (the web package has no `typecheck` script; `astro check` is what CI runs) → PASS.
+- [ ] **Step 5: Commit** `git commit -m "feat(web): deliverables table, form, occurrence drawer; contract section (W01)"`.
+
+---
+
+### Task 14: Org record Service tab and Key dates card
+
+**Files:**
+- Create: `apps/web/src/components/organizations/record/OrgServiceTab.tsx`, `OrgServiceTab.test.tsx`, `OrgKeyDatesCard.tsx`, `OrgKeyDatesCard.test.tsx`
+- Modify: `apps/web/src/components/organizations/record/orgRecordTabs.ts` (add `'service'` after `'billing'`, `TAB_PERMISSION.service = [{ resource: 'contracts', action: 'read' }]`)
+- Modify: `apps/web/src/components/organizations/record/OrganizationRecordPage.tsx:305` (add `{effectiveTab === 'service' && <OrgServiceTab orgId={orgId} orgFetch={orgFetch} />}`)
+- Modify: `apps/web/src/components/organizations/record/OrgOverviewTab.tsx:238` (add `<OrgKeyDatesCard orgId={orgId} orgFetch={orgFetch} />` as a third section in the two-column grid)
+- Modify: `apps/web/src/locales/*/organizations.json` (tab label `tabs.service`)
+
+**Interfaces:**
+- `OrgServiceTab({ orgId, orgFetch })`: `DeliverableTable` for the whole org (no `contractId`; rows grouped by `contractName`, standalone rows under a "No contract" group), an "Add deliverable" button opening `DeliverableForm` with an optional contract picker (`GET /contracts?orgId=`), and an "Upcoming 90 days" list built from each deliverable's `nextDue`.
+- `OrgKeyDatesCard({ orgId, orgFetch })`: list from `listKeyDates` (contract ends rendered read-only with a "contract" pill), add/edit inline form, delete with confirm; all via `runAction`.
+
+- [ ] **Step 1: Failing tests**: tab registry test (pin `ORG_RECORD_TABS` includes `'service'` in order and `TAB_PERMISSION.service` gates on `contracts:read`; extend the existing `orgRecordTabs.test.ts` if present); `OrgServiceTab` groups rows by contract; `OrgKeyDatesCard` renders contract-end rows without edit controls and creates a key date through `orgFetch` (assert the mocked `orgFetch` was called, not `fetchWithAuth`).
+- [ ] **Step 2: Run** `cd apps/web && npx vitest run src/components/organizations/record` → FAIL on the new files.
+- [ ] **Step 3: Implement.**
+- [ ] **Step 4: Run** the record tests, `src/lib/i18n`, `no-silent-mutations`, and the web typecheck → PASS.
+- [ ] **Step 5: Commit** `git commit -m "feat(web): org record Service tab and Key dates card (W01)"`.
+
+---
+
+### Task 15: Wave verification and PR
+
+- [ ] **Step 1: Full API unit run** `cd apps/api && npx vitest run` → green.
+- [ ] **Step 2: Integration contract suites** (test-stack up): the five suites from Task 4 Step 4 plus `serviceDeliverablesRls.integration.test.ts` and `apps/api/src/db/autoMigrate.test.ts` → green. Note the shard log shows the new suite's test count.
+- [ ] **Step 3: Web** `cd apps/web && npx vitest run` and typecheck → green. `pnpm lint` at the root → clean.
+- [ ] **Step 4: Manual smoke** on the worktree stack (`pnpm wt-stack up`): create a deliverable on a contract, open the drawer, deliver with a report run, reopen, waive; add a key date on the org record; confirm the org's Service tab lists the deliverable under the contract name.
+- [ ] **Step 5: Tear down** `pnpm test-stack down` and `pnpm wt-stack down`.
+- [ ] **Step 6: PR** with `Closes #<W01 sub-issue>`, the spec link, and a "Tenancy" section listing the four registrations and the RLS suite. Run `/pr-review-toolkit:review-pr`; act on confirmed findings only. Enqueue with `gh pr merge <N>` on green (never `--admin`).
+
+---
+
+## Self-review
+
+- Spec coverage for this wave: §4.1 (Task 1, 3), §4.2 + `delivered_via` amendment (Task 1, 3, 6), §4.3 without `document` FK (Task 1; W03 adds it), §4.5 (Task 2, 3, 9), §4.8 (Task 2, 3), §4.9 registrations (Task 4), §7 actions (Task 8, 10, 13), §9 contract section + org tabs + key dates card (Task 13, 14), §10 REST (Task 10), §12 error codes `EVIDENCE_REQUIRED`, `NOT_FOUND`-not-403, `DUPLICATE_NAME`, `INVALID_OCCURRENCE_TRANSITION` (Task 8, 10), §13 unit + route + integration (Tasks 5–11). Portal, sweep, subscriber, documents, templates and MCP tools are W02–W05 by design.
+- Placeholders: none; the W02 stubs are named exports that throw, so W02 replaces bodies without renaming.
+- Type consistency: `DeliverableActor`, `DeliverableServiceError`, `DeliverableSummary`, `OccurrenceView`, `KeyDateView`, `EvidenceRef`, `transition`, `planOccurrences` are spelled identically in Tasks 5–14.

--- a/docs/superpowers/plans/billing/2026-09-10-service-deliverables-w02-sweep-and-tickets.md
+++ b/docs/superpowers/plans/billing/2026-09-10-service-deliverables-w02-sweep-and-tickets.md
@@ -1,0 +1,2168 @@
+---
+tracking_issue: LanternOps/breeze#5573
+---
+# Service Deliverables W02: Sweep Worker, Ticket Integration, Key-Date Reminders, Auto-Evidence, MCP Tools — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the W01 tables move on their own — a daily BullMQ sweep that materializes occurrences, opens deliverable tickets, generates auto-evidence report runs, marks misses and fires key-date reminders; an event subscriber that turns a real ticket resolution into a delivery record; a contract-cancelled hook; a move-org guard; SLA suppression for planned work; and MCP tools for deliverables and key dates.
+
+**Architecture:** `jobs/deliverableWorker.ts` owns two BullMQ Workers created by one initializer — the `deliverable-jobs` queue (job `deliverable-sweep`, cron `18 5 * * *`) and the first-ever consumer of the previously-reserved `contract-events` queue. The sweep runs under `withSystemDbAccessContext`, one transaction per deliverable, and delegates every date decision to W01's pure `services/recurrence.ts` and every status decision to W01's pure `services/serviceDeliverableState.ts`. The four W01 stubs in `services/serviceDeliverableService.ts` get real bodies; nothing is renamed. A lazily-imported `deliverable-status` subscriber on `ticket.status_changed` closes the loop from the ticket side. Auto-evidence lives in its own module because it must reproduce the report scheduler's authority-reauthorization sequence.
+
+**Tech Stack:** BullMQ + Redis, PostgreSQL + Drizzle ORM, Hono (no new routes), Zod (`@breeze/shared`), Vitest (unit with Drizzle mocks; integration on real Postgres), Anthropic tool definitions + agent-SDK `tool()` for MCP.
+
+**Spec:** `docs/superpowers/specs/billing/2026-09-10-service-deliverables-portal-design.md` (approved 2026-09-10). Sections 5, 6, 7's D12 auto-evidence, 10's MCP tools for deliverables and key dates, 12's sweep error handling, 13's sweep integration list, and the W02 row of §14.
+
+**Prior wave (the naming contract):** `docs/superpowers/plans/billing/2026-09-10-service-deliverables-w01-schema-core.md`. Every symbol W01 declared is reused **verbatim**: `planOccurrences`, `coveredPeriod`, `isInLeadWindow`, `isPastGrace`, `transition`, `InvalidTransitionError`, `DeliverableServiceError`, `DeliverableActor`, `OccurrenceView`, `materializeOccurrences`, `openOccurrence`, `markOccurrenceMissed`, `applyTicketStatusChange`. Renaming any of them breaks W03–W05.
+
+## Global Constraints
+
+- **No migrations in this wave.** Every table and column W02 touches was created by W01 (`service_deliverables`, `service_deliverable_occurrences`, `service_deliverable_evidence`, `organization_key_dates`, `tickets.work_kind`, `report_runs_id_report_id_uniq`). Writing DDL means the wave has been mis-scoped — stop and re-read W01.
+- Background reads and writes run under `runOutsideDbContext(() => withSystemDbAccessContext(fn, '<label>'))` (`apps/api/src/db/index.ts:610`). **`withDbAccessContext` opens a real Postgres transaction** (`db/index.ts:525-575`), so one call is one transaction. "One transaction per deliverable" means one `withSystemDbAccessContext` call per deliverable, never one around the loop.
+- Always pass a `label`. Under the tsup single-file bundle an anonymous worker arrow collapses to a bare `index` frame and the #3218 held-connection warning arrives unattributable.
+- Fleet sweeps honour `buildAutomationEligibleOrgPredicate(column)` (`services/tenantStatus.ts:46`) — an archived tenant inside its purge countdown gets no tickets.
+- **"Today" is UTC**, computed as the billing sweep does: `asOf.toISOString().slice(0, 10)` (`jobs/contractWorker.ts:48`).
+- Date arithmetic only through `addMonthsClamped` / `addDaysISO` (`services/contractMath.ts:21`, `:62` — `addDaysISO` accepts negatives, verified at lines 62-70).
+- Per-deliverable failures are logged with ids, `captureException`d and skipped; one failure never aborts the sweep (`contractWorker.ts:105-110` is the shape).
+- Every `new Worker(...)` gets exactly one `attachWorkerObservability(worker, '<stableName>')`, and the attached-name set must equal the readiness manifest's declared consumers — `jobs/workerReadinessCoverage.test.ts:131-146` AST-scans both and diffs them.
+- Run one test file as `cd apps/api && npx vitest run <path>`. Never `pnpm … test -- --run <path>` (the `--` is forwarded literally; vitest runs all 1,470 files in watch mode).
+- Branch: `feature/<parent#>-service-deliverables/wave-<sub-issue#>`; PR body contains `Closes #<sub-issue#>`.
+
+---
+
+## File structure
+
+| Path | Responsibility |
+|---|---|
+| `apps/api/src/jobs/scheduleRegistry.ts` | new daily-tier slot `'deliverable-sweep': '18 5 * * *'` |
+| `apps/api/src/jobs/deliverableWorker.ts` (+ `.test.ts`) | `deliverable-jobs` queue/worker, `contract-events` consumer, `runDeliverableSweep` |
+| `apps/api/src/services/workerRegistry.ts` | lazy `deliverableWorker` entry, `placement: 'global'` |
+| `apps/api/src/jobs/workerReadinessManifest.ts` | `consumers('deliverableWorker', [...two names])` |
+| `apps/api/src/services/serviceDeliverableService.ts` (+ `.test.ts`) | replace the four W01 stub bodies; sweep-shaped siblings |
+| `apps/api/src/services/deliverableAutoEvidence.ts` (+ `.test.ts`) | D12 — reauthorized report run + evidence row + ticket note |
+| `apps/api/src/services/orgKeyDateService.ts` (+ `.test.ts`) | `sweepKeyDateReminders`, `rollForwardAnnualKeyDates` |
+| `apps/api/src/services/deliverableStatusSubscriber.ts` (+ `.test.ts`) | `ticket.status_changed` → occurrence transition |
+| `apps/api/src/services/eventSubscriberIds.ts`, `eventSubscribers.ts` | register `deliverable-status` (lazy handler) |
+| `apps/api/src/services/ticketService.ts` | `workKind` on create, SLA bypass, move-org guard |
+| `apps/api/src/jobs/ticketSlaWorker.ts` | exclude non-`support` work kinds from the breach sweep |
+| `apps/api/src/services/contractEvents.ts` | header correction: the bus is consumed now |
+| `apps/api/src/services/aiToolsDeliverables.ts` (+ `.test.ts`) | `list_deliverables`, `manage_deliverables`, `manage_key_dates` |
+| `apps/api/src/services/aiTools.ts`, `aiToolSchemas.ts`, `aiAgentSdkTools.ts`, `aiGuardrails.ts` | the four MCP registration sites |
+| `apps/api/src/__tests__/integration/deliverableSweep.integration.test.ts` | real-Postgres proof of the whole loop |
+
+---
+
+### Task 1: Cron slot, worker plumbing, eligibility select
+
+**Files:**
+- Modify: `apps/api/src/jobs/scheduleRegistry.ts:97` (daily tier, hour 5)
+- Create: `apps/api/src/jobs/deliverableWorker.ts`; Test: `apps/api/src/jobs/deliverableWorker.test.ts`
+- Modify: `apps/api/src/services/workerRegistry.ts:1139-1146`; `apps/api/src/jobs/workerReadinessManifest.ts:155`; `apps/api/src/services/contractEvents.ts:5-9`
+
+**Interfaces:**
+- Consumes: `jobSchedule` (`scheduleRegistry.ts:169`), `getBullMQConnection` (`services/redis`), `attachWorkerObservability` (`jobs/workerObservability.ts:204`), `buildAutomationEligibleOrgPredicate` (`services/tenantStatus.ts:46`), `db`/`runOutsideDbContext`/`withSystemDbAccessContext`.
+- Produces:
+
+```ts
+export interface DeliverableSweepResult { deliverables: number; materialized: number; opened: number; missed: number; autoEvidence: number; keyDateReminders: number; failed: number }
+export function getDeliverableQueue(): Queue;
+export function runDeliverableSweep(asOf?: Date): Promise<DeliverableSweepResult>;
+export function createDeliverableWorker(): Worker;
+export function createContractEventsWorker(): Worker;
+export function scheduleDeliverableJobs(): Promise<void>;
+export function initializeDeliverableWorkers(): Promise<void>;
+export function shutdownDeliverableWorkers(): Promise<void>;
+```
+
+- [ ] **Step 1: Allocate the cron slot**
+
+Daily tier is minutes ≡ 3 (mod 5). Hour 5 holds `8 5` (contract-billing-sweep), `38 5` (tdsynnex-sftp-sync), `58 5` (auth-browser-transition-cleanup); no sub-daily pattern fires on minute 18 (that lane is minutes 0, 7, 12, 15, 17, 22, 27, 32, 35, 37, 42, 47, 52, 57, plus `*/15` → 0/15/30/45). Insert in fire-time order after line 97:
+
+```ts
+  'contract-billing-sweep': '8 5 * * *',
+  // Service deliverables W02 (spec §5.1). Daily tier, minute ≡ 3 (mod 5).
+  // Ten minutes after the billing sweep so the two never hold the pool together.
+  'deliverable-sweep': '18 5 * * *',
+  'tdsynnex-sftp-sync': '38 5 * * *',
+```
+
+- [ ] **Step 2: Write the failing worker test**
+
+`apps/api/src/jobs/deliverableWorker.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { captureExceptionMock } = vi.hoisted(() => ({ captureExceptionMock: vi.fn() }));
+vi.mock('../services/sentry', () => ({ captureException: captureExceptionMock }));
+vi.mock('../services/redis', () => ({ getBullMQConnection: () => ({}) }));
+vi.mock('bullmq', () => ({ Queue: class {}, Worker: class {}, Job: class {} }));
+vi.mock('./workerObservability', () => ({ attachWorkerObservability: vi.fn() }));
+
+const { resultQueue, capturedWhere } = vi.hoisted(() => ({ resultQueue: [] as unknown[][], capturedWhere: [] as unknown[] }));
+vi.mock('../db', () => {
+  const chain: Record<string, unknown> = {};
+  for (const m of ['select', 'from', 'orderBy', 'limit', 'innerJoin', 'update', 'set', 'insert', 'values', 'returning']) chain[m] = vi.fn(() => chain);
+  chain.where = vi.fn((w: unknown) => { capturedWhere.push(w); return chain; });
+  (chain as { then: unknown }).then = (r: (v: unknown) => unknown) => Promise.resolve(resultQueue.shift() ?? []).then(r);
+  return { db: chain, runOutsideDbContext: (fn: () => unknown) => fn(), withSystemDbAccessContext: (fn: () => unknown) => fn() };
+});
+
+const { materializeMock, openMock, missMock, autoEvidenceMock, keyDateMock } = vi.hoisted(() => ({
+  materializeMock: vi.fn(async () => [] as unknown[]), openMock: vi.fn(async () => 0),
+  missMock: vi.fn(async () => 0), autoEvidenceMock: vi.fn(async () => 0), keyDateMock: vi.fn(async () => 0),
+}));
+vi.mock('../services/serviceDeliverableService', () => ({
+  materializeOccurrences: materializeMock,
+  openDueOccurrencesForDeliverable: openMock,
+  markDueOccurrencesMissedForDeliverable: missMock,
+  applyContractCancelledToDeliverables: vi.fn(),
+}));
+vi.mock('../services/deliverableAutoEvidence', () => ({ generateAutoEvidenceForDeliverable: autoEvidenceMock }));
+vi.mock('../services/orgKeyDateService', () => ({ sweepKeyDateReminders: keyDateMock }));
+
+import { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { runDeliverableSweep } from './deliverableWorker';
+
+const D = { id: 'd1', orgId: 'org1', name: 'Sign-in log review', cadence: 'monthly' as const,
+  anchorDueDate: '2026-10-31', effectiveFrom: '2026-10-01', effectiveUntil: null,
+  leadDays: 7, graceDays: 14, autoEvidenceReportId: null };
+const AS_OF = new Date('2026-10-25T05:18:00Z');
+
+describe('runDeliverableSweep', () => {
+  beforeEach(() => { vi.clearAllMocks(); resultQueue.length = 0; capturedWhere.length = 0; });
+
+  it('filters the eligible select on automation-eligible orgs and today', async () => {
+    resultQueue.push([]);
+    await runDeliverableSweep(AS_OF);
+    const text = new PgDialect().sqlToQuery(capturedWhere[0] as SQL).sql;
+    expect(text).toContain('automation_eligible_org');
+    expect(text).toContain("'2026-10-25'");
+  });
+
+  it('runs every step for each deliverable and totals the counts', async () => {
+    resultQueue.push([D]);
+    materializeMock.mockResolvedValueOnce([{ id: 'o1' }, { id: 'o2' }]);
+    openMock.mockResolvedValueOnce(2); missMock.mockResolvedValueOnce(1); keyDateMock.mockResolvedValueOnce(3);
+    expect(await runDeliverableSweep(AS_OF)).toEqual({ deliverables: 1, materialized: 2, opened: 2, missed: 1, autoEvidence: 0, keyDateReminders: 3, failed: 0 });
+    expect(autoEvidenceMock).not.toHaveBeenCalled();   // autoEvidenceReportId is null
+  });
+
+  it('runs auto-evidence only when a report is configured', async () => {
+    resultQueue.push([{ ...D, autoEvidenceReportId: 'r1' }]);
+    autoEvidenceMock.mockResolvedValueOnce(1);
+    const res = await runDeliverableSweep(AS_OF);
+    expect(autoEvidenceMock).toHaveBeenCalledWith({ ...D, autoEvidenceReportId: 'r1' }, '2026-10-25');
+    expect(res.autoEvidence).toBe(1);
+  });
+
+  it('one failing deliverable does not abort the sweep', async () => {
+    resultQueue.push([D, { ...D, id: 'd2' }]);
+    materializeMock.mockRejectedValueOnce(new Error('boom'));
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const res = await runDeliverableSweep(AS_OF);
+      expect(res.failed).toBe(1);
+      expect(res.deliverables).toBe(2);
+      expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+      expect(err).toHaveBeenCalledWith(expect.stringContaining('[DeliverableWorker]'), 'deliverableId=d1', 'orgId=org1', 'boom');
+    } finally { err.mockRestore(); }
+  });
+
+  it('still sweeps key dates when no deliverable is eligible', async () => {
+    resultQueue.push([]); keyDateMock.mockResolvedValueOnce(2);
+    expect((await runDeliverableSweep(AS_OF)).keyDateReminders).toBe(2);
+  });
+});
+```
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `cd apps/api && npx vitest run src/jobs/deliverableWorker.test.ts`
+Expected: FAIL — `Failed to resolve import "./deliverableWorker"`.
+
+- [ ] **Step 4: Write the worker**
+
+```ts
+/**
+ * Deliverable Worker
+ *
+ * Daily sweep (spec §5): for every active deliverable inside its effective
+ * window, materialize missing occurrences, open the due ones as tickets,
+ * generate auto-evidence, mark the ones past grace as missed; then key dates
+ * for the whole fleet. Same singleton shape as contractWorker.ts.
+ *
+ * Also owns the FIRST consumer of the `contract-events` queue (spec §5.4).
+ */
+import { Queue, Worker } from 'bullmq';
+import { and, eq, gte, isNull, lte, or } from 'drizzle-orm';
+import { getBullMQConnection } from '../services/redis';
+import { captureException } from '../services/sentry';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
+import { serviceDeliverables } from '../db/schema/serviceDeliverables';
+import { buildAutomationEligibleOrgPredicate } from '../services/tenantStatus';
+import {
+  materializeOccurrences, openDueOccurrencesForDeliverable,
+  markDueOccurrencesMissedForDeliverable, applyContractCancelledToDeliverables,
+  type SweepDeliverable,
+} from '../services/serviceDeliverableService';
+import { generateAutoEvidenceForDeliverable } from '../services/deliverableAutoEvidence';
+import { sweepKeyDateReminders } from '../services/orgKeyDateService';
+import { CONTRACT_EVENTS_QUEUE, type ContractEvent } from '../services/contractEvents';
+import { jobSchedule } from './scheduleRegistry';
+import { attachWorkerObservability } from './workerObservability';
+
+const DELIVERABLE_QUEUE = 'deliverable-jobs';
+const DELIVERABLE_SWEEP_CRON = jobSchedule('deliverable-sweep');
+
+let deliverableQueue: Queue | null = null;
+let deliverableWorker: Worker | null = null;
+let contractEventsWorker: Worker | null = null;
+
+export interface DeliverableSweepResult {
+  deliverables: number; materialized: number; opened: number;
+  missed: number; autoEvidence: number; keyDateReminders: number; failed: number;
+}
+
+export function getDeliverableQueue(): Queue {
+  if (!deliverableQueue) deliverableQueue = new Queue(DELIVERABLE_QUEUE, { connection: getBullMQConnection() });
+  return deliverableQueue;
+}
+
+/**
+ * Spec §5.2. Contract status is deliberately NOT consulted: generateDueInvoice
+ * flips a contract to `expired` the day after its final invoice
+ * (contractService.ts ~2013) while service runs on for months. The effective
+ * window is the authority.
+ */
+export async function runDeliverableSweep(asOf: Date = new Date()): Promise<DeliverableSweepResult> {
+  const today = asOf.toISOString().slice(0, 10);
+
+  const due = await runOutsideDbContext(() => withSystemDbAccessContext(() =>
+    db.select({
+        id: serviceDeliverables.id, orgId: serviceDeliverables.orgId, name: serviceDeliverables.name,
+        cadence: serviceDeliverables.cadence, anchorDueDate: serviceDeliverables.anchorDueDate,
+        effectiveFrom: serviceDeliverables.effectiveFrom, effectiveUntil: serviceDeliverables.effectiveUntil,
+        leadDays: serviceDeliverables.leadDays, graceDays: serviceDeliverables.graceDays,
+        autoEvidenceReportId: serviceDeliverables.autoEvidenceReportId,
+      })
+      .from(serviceDeliverables)
+      .where(and(
+        eq(serviceDeliverables.active, true),
+        lte(serviceDeliverables.effectiveFrom, today),
+        or(isNull(serviceDeliverables.effectiveUntil), gte(serviceDeliverables.effectiveUntil, today)),
+        buildAutomationEligibleOrgPredicate(serviceDeliverables.orgId)
+      )), 'deliverableSweep.selectDue'));
+
+  const res: DeliverableSweepResult = {
+    deliverables: due.length, materialized: 0, opened: 0, missed: 0,
+    autoEvidence: 0, keyDateReminders: 0, failed: 0,
+  };
+  // Spec §5.3 step 2: one warning per org per run, not per occurrence.
+  const serviceOffWarned = new Set<string>();
+
+  for (const d of due as SweepDeliverable[]) {
+    try {
+      res.materialized += (await materializeOccurrences(d.id, today)).length;
+      res.opened += await openDueOccurrencesForDeliverable(d, today, serviceOffWarned);
+      if (d.autoEvidenceReportId) res.autoEvidence += await generateAutoEvidenceForDeliverable(d, today);
+      res.missed += await markDueOccurrencesMissedForDeliverable(d, today);
+    } catch (err) {
+      res.failed++;
+      console.error('[DeliverableWorker] deliverable sweep failed', `deliverableId=${d.id}`, `orgId=${d.orgId}`,
+        err instanceof Error ? err.message : String(err));
+      captureException(err instanceof Error ? err : new Error(String(err)));
+      continue;
+    }
+  }
+
+  // Fleet-wide, not per deliverable: a key date needs no deliverable at all.
+  try {
+    res.keyDateReminders = await sweepKeyDateReminders(today);
+  } catch (err) {
+    res.failed++;
+    console.error('[DeliverableWorker] key-date sweep failed', err instanceof Error ? err.message : String(err));
+    captureException(err instanceof Error ? err : new Error(String(err)));
+  }
+  return res;
+}
+
+export function createDeliverableWorker(): Worker {
+  return new Worker(DELIVERABLE_QUEUE, async (job) => {
+    if (job.name === 'deliverable-sweep') return runDeliverableSweep();
+    throw new Error(`Unknown deliverable job: ${job.name}`);
+  }, { connection: getBullMQConnection(), concurrency: 1 });
+}
+
+/**
+ * Spec §5.4. `contract-events` was a reserved, unconsumed bus until now, so the
+ * first deploy drains whatever sits in `wait`. That replay is safe by
+ * construction: applyContractCancelledToDeliverables re-reads the contract and
+ * applies nothing unless it is STILL cancelled, and only touches deliverables
+ * whose effective_until is NULL.
+ */
+export function createContractEventsWorker(): Worker {
+  return new Worker(CONTRACT_EVENTS_QUEUE, async (job) => {
+    const event = job.data as ContractEvent;
+    if (event.type !== 'contract.cancelled') return;
+    await applyContractCancelledToDeliverables(event.contractId, new Date().toISOString().slice(0, 10));
+  }, { connection: getBullMQConnection(), concurrency: 1 });
+}
+
+export async function scheduleDeliverableJobs(): Promise<void> {
+  const queue = getDeliverableQueue();
+  for (const job of await queue.getRepeatableJobs()) await queue.removeRepeatableByKey(job.key);
+  await queue.add('deliverable-sweep', { type: 'deliverable-sweep' },
+    { repeat: { pattern: DELIVERABLE_SWEEP_CRON }, removeOnComplete: { count: 10 }, removeOnFail: { count: 50 } });
+  console.log('[DeliverableWorker] Scheduled daily deliverable sweep');
+}
+
+export async function initializeDeliverableWorkers(): Promise<void> {
+  try {
+    deliverableWorker = createDeliverableWorker();
+    attachWorkerObservability(deliverableWorker, 'deliverableWorker');
+    deliverableWorker.on('error', (e) => { console.error('[DeliverableWorker] Worker error:', e); captureException(e); });
+    deliverableWorker.on('failed', (job, e) => { console.error(`[DeliverableWorker] Job ${job?.id} failed:`, e); captureException(e); });
+
+    contractEventsWorker = createContractEventsWorker();
+    attachWorkerObservability(contractEventsWorker, 'deliverableContractEventsWorker');
+    contractEventsWorker.on('error', (e) => { console.error('[DeliverableWorker] contract-events worker error:', e); captureException(e); });
+
+    await scheduleDeliverableJobs();
+    console.log('[DeliverableWorker] Deliverable workers initialized');
+  } catch (error) {
+    console.error('[DeliverableWorker] Failed to initialize:', error);
+    throw error;
+  }
+}
+
+export async function shutdownDeliverableWorkers(): Promise<void> {
+  if (deliverableWorker) { await deliverableWorker.close(); deliverableWorker = null; }
+  if (contractEventsWorker) { await contractEventsWorker.close(); contractEventsWorker = null; }
+  if (deliverableQueue) { await deliverableQueue.close(); deliverableQueue = null; }
+  console.log('[DeliverableWorker] Deliverable workers shut down');
+}
+```
+
+The five service functions this imports do not exist yet. Add them now as exported stubs that `throw new Error('not implemented')` in `serviceDeliverableService.ts`, `deliverableAutoEvidence.ts` and `orgKeyDateService.ts` (the unit test mocks them all); Tasks 2–7 replace the bodies, never the names. `SweepDeliverable` is declared in Task 2.
+
+- [ ] **Step 5: Wire startup**
+
+`apps/api/src/services/workerRegistry.ts`, directly after the `contractWorker` entry (lines 1139-1146):
+
+```ts
+  {
+    // Service deliverables W02 (spec §5.1). Two Workers, one initializer.
+    // 'global' because workerEntrypointClosure.contract.test.ts says so — if it
+    // reports the closure reaching routes/agentWs.ts, flip to 'socket-owner',
+    // never loosen the test.
+    name: 'deliverableWorker',
+    placement: 'global',
+    load: async () => {
+      const m = await import('../jobs/deliverableWorker');
+      return { init: m.initializeDeliverableWorkers, shutdown: m.shutdownDeliverableWorkers };
+    },
+  },
+```
+
+`apps/api/src/jobs/workerReadinessManifest.ts`, directly after `consumers('contractWorker'),` (line 155):
+
+```ts
+  // ONE initializer constructing TWO Workers, so both stable names are declared.
+  // They must match the attachWorkerObservability strings character for
+  // character — workerReadinessCoverage.test.ts diffs the two sets.
+  consumers('deliverableWorker', ['deliverableWorker', 'deliverableContractEventsWorker']),
+```
+
+- [ ] **Step 6: Correct the now-stale `contract-events` header**
+
+Replace `apps/api/src/services/contractEvents.ts:5-9` with:
+
+```ts
+// `contract-events` carries contract lifecycle events. Consumed since the
+// service-deliverables wave (jobs/deliverableWorker.ts's contract-events
+// Worker), which acts on `contract.cancelled` and ignores every other type.
+// Delivery is still best-effort: emitContractEvent never throws, so a Redis
+// hiccup during a cancel drops the event and the MSP closes the deliverable's
+// effective window by hand.
+```
+
+- [ ] **Step 7: Run the unit test and the contract suites**
+
+Run: `cd apps/api && npx vitest run src/jobs/deliverableWorker.test.ts src/jobs/scheduleRegistry.contract.test.ts src/services/workerEntrypointClosure.contract.test.ts src/jobs/workerReadinessCoverage.test.ts src/jobs/workerReadinessManifest.test.ts`
+Expected: all PASS. `scheduleRegistry.contract.test.ts` fails on a slot collision; `workerReadinessCoverage.test.ts` fails if an attach name differs from the manifest.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/api/src/jobs/scheduleRegistry.ts apps/api/src/jobs/deliverableWorker.ts apps/api/src/jobs/deliverableWorker.test.ts apps/api/src/services/workerRegistry.ts apps/api/src/jobs/workerReadinessManifest.ts apps/api/src/services/contractEvents.ts
+git commit -m "feat(deliverables): deliverable sweep worker plumbing and cron slot (W02)"
+```
+
+---
+
+### Task 2: `materializeOccurrences` and the miss step
+
+**Files:**
+- Modify: `apps/api/src/services/serviceDeliverableService.ts` (replace the `materializeOccurrences` / `markOccurrenceMissed` stubs)
+- Test: `apps/api/src/services/serviceDeliverableService.test.ts` (append)
+
+**Interfaces:**
+- Consumes: `planOccurrences` (`services/recurrence.ts`, W01 Task 5); `serviceDeliverables`, `serviceDeliverableOccurrences` (W01 Task 3).
+- Produces:
+
+```ts
+export interface SweepDeliverable {
+  id: string; orgId: string; name: string;
+  cadence: 'monthly' | 'quarterly' | 'semiannual' | 'annual' | 'one_time';
+  anchorDueDate: string; effectiveFrom: string; effectiveUntil: string | null;
+  leadDays: number; graceDays: number; autoEvidenceReportId: string | null;
+}
+export function materializeOccurrences(deliverableId: string, today: string): Promise<ServiceDeliverableOccurrenceRow[]>;  // W01 signature
+export function markOccurrenceMissed(occurrenceId: string): Promise<void>;                                                // W01 signature
+export function markDueOccurrencesMissedForDeliverable(d: SweepDeliverable, today: string): Promise<number>;
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `serviceDeliverableService.test.ts`, reusing the `dbMocks` harness W01 Task 8 established (extend it so `values()` pushes into `dbMocks.inserted` and `set()` into `dbMocks.updated` if it does not already):
+
+```ts
+const DEF = { id: 'd1', orgId: 'org1', name: 'Sign-in log review', cadence: 'monthly',
+  effectiveFrom: '2026-10-01', effectiveUntil: null, leadDays: 7, graceDays: 14 };
+
+describe('materializeOccurrences (spec §5.3 step 1)', () => {
+  beforeEach(() => { dbMocks.rows.length = 0; dbMocks.inserted.length = 0; });
+
+  it('inserts one row per planned due date with the name snapshot', async () => {
+    dbMocks.rows.push([{ ...DEF, anchorDueDate: '2026-10-31' }]);
+    dbMocks.rows.push([]);                      // existing due dates: none
+    dbMocks.rows.push([{ id: 'o1' }]);          // insert ... returning
+    expect(await materializeOccurrences('d1', '2026-10-25')).toHaveLength(1);
+    expect((dbMocks.inserted.at(-1) as Array<Record<string, unknown>>)[0]).toMatchObject({
+      orgId: 'org1', deliverableId: 'd1', nameSnapshot: 'Sign-in log review',
+      periodStart: '2026-10-01', periodEnd: '2026-10-31',
+      dueAt: '2026-10-31', originalDueAt: '2026-10-31', status: 'scheduled',
+    });
+  });
+
+  it('inserts catch-up occurrences past grace directly as missed, capped at 12', async () => {
+    dbMocks.rows.push([{ ...DEF, anchorDueDate: '2026-01-31', effectiveFrom: '2026-01-01' }]);
+    dbMocks.rows.push([]);
+    dbMocks.rows.push([{ id: 'o1' }]);
+    await materializeOccurrences('d1', '2026-10-25');
+    const values = dbMocks.inserted.at(-1) as Array<Record<string, unknown>>;
+    expect(values.length).toBeLessThanOrEqual(12);
+    expect(values[0]).toMatchObject({ dueAt: '2026-01-31', status: 'missed' });
+    expect(values.at(-1)).toMatchObject({ status: 'scheduled' });
+  });
+
+  it('is a no-op when every due date is already materialized', async () => {
+    dbMocks.rows.push([{ ...DEF, anchorDueDate: '2026-10-31' }]);
+    dbMocks.rows.push([{ dueAt: '2026-10-31' }]);
+    expect(await materializeOccurrences('d1', '2026-10-25')).toEqual([]);
+    expect(dbMocks.inserted).toHaveLength(0);
+  });
+
+  it('throws NOT_FOUND for a deliverable that no longer exists', async () => {
+    dbMocks.rows.push([]);
+    await expect(materializeOccurrences('gone', '2026-10-25')).rejects.toMatchObject({ status: 404, code: 'NOT_FOUND' });
+  });
+});
+
+describe('markDueOccurrencesMissedForDeliverable (spec §5.3 step 4)', () => {
+  it('moves rows past grace to missed and never touches the ticket', async () => {
+    dbMocks.rows.length = 0; dbMocks.rows.push([{ id: 'o1' }, { id: 'o2' }]);
+    const n = await markDueOccurrencesMissedForDeliverable(
+      { ...DEF, cadence: 'monthly', anchorDueDate: '2026-01-31', autoEvidenceReportId: null } as never, '2026-10-25');
+    expect(n).toBe(2);
+    const patch = dbMocks.updated.at(-1) as Record<string, unknown>;
+    expect(patch).toMatchObject({ status: 'missed' });
+    expect(patch).not.toHaveProperty('ticketId');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/api && npx vitest run src/services/serviceDeliverableService.test.ts`
+Expected: FAIL — `not implemented (W02)` from the W01 stubs.
+
+- [ ] **Step 3: Implement**
+
+```ts
+export interface SweepDeliverable {
+  id: string; orgId: string; name: string; cadence: Cadence;
+  anchorDueDate: string; effectiveFrom: string; effectiveUntil: string | null;
+  leadDays: number; graceDays: number; autoEvidenceReportId: string | null;
+}
+
+/** Spec §5.3 step 1. System caller — run inside withSystemDbAccessContext. */
+export async function materializeOccurrences(
+  deliverableId: string, today: string
+): Promise<ServiceDeliverableOccurrenceRow[]> {
+  const [d] = await db
+    .select({
+      id: serviceDeliverables.id, orgId: serviceDeliverables.orgId, name: serviceDeliverables.name,
+      cadence: serviceDeliverables.cadence, anchorDueDate: serviceDeliverables.anchorDueDate,
+      effectiveFrom: serviceDeliverables.effectiveFrom, effectiveUntil: serviceDeliverables.effectiveUntil,
+      leadDays: serviceDeliverables.leadDays, graceDays: serviceDeliverables.graceDays,
+    })
+    .from(serviceDeliverables).where(eq(serviceDeliverables.id, deliverableId)).limit(1);
+  if (!d) throw new DeliverableServiceError('Not found', 404, 'NOT_FOUND');
+
+  const existing = await db
+    .select({ dueAt: serviceDeliverableOccurrences.dueAt })
+    .from(serviceDeliverableOccurrences)
+    .where(eq(serviceDeliverableOccurrences.deliverableId, deliverableId));
+
+  const plan = planOccurrences({
+    anchorDueDate: d.anchorDueDate, cadence: d.cadence as Cadence,
+    effectiveFrom: d.effectiveFrom, effectiveUntil: d.effectiveUntil,
+    leadDays: d.leadDays, graceDays: d.graceDays, today,
+    existingDueDates: existing.map((e) => e.dueAt),
+  });
+  if (plan.length === 0) return [];
+
+  return db.insert(serviceDeliverableOccurrences)
+    .values(plan.map((p) => ({
+      orgId: d.orgId, deliverableId: d.id,
+      // Spec §4.2: the name at materialization. A later rename never rewrites history.
+      nameSnapshot: d.name,
+      periodStart: p.periodStart, periodEnd: p.periodEnd,
+      dueAt: p.dueAt, originalDueAt: p.dueAt, status: p.initialStatus,
+    })))
+    // UNIQUE (deliverable_id, period_start) is the claim; a concurrent sweep
+    // loses silently rather than raising 23505 and failing the deliverable.
+    .onConflictDoNothing({ target: [serviceDeliverableOccurrences.deliverableId, serviceDeliverableOccurrences.periodStart] })
+    .returning();
+}
+
+/** Spec §5.3 step 4, single-row form. Kept because W03/W05 call it directly. */
+export async function markOccurrenceMissed(occurrenceId: string): Promise<void> {
+  await db.update(serviceDeliverableOccurrences)
+    .set({ status: 'missed', updatedAt: new Date() })
+    .where(and(eq(serviceDeliverableOccurrences.id, occurrenceId),
+      inArray(serviceDeliverableOccurrences.status, ['open', 'awaiting_evidence'])));
+}
+
+/**
+ * Spec §5.3 step 4, sweep form. The ticket is deliberately untouched: a missed
+ * deliverable's work may still be in flight, and closing its ticket would
+ * destroy that signal.
+ */
+export async function markDueOccurrencesMissedForDeliverable(d: SweepDeliverable, today: string): Promise<number> {
+  const cutoff = addDaysISO(today, -d.graceDays);   // dueAt < cutoff ⇔ dueAt + grace < today
+  const rows = await db.update(serviceDeliverableOccurrences)
+    .set({ status: 'missed', updatedAt: new Date() })
+    .where(and(
+      eq(serviceDeliverableOccurrences.deliverableId, d.id),
+      inArray(serviceDeliverableOccurrences.status, ['open', 'awaiting_evidence']),
+      lt(serviceDeliverableOccurrences.dueAt, cutoff)
+    ))
+    .returning({ id: serviceDeliverableOccurrences.id });
+  return rows.length;
+}
+```
+
+Add `lt`, `inArray` to the drizzle import, `addDaysISO` to `./contractMath`, and `planOccurrences`, `type Cadence` to `./recurrence`.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd apps/api && npx vitest run src/services/serviceDeliverableService.test.ts src/services/recurrence.test.ts && npx tsc --noEmit`
+Expected: PASS; no type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/serviceDeliverableService.ts apps/api/src/services/serviceDeliverableService.test.ts
+git commit -m "feat(deliverables): materialize occurrences and mark misses in the sweep (W02)"
+```
+
+---
+
+### Task 3: Open due occurrences as deliverable tickets, with SLA suppressed
+
+**Files:**
+- Modify: `apps/api/src/services/ticketService.ts` (`BaseCreateTicketInput` at 460-481; SLA resolution and insert at 661-703)
+- Modify: `apps/api/src/jobs/ticketSlaWorker.ts:70-84` (the `due` CTE)
+- Modify: `apps/api/src/services/serviceDeliverableService.ts` (replace the `openOccurrence` stub; add the sweep form)
+- Test: `apps/api/src/services/ticketService.workKind.test.ts` (new); `serviceDeliverableService.test.ts` (append)
+
+**Interfaces:**
+- Consumes: `createTicket` (`ticketService.ts:498`), `TicketServiceError` (`:64`), `isInLeadWindow` (`recurrence.ts`).
+- Produces:
+
+```ts
+interface BaseCreateTicketInput { /* …existing… */ workKind?: 'support' | 'deliverable' | 'project_task' }
+export function resolveSlaTargetsForWorkKind(workKind: 'support'|'deliverable'|'project_task', targets: { responseMinutes: number|null; resolutionMinutes: number|null }): { responseMinutes: number|null; resolutionMinutes: number|null };
+export function openOccurrence(occurrenceId: string, ticketId: string | null): Promise<void>;   // W01 signature
+export function periodLabel(cadence: Cadence, periodEnd: string): string;
+export function openDueOccurrencesForDeliverable(d: SweepDeliverable, today: string, serviceOffWarned: Set<string>): Promise<number>;
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+`apps/api/src/services/ticketService.workKind.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { resolveSlaTargetsForWorkKind } from './ticketService';
+
+describe('SLA defaults by work kind (spec §4.8, D3)', () => {
+  const targets = { responseMinutes: 60, resolutionMinutes: 480 };
+  it('keeps the resolved SLA for support work', () => {
+    expect(resolveSlaTargetsForWorkKind('support', targets)).toEqual(targets);
+  });
+  it('drops BOTH SLA minutes for deliverable work', () => {
+    // The SLA worker clocks from created_at, so a 7-day-lead deliverable ticket
+    // would breach before the work was due.
+    expect(resolveSlaTargetsForWorkKind('deliverable', targets)).toEqual({ responseMinutes: null, resolutionMinutes: null });
+  });
+  it('drops both for the reserved project_task kind too', () => {
+    expect(resolveSlaTargetsForWorkKind('project_task', targets)).toEqual({ responseMinutes: null, resolutionMinutes: null });
+  });
+});
+```
+
+Append to `serviceDeliverableService.test.ts` (add `createTicketMock` to the file's `vi.hoisted` block and `vi.mock('./ticketService', () => ({ createTicket: createTicketMock }))`):
+
+```ts
+const SD = { id: 'd1', orgId: 'org1', name: 'Sign-in log review', cadence: 'monthly' as const,
+  anchorDueDate: '2026-10-31', effectiveFrom: '2026-10-01', effectiveUntil: null,
+  leadDays: 7, graceDays: 14, autoEvidenceReportId: null };
+const OCC = { id: 'o1', nameSnapshot: 'Sign-in log review', periodStart: '2026-10-01', periodEnd: '2026-10-31', dueAt: '2026-10-31' };
+/** candidates, claim, config, partner pre-resolve */
+const seedOpen = (claim: unknown[], cfg: Record<string, unknown>, ok: Record<string, boolean>) => {
+  dbMocks.rows.push([OCC], claim, [cfg], [ok]);
+};
+
+describe('openDueOccurrencesForDeliverable (spec §5.3 step 2)', () => {
+  beforeEach(() => { dbMocks.rows.length = 0; dbMocks.updated.length = 0; createTicketMock.mockReset(); });
+
+  it('creates an SLA-free deliverable ticket and links it to the claimed occurrence', async () => {
+    seedOpen([{ id: 'o1' }], { ownerUserId: 'u1', ticketCategoryId: 'c1', description: 'Review sign-in logs' }, { ownerOk: true, categoryOk: true });
+    createTicketMock.mockResolvedValue({ id: 't1' });
+    expect(await openDueOccurrencesForDeliverable(SD, '2026-10-25', new Set())).toBe(1);
+    expect(createTicketMock).toHaveBeenCalledWith(expect.objectContaining({
+      orgId: 'org1', source: 'api', workKind: 'deliverable',
+      subject: 'Sign-in log review — Oct 2026',
+      dueDate: new Date('2026-10-31T00:00:00.000Z'), assigneeId: 'u1', categoryId: 'c1',
+    }), expect.objectContaining({ userId: expect.any(String) }));
+    expect(dbMocks.updated.at(-1)).toMatchObject({ ticketId: 't1' });
+  });
+
+  it('leaves the occurrence open with a null ticket when Service Management is off, warning once per org', async () => {
+    seedOpen([{ id: 'o1' }], { ownerUserId: null, ticketCategoryId: null, description: null }, { ownerOk: true, categoryOk: true });
+    createTicketMock.mockRejectedValue(Object.assign(new Error('off'), { code: 'service_management_off' }));
+    const warned = new Set<string>();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      expect(await openDueOccurrencesForDeliverable(SD, '2026-10-25', warned)).toBe(1);  // the occurrence IS open
+      expect(dbMocks.updated.at(-1)).not.toHaveProperty('ticketId');
+      expect(warn).toHaveBeenCalledTimes(1);
+      seedOpen([{ id: 'o1' }], { ownerUserId: null, ticketCategoryId: null, description: null }, { ownerOk: true, categoryOk: true });
+      await openDueOccurrencesForDeliverable(SD, '2026-10-25', warned);
+      expect(warn).toHaveBeenCalledTimes(1);                                             // once per org per run
+    } finally { warn.mockRestore(); }
+  });
+
+  it('rethrows any other ticket failure so the claim rolls back and retries tomorrow', async () => {
+    seedOpen([{ id: 'o1' }], { ownerUserId: null, ticketCategoryId: null, description: null }, { ownerOk: true, categoryOk: true });
+    createTicketMock.mockRejectedValue(new Error('connection reset'));
+    await expect(openDueOccurrencesForDeliverable(SD, '2026-10-25', new Set())).rejects.toThrow('connection reset');
+  });
+
+  it('drops an owner or category no longer in the org partner instead of stalling forever', async () => {
+    seedOpen([{ id: 'o1' }], { ownerUserId: 'u-gone', ticketCategoryId: 'c-gone', description: null }, { ownerOk: false, categoryOk: false });
+    createTicketMock.mockResolvedValue({ id: 't1' });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      await openDueOccurrencesForDeliverable(SD, '2026-10-25', new Set());
+      const input = createTicketMock.mock.calls[0]![0] as Record<string, unknown>;
+      expect(input.assigneeId).toBeUndefined();
+      expect(input.categoryId).toBeUndefined();
+    } finally { warn.mockRestore(); }
+  });
+
+  it('skips an occurrence another sweep already claimed', async () => {
+    dbMocks.rows.push([OCC], []);                          // claim returned 0 rows
+    expect(await openDueOccurrencesForDeliverable(SD, '2026-10-25', new Set())).toBe(0);
+    expect(createTicketMock).not.toHaveBeenCalled();
+  });
+
+  it('never opens an occurrence outside its lead window', async () => {
+    dbMocks.rows.push([{ ...OCC, dueAt: '2026-12-31' }]);
+    expect(await openDueOccurrencesForDeliverable(SD, '2026-10-25', new Set())).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/api && npx vitest run src/services/ticketService.workKind.test.ts src/services/serviceDeliverableService.test.ts`
+Expected: FAIL — `resolveSlaTargetsForWorkKind` and `openDueOccurrencesForDeliverable` are not exported.
+
+- [ ] **Step 3: Add `workKind` and the SLA bypass to `createTicket`**
+
+In `BaseCreateTicketInput`, after `formResponses?` (line 480):
+
+```ts
+  /**
+   * Spec §4.8 (D3/D14). Planned work is typed, not tagged. Defaults to
+   * 'support'; only the deliverable sweep and the key-date reminder set
+   * anything else today. Non-'support' gets NO SLA — see below.
+   */
+  workKind?: 'support' | 'deliverable' | 'project_task';
+```
+
+Above `createTicket`:
+
+```ts
+/**
+ * Planned work carries no SLA. The SLA worker clocks from `created_at`
+ * (jobs/ticketSlaWorker.ts:79), so a deliverable ticket opened `lead_days`
+ * before its due date would breach before the work was due. This is the SINGLE
+ * place category/org/partner defaults are dropped; the worker's own
+ * `work_kind = 'support'` predicate is defence in depth for older rows.
+ */
+export function resolveSlaTargetsForWorkKind(
+  workKind: 'support' | 'deliverable' | 'project_task',
+  targets: { responseMinutes: number | null; resolutionMinutes: number | null }
+): { responseMinutes: number | null; resolutionMinutes: number | null } {
+  return workKind === 'support' ? targets : { responseMinutes: null, resolutionMinutes: null };
+}
+```
+
+Immediately after the `resolveSlaTargets({...})` call (lines 667-675):
+
+```ts
+  const workKind = input.workKind ?? 'support';
+  const effectiveSla = resolveSlaTargetsForWorkKind(workKind, slaTargets);
+```
+
+and in `insertValues` replace lines 699-700 and add the column:
+
+```ts
+    responseSlaMinutes: effectiveSla.responseMinutes,
+    resolutionSlaMinutes: effectiveSla.resolutionMinutes,
+    workKind,
+```
+
+- [ ] **Step 4: Suppress SLA breaches for non-support work**
+
+In `apps/api/src/jobs/ticketSlaWorker.ts`, add one predicate to the `due` CTE between lines 74 and 75:
+
+```sql
+      WHERE status IN ('new', 'open')
+        -- Spec §4.8: planned work has a due date, not an SLA. Rows written
+        -- before tickets.work_kind shipped default to 'support', so this
+        -- narrows nothing that used to be swept.
+        AND work_kind = 'support'
+        AND sla_paused_at IS NULL
+```
+
+- [ ] **Step 5: Implement the open step**
+
+```ts
+/** Spec §5.3 step 2, single-row form. System caller. */
+export async function openOccurrence(occurrenceId: string, ticketId: string | null): Promise<void> {
+  await db.update(serviceDeliverableOccurrences)
+    .set({ status: 'open', ...(ticketId ? { ticketId } : {}), updatedAt: new Date() })
+    .where(and(eq(serviceDeliverableOccurrences.id, occurrenceId), eq(serviceDeliverableOccurrences.status, 'scheduled')));
+}
+
+/** "Oct 2026" | "Q4 2026" | "H2 2026" | "2026" — the period label in the subject. */
+export function periodLabel(cadence: Cadence, periodEnd: string): string {
+  const [y, m] = periodEnd.split('-').map(Number) as [number, number];
+  const MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+  if (cadence === 'annual') return String(y);
+  if (cadence === 'semiannual') return `H${m <= 6 ? 1 : 2} ${y}`;
+  if (cadence === 'quarterly') return `Q${Math.ceil(m / 3)} ${y}`;
+  return `${MONTHS[m - 1]} ${y}`;                          // monthly and one_time
+}
+
+/**
+ * Synthetic actor: only ever written to audit_logs.actor_id, which is NOT NULL
+ * with no FK to users (precedent: inboundEmailService.ts:31). createTicket
+ * writes no `tickets` column from actor.userId.
+ */
+const DELIVERABLE_SWEEP_ACTOR = { userId: '00000000-0000-0000-0000-000000000000', name: 'Service deliverables' } as const;
+
+/**
+ * Spec §5.3 step 2. One transaction per occurrence: the claim UPDATE and the
+ * ticket creation commit or roll back together, so a crash between them cannot
+ * strand an `open` occurrence with no ticket and no retry.
+ */
+export async function openDueOccurrencesForDeliverable(
+  d: SweepDeliverable, today: string, serviceOffWarned: Set<string>
+): Promise<number> {
+  const candidates = await runOutsideDbContext(() => withSystemDbAccessContext(() =>
+    db.select({
+        id: serviceDeliverableOccurrences.id, nameSnapshot: serviceDeliverableOccurrences.nameSnapshot,
+        periodStart: serviceDeliverableOccurrences.periodStart, periodEnd: serviceDeliverableOccurrences.periodEnd,
+        dueAt: serviceDeliverableOccurrences.dueAt,
+      })
+      .from(serviceDeliverableOccurrences)
+      .where(and(eq(serviceDeliverableOccurrences.deliverableId, d.id), eq(serviceDeliverableOccurrences.status, 'scheduled'))),
+    'deliverableSweep.selectScheduled'));
+
+  let opened = 0;
+  for (const occ of candidates) {
+    if (!isInLeadWindow(occ.dueAt, d.leadDays, today)) continue;
+    opened += await runOutsideDbContext(() => withSystemDbAccessContext(
+      () => openOneOccurrence(d, occ, serviceOffWarned), 'deliverableSweep.openOccurrence'));
+  }
+  return opened;
+}
+
+async function openOneOccurrence(
+  d: SweepDeliverable,
+  occ: { id: string; nameSnapshot: string; periodStart: string; periodEnd: string; dueAt: string },
+  serviceOffWarned: Set<string>
+): Promise<number> {
+  // Claim first: 0 rows means a concurrent sweep won and already has the ticket.
+  const claimed = await db.update(serviceDeliverableOccurrences)
+    .set({ status: 'open', updatedAt: new Date() })
+    .where(and(eq(serviceDeliverableOccurrences.id, occ.id), eq(serviceDeliverableOccurrences.status, 'scheduled')))
+    .returning({ id: serviceDeliverableOccurrences.id });
+  if (claimed.length === 0) return 0;
+
+  const [cfg] = await db.select({
+      ownerUserId: serviceDeliverables.ownerUserId,
+      ticketCategoryId: serviceDeliverables.ticketCategoryId,
+      description: serviceDeliverables.description,
+    }).from(serviceDeliverables).where(eq(serviceDeliverables.id, d.id)).limit(1);
+
+  const { ownerUserId, ticketCategoryId } =
+    await resolveTicketTargets(d.orgId, cfg?.ownerUserId ?? null, cfg?.ticketCategoryId ?? null);
+
+  let ticketId: string | null = null;
+  try {
+    const ticket = await createTicket({
+      orgId: d.orgId, source: 'api', workKind: 'deliverable',
+      subject: `${occ.nameSnapshot} — ${periodLabel(d.cadence, occ.periodEnd)}`,
+      description: cfg?.description ?? undefined,
+      dueDate: new Date(`${occ.dueAt}T00:00:00.000Z`),
+      assigneeId: ownerUserId ?? undefined,
+      categoryId: ticketCategoryId ?? undefined,
+    }, DELIVERABLE_SWEEP_ACTOR);
+    ticketId = ticket.id;
+  } catch (err) {
+    // Spec §5.3 step 2: an `off` partner still gets the occurrence, fulfilled by
+    // hand. Anything else rolls this transaction back — the claim is released
+    // and the occurrence retries on the next run rather than being stranded.
+    if ((err as { code?: string }).code !== 'service_management_off') throw err;
+    if (!serviceOffWarned.has(d.orgId)) {
+      serviceOffWarned.add(d.orgId);
+      console.warn('[deliverables] Service Management is off for this partner — occurrences opened without tickets',
+        `orgId=${d.orgId}`, `deliverableId=${d.id}`);
+    }
+    return 1;
+  }
+
+  await db.update(serviceDeliverableOccurrences)
+    .set({ ticketId, updatedAt: new Date() })
+    .where(eq(serviceDeliverableOccurrences.id, occ.id));
+  return 1;
+}
+
+/**
+ * An owner who left the partner, or a category deleted since, would make
+ * createTicket throw ASSIGNEE_WRONG_PARTNER / CATEGORY_NOT_FOUND on every run
+ * and stall this deliverable permanently and silently. Pre-resolve both against
+ * the org's partner and drop whichever no longer holds, loudly.
+ */
+async function resolveTicketTargets(
+  orgId: string, ownerUserId: string | null, ticketCategoryId: string | null
+): Promise<{ ownerUserId: string | null; ticketCategoryId: string | null }> {
+  if (!ownerUserId && !ticketCategoryId) return { ownerUserId: null, ticketCategoryId: null };
+  const [row] = await db.select({
+      ownerOk: sql<boolean>`EXISTS (SELECT 1 FROM ${users} u JOIN ${organizations} o ON o.partner_id = u.partner_id
+        WHERE u.id = ${ownerUserId}::uuid AND o.id = ${orgId}::uuid)`,
+      categoryOk: sql<boolean>`EXISTS (SELECT 1 FROM ${ticketCategories} tc JOIN ${organizations} o ON o.partner_id = tc.partner_id
+        WHERE tc.id = ${ticketCategoryId}::uuid AND o.id = ${orgId}::uuid)`,
+    }).from(organizations).where(eq(organizations.id, orgId)).limit(1);
+  const okOwner = ownerUserId !== null && row?.ownerOk === true;
+  const okCategory = ticketCategoryId !== null && row?.categoryOk === true;
+  if (ownerUserId && !okOwner) console.warn('[deliverables] dropping owner no longer in the org partner', `orgId=${orgId}`, `userId=${ownerUserId}`);
+  if (ticketCategoryId && !okCategory) console.warn('[deliverables] dropping ticket category no longer in the org partner', `orgId=${orgId}`, `categoryId=${ticketCategoryId}`);
+  return { ownerUserId: okOwner ? ownerUserId : null, ticketCategoryId: okCategory ? ticketCategoryId : null };
+}
+```
+
+Add `createTicket` to the `./ticketService` import and `isInLeadWindow` to `./recurrence`.
+
+- [ ] **Step 6: Run to verify pass**
+
+Run: `cd apps/api && npx vitest run src/services/ticketService.workKind.test.ts src/services/serviceDeliverableService.test.ts src/jobs/ticketSlaWorker.test.ts src/services/ticketService.test.ts && npx tsc --noEmit`
+Expected: PASS. `ticketService.test.ts` is included because `insertValues` changed — an existing shape assertion there needs `workKind: 'support'` added.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/services/ticketService.ts apps/api/src/services/ticketService.workKind.test.ts apps/api/src/jobs/ticketSlaWorker.ts apps/api/src/services/serviceDeliverableService.ts apps/api/src/services/serviceDeliverableService.test.ts
+git commit -m "feat(deliverables): open occurrences as SLA-free deliverable tickets (W02)"
+```
+
+---
+
+### Task 4: Auto-evidence report runs (spec D12, §5.3 step 3)
+
+**Files:**
+- Create: `apps/api/src/services/deliverableAutoEvidence.ts`; Test: `apps/api/src/services/deliverableAutoEvidence.test.ts`
+
+**Interfaces:**
+- Consumes: `generateReport` (`services/reportGenerationService.ts:743`), `assertReportExecutionPreflight` (`:232`), `decodeSiteScope` (`services/siteScope.ts:377`), `resolveLiveReportAuthority` (`:1052`), `persistedSiteScopeValues` (`:451`), `intersectSiteScopes`, `siteScopeFingerprint` (same module), `reports`/`reportRuns` (`db/schema/reports.ts:96`), `serviceDeliverableEvidence`, `ticketComments` (`db/schema/portal.ts:181-205`).
+- Produces:
+
+```ts
+export const AUTO_EVIDENCE_TICKET_NOTE = 'Report attached, review and resolve';
+export type AutoEvidenceOutcome =
+  | { ok: true; reportRunId: string }
+  | { ok: false; reason: 'already_attached' | 'not_due' | 'definition_not_found'
+      | 'system_principal_definition' | 'portal_user_principal_definition'
+      | 'scope_unverifiable' | 'scope_no_intersection' | 'scope_empty' | 'generation_failed' };
+export function generateAutoEvidenceForDeliverable(d: SweepDeliverable, today: string): Promise<number>;
+export function generateAutoEvidenceForOccurrence(args: {
+  orgId: string; occurrenceId: string; ticketId: string | null; reportId: string; dueAt: string; today: string;
+}): Promise<AutoEvidenceOutcome>;
+```
+
+**Design constraint the implementer must not "simplify" away.** `ReportExecutionAuthority` (`siteScope.ts:64-81`) has exactly two arms, `'user'` and `'portal_user'`; `SystemReportExecutionAuthority` (`:91-96`) is a **deliberately separate** type and `assertExecutableAuthority` (`reportGenerationService.ts:170`) ends in `const exhaustive: never = authority`. Do **not** widen that union and do **not** forge a `'user'` authority. Do exactly what `jobs/reportScheduleWorker.ts:546-626` does: refuse a non-user-principal definition, decode its persisted scope, re-resolve the owning user's **live** authority, intersect, preflight. The run row is then stamped `requested_by_kind: 'system'` with both requester ids NULL — which is precisely what the `report_runs_requested_by_shape_chk` system arm requires (`migrations/2026-10-08-100100-portal-report-self-service.sql:78-98`) — while `execution_scope_*` records whose scope actually ran. The two column families answer different questions: who could see the data, and who asked.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { rows, inserted, generateReportMock, resolveLiveMock, preflightMock } = vi.hoisted(() => ({
+  rows: [] as unknown[], inserted: [] as unknown[],
+  generateReportMock: vi.fn(), resolveLiveMock: vi.fn(), preflightMock: vi.fn(),
+}));
+vi.mock('../db', () => {
+  const chain: Record<string, unknown> = {};
+  for (const m of ['select','from','where','limit','orderBy','update','set','insert','returning']) chain[m] = vi.fn(() => chain);
+  chain.values = vi.fn((v: unknown) => { inserted.push(v); return chain; });
+  (chain as { then: unknown }).then = (r: (v: unknown) => unknown) => Promise.resolve(rows.shift() ?? []).then(r);
+  return { db: chain, runOutsideDbContext: (fn: () => unknown) => fn(), withSystemDbAccessContext: (fn: () => unknown) => fn() };
+});
+vi.mock('./reportGenerationService', () => ({ generateReport: generateReportMock, assertReportExecutionPreflight: preflightMock }));
+vi.mock('./siteScope', async (orig) => ({ ...(await orig<typeof import('./siteScope')>()), resolveLiveReportAuthority: resolveLiveMock }));
+import { generateAutoEvidenceForOccurrence } from './deliverableAutoEvidence';
+
+const DEF = { id: 'r1', orgId: 'org1', type: 'vulnerability_summary', config: {}, name: 'Vulnerability summary',
+  executionScopePrincipalKind: 'user', executionScopeUserId: 'u1',
+  executionScopeVersion: 1, executionScopeKind: 'unrestricted', executionScopeSiteIds: null };
+const ARGS = { orgId: 'org1', occurrenceId: 'o1', ticketId: 't1', reportId: 'r1', dueAt: '2026-10-31', today: '2026-10-31' };
+const LIVE = { ok: true, authority: { principalKind: 'user', principalUserId: 'u1', capturedAt: new Date(),
+  fingerprint: 'f', scope: { version: 1, kind: 'unrestricted', orgId: 'org1' } } };
+
+describe('generateAutoEvidenceForOccurrence (spec D12)', () => {
+  beforeEach(() => { rows.length = 0; inserted.length = 0; vi.clearAllMocks(); });
+
+  it('does nothing before the due date', async () => {
+    expect(await generateAutoEvidenceForOccurrence({ ...ARGS, today: '2026-10-30' })).toEqual({ ok: false, reason: 'not_due' });
+    expect(generateReportMock).not.toHaveBeenCalled();
+  });
+
+  it('never generates twice for the same occurrence', async () => {
+    rows.push([{ id: 'e1' }]);
+    expect(await generateAutoEvidenceForOccurrence(ARGS)).toEqual({ ok: false, reason: 'already_attached' });
+    expect(generateReportMock).not.toHaveBeenCalled();
+  });
+
+  it('stamps the run requested_by_kind=system with BOTH requester ids null, attaches evidence and a note', async () => {
+    rows.push([], [DEF]);
+    resolveLiveMock.mockResolvedValue(LIVE);
+    rows.push([{ id: 'run1' }]);
+    generateReportMock.mockResolvedValue({ rows: [{ a: 1 }], rowCount: 1, summary: {} });
+    rows.push([], [{ id: 'e1' }], []);
+    expect(await generateAutoEvidenceForOccurrence(ARGS)).toEqual({ ok: true, reportRunId: 'run1' });
+    expect(inserted[0]).toMatchObject({ reportId: 'r1', status: 'running', requestedByKind: 'system', requestedByUserId: null, requestedByPortalUserId: null });
+    expect(inserted[1]).toMatchObject({ orgId: 'org1', occurrenceId: 'o1', kind: 'report_run', reportId: 'r1', reportRunId: 'run1' });
+    expect(inserted[2]).toMatchObject({ ticketId: 't1', commentType: 'internal', isPublic: false, content: 'Report attached, review and resolve' });
+  });
+
+  it('refuses a system-principal definition instead of inventing a principal', async () => {
+    rows.push([], [{ ...DEF, executionScopePrincipalKind: 'system', executionScopeUserId: null }]);
+    expect(await generateAutoEvidenceForOccurrence(ARGS)).toEqual({ ok: false, reason: 'system_principal_definition' });
+    expect(generateReportMock).not.toHaveBeenCalled();
+  });
+
+  it('refuses when the owning user no longer holds the scope', async () => {
+    rows.push([], [DEF]);
+    resolveLiveMock.mockResolvedValue({ ok: false, reason: 'permission_removed' });
+    expect(await generateAutoEvidenceForOccurrence(ARGS)).toEqual({ ok: false, reason: 'scope_unverifiable' });
+  });
+
+  it('records a failed run and attaches no evidence when generation throws', async () => {
+    rows.push([], [DEF]);
+    resolveLiveMock.mockResolvedValue(LIVE);
+    rows.push([{ id: 'run1' }]);
+    generateReportMock.mockRejectedValue(new Error('boom'));
+    rows.push([]);
+    expect(await generateAutoEvidenceForOccurrence(ARGS)).toEqual({ ok: false, reason: 'generation_failed' });
+    expect(inserted).toHaveLength(1);                       // only the run row
+  });
+
+  it('attaches evidence but posts no comment when the occurrence has no ticket', async () => {
+    rows.push([], [DEF]);
+    resolveLiveMock.mockResolvedValue(LIVE);
+    rows.push([{ id: 'run1' }]);
+    generateReportMock.mockResolvedValue({ rows: [], rowCount: 0 });
+    rows.push([], [{ id: 'e1' }]);
+    expect(await generateAutoEvidenceForOccurrence({ ...ARGS, ticketId: null })).toEqual({ ok: true, reportRunId: 'run1' });
+    expect(inserted).toHaveLength(2);                       // run + evidence, no comment
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/api && npx vitest run src/services/deliverableAutoEvidence.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+/**
+ * Auto-evidence for service deliverables (spec D12, §5.3 step 3).
+ *
+ * A deliverable with `auto_evidence_report_id` gets a run of that report on its
+ * due date, attached as `report_run` evidence, plus an internal ticket note. The
+ * technician reviews a report Breeze already made instead of assembling one.
+ *
+ * AUTHORITY: ReportExecutionAuthority has no 'system' arm by design
+ * (siteScope.ts:84-96 — widening it would let user-path callers forge human
+ * provenance). So this reproduces reportScheduleWorker.ts's reauthorization
+ * sequence: refuse a non-user-principal definition, decode its persisted scope,
+ * re-resolve the owner's LIVE scope, intersect. `requested_by_kind` is still
+ * 'system' — the sweep asked for the run, not the owner.
+ */
+import { and, eq } from 'drizzle-orm';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
+import { reports, reportRuns } from '../db/schema/reports';
+import { serviceDeliverableEvidence, serviceDeliverableOccurrences } from '../db/schema/serviceDeliverables';
+import { ticketComments } from '../db/schema/portal';
+import { generateReport, assertReportExecutionPreflight } from './reportGenerationService';
+import {
+  decodeSiteScope, intersectSiteScopes, persistedSiteScopeValues, resolveLiveReportAuthority,
+  siteScopeFingerprint, type PersistedSiteScopeColumns, type ReportExecutionAuthority,
+} from './siteScope';
+import type { SweepDeliverable } from './serviceDeliverableService';
+
+export const AUTO_EVIDENCE_TICKET_NOTE = 'Report attached, review and resolve';
+
+export type AutoEvidenceOutcome =
+  | { ok: true; reportRunId: string }
+  | { ok: false; reason: 'already_attached' | 'not_due' | 'definition_not_found'
+      | 'system_principal_definition' | 'portal_user_principal_definition'
+      | 'scope_unverifiable' | 'scope_no_intersection' | 'scope_empty' | 'generation_failed' };
+
+const failed = (reason: Exclude<AutoEvidenceOutcome, { ok: true }>['reason']): AutoEvidenceOutcome => ({ ok: false, reason });
+
+/** Every `open` occurrence of this deliverable that is due and has no run yet. */
+export async function generateAutoEvidenceForDeliverable(d: SweepDeliverable, today: string): Promise<number> {
+  if (!d.autoEvidenceReportId) return 0;
+  const open = await runOutsideDbContext(() => withSystemDbAccessContext(() =>
+    db.select({ id: serviceDeliverableOccurrences.id, ticketId: serviceDeliverableOccurrences.ticketId,
+                dueAt: serviceDeliverableOccurrences.dueAt })
+      .from(serviceDeliverableOccurrences)
+      .where(and(eq(serviceDeliverableOccurrences.deliverableId, d.id), eq(serviceDeliverableOccurrences.status, 'open'))),
+    'deliverableSweep.selectAutoEvidence'));
+
+  let generated = 0;
+  for (const occ of open) {
+    const res = await runOutsideDbContext(() => withSystemDbAccessContext(() =>
+      generateAutoEvidenceForOccurrence({
+        orgId: d.orgId, occurrenceId: occ.id, ticketId: occ.ticketId,
+        reportId: d.autoEvidenceReportId!, dueAt: occ.dueAt, today,
+      }), 'deliverableSweep.autoEvidence'));
+    if (res.ok) generated++;
+    else if (res.reason !== 'not_due' && res.reason !== 'already_attached') {
+      // Never silent: a refused or failed generation leaves the occurrence
+      // untouched and the technician delivers manually.
+      console.warn('[deliverables] auto-evidence skipped', `occurrenceId=${occ.id}`, `reportId=${d.autoEvidenceReportId}`, `reason=${res.reason}`);
+    }
+  }
+  return generated;
+}
+
+export async function generateAutoEvidenceForOccurrence(args: {
+  orgId: string; occurrenceId: string; ticketId: string | null; reportId: string; dueAt: string; today: string;
+}): Promise<AutoEvidenceOutcome> {
+  if (args.today < args.dueAt) return failed('not_due');
+
+  // Once per occurrence, ever (spec §5.3 step 3).
+  const existing = await db.select({ id: serviceDeliverableEvidence.id })
+    .from(serviceDeliverableEvidence)
+    .where(and(eq(serviceDeliverableEvidence.occurrenceId, args.occurrenceId), eq(serviceDeliverableEvidence.kind, 'report_run')))
+    .limit(1);
+  if (existing.length > 0) return failed('already_attached');
+
+  const [definition] = await db.select().from(reports)
+    .where(and(eq(reports.id, args.reportId), eq(reports.orgId, args.orgId))).limit(1);
+  if (!definition) return failed('definition_not_found');
+
+  const principal = definition.executionScopePrincipalKind ?? null;
+  if (principal === 'system') return failed('system_principal_definition');
+  if (principal === 'portal_user') return failed('portal_user_principal_definition');
+  if (!definition.executionScopeUserId) return failed('scope_unverifiable');
+
+  let persistedScope;
+  try { persistedScope = decodeSiteScope(definition as unknown as PersistedSiteScopeColumns, definition.orgId); }
+  catch { return failed('scope_unverifiable'); }
+  if (persistedScope.kind === 'legacy_unscoped') return failed('scope_unverifiable');
+
+  const live = await resolveLiveReportAuthority(definition.executionScopeUserId, definition.orgId, 'read')
+    .catch(() => ({ ok: false as const, reason: 'unverifiable_scope' as const }));
+  if (!live.ok || live.authority.scope.kind === 'legacy_unscoped') return failed('scope_unverifiable');
+
+  const effectiveScope = intersectSiteScopes(persistedScope, live.authority.scope);
+  if (!effectiveScope) return failed('scope_no_intersection');
+  if (effectiveScope.kind === 'legacy_unscoped') return failed('scope_unverifiable');
+  if (effectiveScope.kind === 'restricted' && effectiveScope.siteIds.length === 0) return failed('scope_empty');
+
+  const authority: ReportExecutionAuthority = {
+    principalKind: 'user', scope: effectiveScope,
+    principalUserId: live.authority.principalUserId, capturedAt: live.authority.capturedAt,
+    fingerprint: siteScopeFingerprint(effectiveScope),
+  };
+  const config = (definition.config ?? {}) as Record<string, unknown>;
+  try { assertReportExecutionPreflight(definition.orgId, config, authority, definition.type); }
+  catch { return failed('scope_unverifiable'); }
+
+  const [run] = await db.insert(reportRuns).values({
+      reportId: definition.id, status: 'running', startedAt: new Date(),
+      // The sweep requested this run; no human did. report_runs_requested_by_shape_chk
+      // requires BOTH ids NULL for 'system'.
+      requestedByKind: 'system', requestedByUserId: null, requestedByPortalUserId: null,
+      ...persistedSiteScopeValues(authority),
+    }).returning({ id: reportRuns.id });
+  if (!run) return failed('generation_failed');
+
+  let result;
+  try {
+    result = await generateReport(definition.type, definition.orgId, config, authority);
+  } catch (err) {
+    await db.update(reportRuns).set({ status: 'failed', completedAt: new Date(),
+      errorMessage: err instanceof Error ? err.message : 'Failed to generate report' })
+      .where(eq(reportRuns.id, run.id));
+    return failed('generation_failed');
+  }
+
+  const rowsOut = Array.isArray(result.rows) ? result.rows : [];
+  await db.update(reportRuns).set({
+      status: 'completed', completedAt: new Date(),
+      outputUrl: `/api/reports/runs/${run.id}/download`,
+      result, rowCount: result.rowCount ?? rowsOut.length,
+    }).where(eq(reportRuns.id, run.id));
+
+  await db.insert(serviceDeliverableEvidence).values({
+      orgId: args.orgId, occurrenceId: args.occurrenceId, kind: 'report_run',
+      // report_id proves org ownership: report_runs has no org_id of its own
+      // (D6), so the composite FK (report_id, org_id) -> reports(id, org_id) is
+      // what keeps a foreign run out.
+      reportId: definition.id, reportRunId: run.id, createdByUserId: null,
+    }).returning({ id: serviceDeliverableEvidence.id });
+
+  if (args.ticketId) {
+    await db.insert(ticketComments).values({
+      ticketId: args.ticketId, userId: null, authorName: 'Breeze', authorType: 'system',
+      commentType: 'internal', content: AUTO_EVIDENCE_TICKET_NOTE, isPublic: false,
+    });
+  }
+  return { ok: true, reportRunId: run.id };
+}
+```
+
+Before finishing, confirm the exact export names `intersectSiteScopes`, `siteScopeFingerprint`, `PersistedSiteScopeColumns` in `services/siteScope.ts` (used verbatim by `reportScheduleWorker.ts:603, 625, 568`) and `assertReportExecutionPreflight`'s fourth parameter (`reportType?: ReportType`, `reportGenerationService.ts:232`).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd apps/api && npx vitest run src/services/deliverableAutoEvidence.test.ts && npx tsc --noEmit`
+Expected: PASS (7 tests); no type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/deliverableAutoEvidence.ts apps/api/src/services/deliverableAutoEvidence.test.ts
+git commit -m "feat(deliverables): auto-evidence report runs attached to due occurrences (W02)"
+```
+
+---
+
+### Task 5: Key-date reminders and annual roll-forward
+
+**Files:**
+- Modify: `apps/api/src/services/orgKeyDateService.ts`; Test: `apps/api/src/services/orgKeyDateService.test.ts` (append)
+
+**Interfaces:**
+- Produces: `export function sweepKeyDateReminders(today: string): Promise<number>;` and `export function rollForwardAnnualKeyDates(today: string): Promise<number>;`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+const K = { id: 'k1', orgId: 'org1', label: 'Cyber insurance renewal', kind: 'insurance_renewal',
+  date: '2027-03-01', ownerUserId: 'u1' };
+
+describe('sweepKeyDateReminders (spec §5.3 step 5)', () => {
+  beforeEach(() => { dbMocks.rows.length = 0; dbMocks.updated.length = 0; createTicketMock.mockReset(); });
+
+  it('creates one deliverable-kind reminder ticket and stamps reminded_for_date', async () => {
+    dbMocks.rows.push([K], [{ id: 'k1' }], [], []);          // due, claim, link, roll-forward
+    createTicketMock.mockResolvedValue({ id: 't9' });
+    expect(await sweepKeyDateReminders('2027-01-01')).toBe(1);
+    expect(createTicketMock).toHaveBeenCalledWith(expect.objectContaining({
+      orgId: 'org1', source: 'api', workKind: 'deliverable',
+      subject: 'Key date: Cyber insurance renewal — 2027-03-01',
+      dueDate: new Date('2027-03-01T00:00:00.000Z'), assigneeId: 'u1',
+    }), expect.anything());
+    expect(dbMocks.updated.some((u) => (u as Record<string, unknown>).remindedForDate === '2027-03-01')).toBe(true);
+  });
+
+  it('never reminds twice for the same (id, date)', async () => {
+    dbMocks.rows.push([K], [], []);                          // claim matched 0 rows
+    expect(await sweepKeyDateReminders('2027-01-01')).toBe(0);
+    expect(createTicketMock).not.toHaveBeenCalled();
+  });
+
+  it('still stamps the reminder when Service Management is off', async () => {
+    dbMocks.rows.push([K], [{ id: 'k1' }], []);
+    createTicketMock.mockRejectedValue(Object.assign(new Error('off'), { code: 'service_management_off' }));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try { expect(await sweepKeyDateReminders('2027-01-01')).toBe(1); } finally { warn.mockRestore(); }
+  });
+});
+
+describe('rollForwardAnnualKeyDates', () => {
+  beforeEach(() => { dbMocks.rows.length = 0; dbMocks.updated.length = 0; });
+
+  it('advances a past recurring date one year and clears both reminder stamps', async () => {
+    dbMocks.rows.push([{ id: 'k1', date: '2026-03-01' }], [{ id: 'k1' }]);
+    expect(await rollForwardAnnualKeyDates('2026-09-10')).toBe(1);
+    expect(dbMocks.updated.at(-1)).toMatchObject({ date: '2027-03-01', remindedForDate: null, reminderTicketId: null });
+  });
+
+  it('leaves a future date alone', async () => {
+    dbMocks.rows.push([]);
+    expect(await rollForwardAnnualKeyDates('2026-09-10')).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/api && npx vitest run src/services/orgKeyDateService.test.ts`
+Expected: FAIL — `sweepKeyDateReminders` is not exported.
+
+- [ ] **Step 3: Implement**
+
+```ts
+const KEY_DATE_SWEEP_ACTOR = { userId: '00000000-0000-0000-0000-000000000000', name: 'Key dates' } as const;
+
+/**
+ * Spec §5.3 step 5. Two passes:
+ *  1. reminders — `date - remind_days_before <= today` and `reminded_for_date IS
+ *     DISTINCT FROM date`. The stamp IS the claim: written by a CAS UPDATE
+ *     before the ticket is created, so a crash mid-create loses the ticket,
+ *     never doubles it.
+ *  2. annual roll-forward — a recurring date in the past advances one year and
+ *     drops its reminder stamps so next year's reminder can fire at all.
+ */
+export async function sweepKeyDateReminders(today: string): Promise<number> {
+  const due = await runOutsideDbContext(() => withSystemDbAccessContext(() =>
+    db.select({ id: organizationKeyDates.id, orgId: organizationKeyDates.orgId,
+                label: organizationKeyDates.label, kind: organizationKeyDates.kind,
+                date: organizationKeyDates.date, ownerUserId: organizationKeyDates.ownerUserId })
+      .from(organizationKeyDates)
+      .where(and(
+        isNotNull(organizationKeyDates.remindDaysBefore),
+        sql`${organizationKeyDates.date} - (${organizationKeyDates.remindDaysBefore} * INTERVAL '1 day') <= ${today}::date`,
+        sql`${organizationKeyDates.remindedForDate} IS DISTINCT FROM ${organizationKeyDates.date}`,
+        buildAutomationEligibleOrgPredicate(organizationKeyDates.orgId)
+      )), 'keyDateSweep.selectDue'));
+
+  let created = 0;
+  for (const row of due) {
+    created += await runOutsideDbContext(() => withSystemDbAccessContext(async () => {
+      const claimed = await db.update(organizationKeyDates)
+        .set({ remindedForDate: row.date, updatedAt: new Date() })
+        .where(and(eq(organizationKeyDates.id, row.id),
+          sql`${organizationKeyDates.remindedForDate} IS DISTINCT FROM ${row.date}::date`))
+        .returning({ id: organizationKeyDates.id });
+      if (claimed.length === 0) return 0;
+
+      let ticketId: string | null = null;
+      try {
+        const ticket = await createTicket({
+          orgId: row.orgId, source: 'api', workKind: 'deliverable',
+          subject: `Key date: ${row.label} — ${row.date}`,
+          description: `This ${String(row.kind).replace(/_/g, ' ')} key date falls on ${row.date}.`,
+          dueDate: new Date(`${row.date}T00:00:00.000Z`),
+          assigneeId: row.ownerUserId ?? undefined,
+        }, KEY_DATE_SWEEP_ACTOR);
+        ticketId = ticket.id;
+      } catch (err) {
+        if ((err as { code?: string }).code !== 'service_management_off') throw err;
+        console.warn('[deliverables] key-date reminder without a ticket (Service Management off)', `orgId=${row.orgId}`, `keyDateId=${row.id}`);
+        return 1;
+      }
+      await db.update(organizationKeyDates)
+        .set({ reminderTicketId: ticketId, updatedAt: new Date() })
+        .where(eq(organizationKeyDates.id, row.id));
+      return 1;
+    }, 'keyDateSweep.remind'));
+  }
+
+  await rollForwardAnnualKeyDates(today);
+  return created;
+}
+
+export async function rollForwardAnnualKeyDates(today: string): Promise<number> {
+  return runOutsideDbContext(() => withSystemDbAccessContext(async () => {
+    const stale = await db.select({ id: organizationKeyDates.id, date: organizationKeyDates.date })
+      .from(organizationKeyDates)
+      .where(and(eq(organizationKeyDates.recursAnnually, true), lt(organizationKeyDates.date, today)));
+    let rolled = 0;
+    for (const row of stale) {
+      const updated = await db.update(organizationKeyDates)
+        .set({ date: addMonthsClamped(row.date, 12), remindedForDate: null, reminderTicketId: null, updatedAt: new Date() })
+        .where(and(eq(organizationKeyDates.id, row.id), eq(organizationKeyDates.date, row.date)))
+        .returning({ id: organizationKeyDates.id });
+      rolled += updated.length;
+    }
+    return rolled;
+  }, 'keyDateSweep.rollForward'));
+}
+```
+
+Add `isNotNull`, `lt`, `sql` to the drizzle import; `createTicket` from `./ticketService`; `buildAutomationEligibleOrgPredicate` from `./tenantStatus`; `addMonthsClamped` from `./contractMath`; `runOutsideDbContext`, `withSystemDbAccessContext` from `../db`.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd apps/api && npx vitest run src/services/orgKeyDateService.test.ts && npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/orgKeyDateService.ts apps/api/src/services/orgKeyDateService.test.ts
+git commit -m "feat(deliverables): key-date reminder tickets and annual roll-forward (W02)"
+```
+
+---
+
+### Task 6: `applyTicketStatusChange` and the `deliverable-status` subscriber
+
+**Files:**
+- Modify: `apps/api/src/services/serviceDeliverableService.ts` (replace the `applyTicketStatusChange` stub)
+- Create: `apps/api/src/services/deliverableStatusSubscriber.ts` (+ `.test.ts`)
+- Modify: `apps/api/src/services/eventSubscriberIds.ts:4-19`; `apps/api/src/services/eventSubscribers.ts:135`
+
+**Interfaces:**
+- Consumes: `transition` (`services/serviceDeliverableState.ts`, W01 Task 6); `BreezeEvent` (`services/eventBus.ts:197`).
+- Produces: `applyTicketStatusChange` (W01 signature, unchanged) and `export function handleDeliverableTicketStatusChanged(event: BreezeEvent): Promise<void>;`
+
+**Payload facts the implementer must not guess.** `ticket.status_changed` is published from the transactional outbox with an **id-only** payload `{ ticketId, from, to }` (`ticketService.ts:1037` writes `{ from, to }`; `jobs/ticketOutboxPublisher.ts:199` prepends `ticketId`). It carries **no** actor and **no** resolution note — both are content, deliberately excluded. The subscriber re-reads both under a system context. The actor is recoverable exactly: `changeTicketStatus` inserts a `ticket_comments` row with `commentType='status_change'`, `oldValue=fromStatus`, `newValue=toStatus`, `userId=actor.userId` (`ticketService.ts:1018-1029`).
+
+- [ ] **Step 1: Write the failing tests**
+
+`deliverableStatusSubscriber.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { rows, applyMock } = vi.hoisted(() => ({ rows: [] as unknown[], applyMock: vi.fn() }));
+vi.mock('../db', () => {
+  const chain: Record<string, unknown> = {};
+  for (const m of ['select','from','where','limit','orderBy']) chain[m] = vi.fn(() => chain);
+  (chain as { then: unknown }).then = (r: (v: unknown) => unknown) => Promise.resolve(rows.shift() ?? []).then(r);
+  return { db: chain, runOutsideDbContext: (fn: () => unknown) => fn(), withSystemDbAccessContext: (fn: () => unknown) => fn() };
+});
+vi.mock('./serviceDeliverableService', () => ({ applyTicketStatusChange: applyMock }));
+import { handleDeliverableTicketStatusChanged } from './deliverableStatusSubscriber';
+
+const evt = (payload: unknown) => ({ id: 'e1', type: 'ticket.status_changed', orgId: 'org1',
+  source: 't', priority: 'normal', payload, metadata: { timestamp: '' } } as never);
+
+describe('deliverable-status subscriber (spec §6)', () => {
+  beforeEach(() => { rows.length = 0; vi.clearAllMocks(); });
+
+  it('drops a malformed event without touching the service', async () => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      await handleDeliverableTicketStatusChanged(evt({ to: 'resolved' }));
+      expect(applyMock).not.toHaveBeenCalled();
+      expect(err).toHaveBeenCalled();
+    } finally { err.mockRestore(); }
+  });
+
+  it('ignores a ticket no occurrence is linked to', async () => {
+    rows.push([]);
+    await handleDeliverableTicketStatusChanged(evt({ ticketId: 't1', from: 'open', to: 'resolved' }));
+    expect(applyMock).not.toHaveBeenCalled();
+  });
+
+  it('passes the resolution note and the status-change actor through on resolve', async () => {
+    rows.push([{ id: 'o1' }], [{ resolutionNote: 'Reviewed, no findings' }], [{ userId: 'u7' }]);
+    await handleDeliverableTicketStatusChanged(evt({ ticketId: 't1', from: 'open', to: 'resolved' }));
+    expect(applyMock).toHaveBeenCalledWith({ ticketId: 't1', orgId: 'org1', to: 'resolved', actorUserId: 'u7', resolutionNote: 'Reviewed, no findings' });
+  });
+
+  it('forwards a reopen with a null note', async () => {
+    rows.push([{ id: 'o1' }], [{ resolutionNote: null }], []);
+    await handleDeliverableTicketStatusChanged(evt({ ticketId: 't1', from: 'resolved', to: 'open' }));
+    expect(applyMock).toHaveBeenCalledWith({ ticketId: 't1', orgId: 'org1', to: 'open', actorUserId: null, resolutionNote: null });
+  });
+});
+```
+
+Append to `serviceDeliverableService.test.ts`:
+
+```ts
+const occRow = (over: Record<string, unknown> = {}) => ({ id: 'o1', orgId: 'org1', status: 'open',
+  deliveredVia: null, artifactRequired: true, completionMode: 'on_ticket_resolve', ...over });
+
+describe('applyTicketStatusChange (spec §6)', () => {
+  beforeEach(() => { dbMocks.rows.length = 0; dbMocks.updated.length = 0; });
+
+  it('resolve with evidence delivers via ticket and copies the resolution note', async () => {
+    dbMocks.rows.push([occRow()], [{ id: 'e1' }], [{ id: 'o1' }]);
+    await applyTicketStatusChange({ ticketId: 't1', orgId: 'org1', to: 'resolved', actorUserId: 'u7', resolutionNote: 'done' });
+    expect(dbMocks.updated.at(-1)).toMatchObject({ status: 'delivered', deliveredVia: 'ticket', deliveredByUserId: 'u7', deliveryNote: 'done' });
+  });
+
+  it('resolve with artifact required and no evidence goes to awaiting_evidence, stamping no delivery', async () => {
+    dbMocks.rows.push([occRow()], [], [{ id: 'o1' }]);
+    await applyTicketStatusChange({ ticketId: 't1', orgId: 'org1', to: 'closed', actorUserId: null, resolutionNote: null });
+    const patch = dbMocks.updated.at(-1) as Record<string, unknown>;
+    expect(patch).toMatchObject({ status: 'awaiting_evidence' });
+    expect(patch.deliveredAt).toBeUndefined();
+  });
+
+  it('explicit completion mode changes nothing', async () => {
+    dbMocks.rows.push([occRow({ completionMode: 'explicit' })], []);
+    await applyTicketStatusChange({ ticketId: 't1', orgId: 'org1', to: 'resolved', actorUserId: 'u7', resolutionNote: 'x' });
+    expect(dbMocks.updated).toHaveLength(0);
+  });
+
+  it('a reopen undoes a ticket-driven delivery and clears the delivery fields', async () => {
+    dbMocks.rows.push([occRow({ status: 'delivered', deliveredVia: 'ticket' })], [], [{ id: 'o1' }]);
+    await applyTicketStatusChange({ ticketId: 't1', orgId: 'org1', to: 'open', actorUserId: 'u7', resolutionNote: null });
+    expect(dbMocks.updated.at(-1)).toMatchObject({ status: 'open', deliveredAt: null, deliveredByUserId: null, deliveredVia: null, deliveryNote: null });
+  });
+
+  it('a reopen NEVER undoes an explicit delivery', async () => {
+    dbMocks.rows.push([occRow({ status: 'delivered', deliveredVia: 'explicit' })], []);
+    await applyTicketStatusChange({ ticketId: 't1', orgId: 'org1', to: 'open', actorUserId: 'u7', resolutionNote: null });
+    expect(dbMocks.updated).toHaveLength(0);
+  });
+
+  it('is idempotent — a redelivery of an already-delivered occurrence is a no-op', async () => {
+    dbMocks.rows.push([occRow({ status: 'delivered', deliveredVia: 'ticket' })], [{ id: 'e1' }]);
+    await applyTicketStatusChange({ ticketId: 't1', orgId: 'org1', to: 'resolved', actorUserId: 'u7', resolutionNote: 'done' });
+    expect(dbMocks.updated).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/api && npx vitest run src/services/deliverableStatusSubscriber.test.ts src/services/serviceDeliverableService.test.ts`
+Expected: FAIL — module not found, and `not implemented (W02)`.
+
+- [ ] **Step 3: Implement the service function**
+
+```ts
+const RESOLVED_LIKE = new Set(['resolved', 'closed']);
+const REOPENED_LIKE = new Set(['new', 'open', 'pending', 'on_hold']);
+
+/**
+ * Spec §6. Advisory, not the record of delivery (D4) — the completion policy
+ * decides. Idempotent by construction: the write is CAS'd on the status this
+ * function read, so a duplicate event updates 0 rows.
+ */
+export async function applyTicketStatusChange(args: {
+  ticketId: string; orgId: string; to: string; actorUserId: string | null; resolutionNote: string | null;
+}): Promise<void> {
+  const [occ] = await db.select({
+      id: serviceDeliverableOccurrences.id, status: serviceDeliverableOccurrences.status,
+      deliveredVia: serviceDeliverableOccurrences.deliveredVia,
+      artifactRequired: serviceDeliverables.artifactRequired,
+      completionMode: serviceDeliverables.completionMode,
+    })
+    .from(serviceDeliverableOccurrences)
+    .innerJoin(serviceDeliverables, eq(serviceDeliverables.id, serviceDeliverableOccurrences.deliverableId))
+    .where(and(eq(serviceDeliverableOccurrences.ticketId, args.ticketId), eq(serviceDeliverableOccurrences.orgId, args.orgId)))
+    .limit(1);
+  if (!occ) return;
+
+  const current = occ.status as OccurrenceStatus;
+  let outcome;
+  if (RESOLVED_LIKE.has(args.to)) {
+    const evidence = await db.select({ id: serviceDeliverableEvidence.id })
+      .from(serviceDeliverableEvidence)
+      .where(eq(serviceDeliverableEvidence.occurrenceId, occ.id)).limit(1);
+    outcome = transition(current, {
+      type: 'ticket_resolved', hasEvidence: evidence.length > 0,
+      artifactRequired: occ.artifactRequired,
+      completionMode: occ.completionMode as 'explicit' | 'on_ticket_resolve',
+    });
+  } else if (REOPENED_LIKE.has(args.to)) {
+    outcome = transition(current, { type: 'ticket_reopened', deliveredVia: occ.deliveredVia });
+  } else {
+    return;
+  }
+  if (outcome.next === null) return;
+
+  const patch: Record<string, unknown> = { status: outcome.next, updatedAt: new Date() };
+  if (outcome.next === 'delivered') {
+    patch.deliveredAt = new Date();
+    patch.deliveredByUserId = args.actorUserId;
+    patch.deliveredVia = 'ticket';
+    patch.deliveryNote = args.resolutionNote;
+  } else if (outcome.next === 'open') {
+    patch.deliveredAt = null; patch.deliveredByUserId = null;
+    patch.deliveredVia = null; patch.deliveryNote = null;
+  }
+
+  await db.update(serviceDeliverableOccurrences).set(patch)
+    // CAS on the status we decided from: a concurrent write loses silently.
+    .where(and(eq(serviceDeliverableOccurrences.id, occ.id), eq(serviceDeliverableOccurrences.status, current)));
+}
+```
+
+- [ ] **Step 4: Implement the subscriber**
+
+```ts
+/**
+ * `ticket.status_changed` -> service-deliverable occurrence (spec §6).
+ *
+ * The payload is id-only by design (`{ ticketId, from, to }` —
+ * ticketService.ts:1037 + ticketOutboxPublisher.ts:199), so neither the acting
+ * user nor the resolution note travels on it. Both are re-read here under a
+ * system context: the note from `tickets.resolution_note`, the actor from the
+ * `status_change` comment changeTicketStatus writes with the real actor id
+ * (ticketService.ts:1018-1029). No linked occurrence means this handler does
+ * nothing at all — the overwhelming majority of tickets.
+ */
+import { and, desc, eq } from 'drizzle-orm';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
+import { tickets, ticketComments } from '../db/schema/portal';
+import { serviceDeliverableOccurrences } from '../db/schema/serviceDeliverables';
+import { applyTicketStatusChange } from './serviceDeliverableService';
+import type { BreezeEvent } from './eventBus';
+
+export async function handleDeliverableTicketStatusChanged(event: BreezeEvent): Promise<void> {
+  const payload = event.payload as { ticketId?: unknown; to?: unknown } | null | undefined;
+  const ticketId = typeof payload?.ticketId === 'string' ? payload.ticketId : null;
+  const to = typeof payload?.to === 'string' ? payload.to : null;
+  const orgId = event.orgId;
+  if (!ticketId || !to || !orgId) {
+    console.error('[deliverableStatusSubscriber] malformed ticket.status_changed — dropping',
+      { eventId: event.id, orgId, payload: event.payload });
+    return;
+  }
+
+  await runOutsideDbContext(() => withSystemDbAccessContext(async () => {
+    const linked = await db.select({ id: serviceDeliverableOccurrences.id })
+      .from(serviceDeliverableOccurrences)
+      .where(and(eq(serviceDeliverableOccurrences.ticketId, ticketId), eq(serviceDeliverableOccurrences.orgId, orgId)))
+      .limit(1);
+    if (linked.length === 0) return;
+
+    const [ticket] = await db.select({ resolutionNote: tickets.resolutionNote })
+      .from(tickets).where(eq(tickets.id, ticketId)).limit(1);
+
+    const [statusComment] = await db.select({ userId: ticketComments.userId })
+      .from(ticketComments)
+      .where(and(eq(ticketComments.ticketId, ticketId),
+        eq(ticketComments.commentType, 'status_change'), eq(ticketComments.newValue, to)))
+      .orderBy(desc(ticketComments.createdAt)).limit(1);
+
+    await applyTicketStatusChange({
+      ticketId, orgId, to,
+      actorUserId: statusComment?.userId ?? null,
+      resolutionNote: ticket?.resolutionNote ?? null,
+    });
+  }, 'deliverableStatusSubscriber'));
+}
+```
+
+- [ ] **Step 5: Register the subscriber**
+
+`eventSubscriberIds.ts` — insert alphabetically between `'automation-worker'` and `'dns-threat-alerts'`:
+
+```ts
+  // Service deliverables W02 (spec §6) — turns a real ticket resolution into a
+  // delivery record per the deliverable's completion policy.
+  'deliverable-status',
+```
+
+`eventSubscribers.ts`, after the `ai-agent-ticket-helpdesk` block (line 135):
+
+```ts
+  registerEventSubscriber({
+    id: 'deliverable-status',
+    // Lazy import for the same reason as every ticket subscriber above:
+    // workerEntrypointClosure.contract.test.ts constrains what this module may
+    // pull into the worker boot closure statically.
+    eventTypes: ['ticket.status_changed'],
+    handler: async (event: BreezeEvent) => {
+      const { handleDeliverableTicketStatusChanged } = await import('./deliverableStatusSubscriber');
+      return handleDeliverableTicketStatusChanged(event);
+    },
+    retry: { attempts: 5, backoffMs: 10_000 },
+  });
+```
+
+- [ ] **Step 6: Run to verify pass**
+
+Run: `cd apps/api && npx vitest run src/services/deliverableStatusSubscriber.test.ts src/services/serviceDeliverableService.test.ts src/services/eventSubscribers.contract.test.ts src/services/workerEntrypointClosure.contract.test.ts && npx tsc --noEmit`
+Expected: PASS. `eventSubscribers.contract.test.ts` fails if the id is registered zero or twice, or registered without being in `EVENT_SUBSCRIBER_IDS`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/services/serviceDeliverableService.ts apps/api/src/services/serviceDeliverableService.test.ts apps/api/src/services/deliverableStatusSubscriber.ts apps/api/src/services/deliverableStatusSubscriber.test.ts apps/api/src/services/eventSubscriberIds.ts apps/api/src/services/eventSubscribers.ts
+git commit -m "feat(deliverables): ticket.status_changed subscriber records delivery (W02)"
+```
+
+---
+
+### Task 7: Contract-cancelled hook
+
+**Files:**
+- Modify: `apps/api/src/services/serviceDeliverableService.ts`; Test: `serviceDeliverableService.test.ts` (append)
+
+**Interfaces:**
+- Produces: `export function applyContractCancelledToDeliverables(contractId: string, today: string): Promise<number>;`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+describe('applyContractCancelledToDeliverables (spec §5.4)', () => {
+  beforeEach(() => { dbMocks.rows.length = 0; dbMocks.updated.length = 0; });
+
+  it('closes the effective window of every open-ended deliverable on the contract', async () => {
+    dbMocks.rows.push([{ id: 'c1', status: 'cancelled' }], [{ id: 'd1' }, { id: 'd2' }]);
+    expect(await applyContractCancelledToDeliverables('c1', '2026-09-10')).toBe(2);
+    expect(dbMocks.updated.at(-1)).toMatchObject({ effectiveUntil: '2026-09-10' });
+  });
+
+  it('does nothing when the contract is no longer cancelled (a replayed event)', async () => {
+    dbMocks.rows.push([{ id: 'c1', status: 'active' }]);
+    expect(await applyContractCancelledToDeliverables('c1', '2026-09-10')).toBe(0);
+    expect(dbMocks.updated).toHaveLength(0);
+  });
+
+  it('does nothing for a contract that no longer exists', async () => {
+    dbMocks.rows.push([]);
+    expect(await applyContractCancelledToDeliverables('gone', '2026-09-10')).toBe(0);
+  });
+
+  it('never overwrites an effective_until the MSP already set', async () => {
+    dbMocks.rows.push([{ id: 'c1', status: 'cancelled' }], []);   // IS NULL predicate matched nothing
+    expect(await applyContractCancelledToDeliverables('c1', '2026-09-10')).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/api && npx vitest run src/services/serviceDeliverableService.test.ts`
+Expected: FAIL — `applyContractCancelledToDeliverables` is not exported.
+
+- [ ] **Step 3: Implement**
+
+```ts
+/**
+ * Spec §5.4. A cancelled contract ends the service it paid for, so every
+ * deliverable still open-ended on it stops today. `paused` deliberately does
+ * nothing (a billing pause is not a service pause) and `expired` is ignored
+ * entirely (D1 — generateDueInvoice expires an annual-advance contract the day
+ * after its single invoice while service runs 12 more months).
+ *
+ * The contract's CURRENT status is re-read rather than trusted from the event:
+ * `contract-events` gained its first consumer in this wave, so the first deploy
+ * drains a historical backlog, and a cancel later reversed must not close a
+ * live deliverable. `cancelContract` (contractService.ts:1690-1698) stores no
+ * cancellation timestamp, so `today` is the processing date, not a back-date.
+ */
+export async function applyContractCancelledToDeliverables(contractId: string, today: string): Promise<number> {
+  return runOutsideDbContext(() => withSystemDbAccessContext(async () => {
+    const [contract] = await db.select({ id: contracts.id, status: contracts.status })
+      .from(contracts).where(eq(contracts.id, contractId)).limit(1);
+    if (!contract || contract.status !== 'cancelled') return 0;
+
+    const updated = await db.update(serviceDeliverables)
+      .set({ effectiveUntil: today, updatedAt: new Date() })
+      .where(and(eq(serviceDeliverables.contractId, contractId), isNull(serviceDeliverables.effectiveUntil)))
+      .returning({ id: serviceDeliverables.id });
+    if (updated.length > 0) {
+      console.log('[deliverables] contract cancelled — closed effective window',
+        `contractId=${contractId}`, `deliverables=${updated.length}`, `effectiveUntil=${today}`);
+    }
+    return updated.length;
+  }, 'deliverables.contractCancelled'));
+}
+```
+
+Add `isNull` to the drizzle import and `contracts` from `../db/schema/contracts` if not already imported.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd apps/api && npx vitest run src/services/serviceDeliverableService.test.ts src/jobs/deliverableWorker.test.ts && npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/serviceDeliverableService.ts apps/api/src/services/serviceDeliverableService.test.ts
+git commit -m "feat(deliverables): contract-cancelled hook closes the effective window (W02)"
+```
+
+---
+
+### Task 8: Move-org guard — 409 `DELIVERABLE_TICKET_PINNED`
+
+**Files:**
+- Modify: `apps/api/src/services/ticketService.ts` — `TicketServiceErrorCode` union (~45-62), `moveTicketOrg` (insert after the partner check at line 2339)
+- Test: `apps/api/src/services/ticketService.moveOrg.deliverable.test.ts`
+
+**Where the guard goes, and why the service, not the route.** `routes/tickets/moveOrg.ts` is one of two doors — the `manage_tickets` AI tool calls `moveTicketOrg` directly (`services/aiToolsTicketing.ts:754-756`). Both funnel through `moveTicketOrg` (`ticketService.ts:2260`), where every other tenancy guard already lives (`:2336`, `:2337-2339`, `:2515`). The database is the real backstop: `sd_occ_ticket_org_fk` is `FOREIGN KEY (ticket_id, org_id) REFERENCES tickets(id, org_id)` with the default `ON UPDATE NO ACTION`, so re-stamping `tickets.org_id` under a linked occurrence raises `23503` regardless. The app guard turns that into a 409 the UI can explain. `service_deliverable_occurrences` is therefore **deliberately absent** from `TICKET_ORG_DENORMALIZED_TABLES` (`services/ticketOrgMoveLockOrder.ts:117-124`): a pinned ticket never moves, so there is nothing to re-stamp. Do not add it there.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { DELIVERABLE_TICKET_PINNED_MESSAGE, assertTicketNotPinnedToDeliverable } from './ticketService';
+
+const txWith = (result: unknown[]) => ({ select: () => ({ from: () => ({ where: () => ({ limit: async () => result }) }) }) });
+
+describe('move-org deliverable pin (spec §6)', () => {
+  it('throws 409 DELIVERABLE_TICKET_PINNED when an occurrence is linked', async () => {
+    await expect(assertTicketNotPinnedToDeliverable(txWith([{ id: 'o1', nameSnapshot: 'Sign-in log review' }]) as never, 't1'))
+      .rejects.toMatchObject({ status: 409, code: 'DELIVERABLE_TICKET_PINNED', message: DELIVERABLE_TICKET_PINNED_MESSAGE });
+  });
+
+  it('passes when no occurrence is linked', async () => {
+    await expect(assertTicketNotPinnedToDeliverable(txWith([]) as never, 't1')).resolves.toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/api && npx vitest run src/services/ticketService.moveOrg.deliverable.test.ts`
+Expected: FAIL — `assertTicketNotPinnedToDeliverable` is not exported.
+
+- [ ] **Step 3: Implement**
+
+Add `| 'DELIVERABLE_TICKET_PINNED'` to `TicketServiceErrorCode` (after `'service_management_off'`), then above `moveTicketOrg`:
+
+```ts
+export const DELIVERABLE_TICKET_PINNED_MESSAGE =
+  'This ticket is the work item for a service deliverable and cannot be moved to another organization. Unlink or reschedule the deliverable occurrence first.';
+
+/**
+ * Spec §6. A deliverable occurrence pins its ticket to the deliverable's org.
+ * Defence in depth only: sd_occ_ticket_org_fk (ticket_id, org_id) ->
+ * tickets(id, org_id) has no ON UPDATE clause, so the move would raise 23503
+ * anyway — this turns an opaque FK violation into an explainable 409.
+ */
+export async function assertTicketNotPinnedToDeliverable(tx: typeof db, ticketId: string): Promise<void> {
+  const linked = await tx
+    .select({ id: serviceDeliverableOccurrences.id, nameSnapshot: serviceDeliverableOccurrences.nameSnapshot })
+    .from(serviceDeliverableOccurrences)
+    .where(eq(serviceDeliverableOccurrences.ticketId, ticketId))
+    .limit(1);
+  if (linked.length > 0) {
+    throw new TicketServiceError(DELIVERABLE_TICKET_PINNED_MESSAGE, 409, 'DELIVERABLE_TICKET_PINNED');
+  }
+}
+```
+
+Inside `moveTicketOrg`, immediately after the same-partner check (line 2339) and before the `sourceOrg` const:
+
+```ts
+    // Cheap precondition, before the ticket UPDATE burns anything.
+    await assertTicketNotPinnedToDeliverable(tx, ticketId);
+```
+
+Import `serviceDeliverableOccurrences` from `../db/schema/serviceDeliverables`.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd apps/api && npx vitest run src/services/ticketService.moveOrg.deliverable.test.ts src/services/ticketOrgMoveLockOrder.test.ts src/routes/tickets/moveOrg.test.ts && npx tsc --noEmit`
+Expected: PASS. The route needs no change — `handleServiceError` (`routes/tickets/tickets.ts:92-99`) already serializes `TicketServiceError` as `{ error, code }` at `err.status`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/ticketService.ts apps/api/src/services/ticketService.moveOrg.deliverable.test.ts
+git commit -m "feat(deliverables): block moving a deliverable ticket between orgs (W02)"
+```
+
+---
+
+### Task 9: MCP / AI tools for deliverables and key dates
+
+**Files:**
+- Create: `apps/api/src/services/aiToolsDeliverables.ts` (+ `.test.ts`)
+- Modify: `apps/api/src/services/aiTools.ts:80` and `:294`; `aiToolSchemas.ts:452` area; `aiAgentSdkTools.ts:287` and `:2547` area; `aiGuardrails.ts:703` area
+
+**A new tool has FOUR registration sites** (documented at `services/aiToolsContracts.registryParity.contract.test.ts:1-21`): the core registry, the zod `toolInputSchemas`, the SDK `tool()` block + `TOOL_TIERS`, and `TOOL_PERMISSIONS`. Missing site 4 fails closed with `Unknown action "<x>" for tool "manage_deliverables"`. All three tools are **tier 2 and NOT approval-gated** — no `TIER3_ACTIONS` entry (spec §10: only `apply_template` is gated, and that is W05; it must not appear here).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { aiTools } from './aiTools';
+import { toolInputSchemas } from './aiToolSchemas';
+import { TOOL_PERMISSIONS, TIER3_ACTIONS } from './aiGuardrails';
+import { TOOL_TIERS } from './aiAgentSdkTools';
+
+const NAMES = ['list_deliverables', 'manage_deliverables', 'manage_key_dates'] as const;
+const MANAGE_ACTIONS = ['create','update','deactivate','deliver','waive','reopen','reschedule','link_evidence'] as const;
+
+describe('deliverable AI tools', () => {
+  it('registers all three at tier 2 with a schema, an SDK tier and permissions (the four-site rule)', () => {
+    for (const n of NAMES) {
+      expect(aiTools.get(n), `${n} not registered`).toBeDefined();
+      expect(aiTools.get(n)!.tier).toBe(2);
+      expect(toolInputSchemas[n], `${n} missing zod schema`).toBeDefined();
+      expect(TOOL_TIERS[n], `${n} missing SDK tier`).toBe(2);
+      expect(TOOL_PERMISSIONS[n], `${n} missing permissions`).toBeDefined();
+    }
+  });
+
+  it('exposes every manage action and NOT apply_template (that is W05)', () => {
+    expect(toolInputSchemas.manage_deliverables.safeParse({ action: 'apply_template' }).success).toBe(false);
+    const perms = TOOL_PERMISSIONS.manage_deliverables as Record<string, unknown>;
+    for (const a of MANAGE_ACTIONS) expect(perms[a], `no permission for ${a}`).toBeDefined();
+    expect(perms.apply_template).toBeUndefined();
+  });
+
+  it('is not approval-gated', () => {
+    for (const n of NAMES) expect(TIER3_ACTIONS[n]).toBeUndefined();
+  });
+
+  it('returns a JSON error string instead of throwing a service error', async () => {
+    const auth = { user: { id: 'u1' }, partnerId: 'p1', accessibleOrgIds: ['org1'] } as never;
+    const out = await aiTools.get('manage_deliverables')!.handler({ action: 'nope' }, auth);
+    expect(JSON.parse(out)).toMatchObject({ code: 'VALIDATION_ERROR' });
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/api && npx vitest run src/services/aiToolsDeliverables.test.ts`
+Expected: FAIL — `aiTools.get('list_deliverables')` is `undefined`.
+
+- [ ] **Step 3: Write `aiToolsDeliverables.ts`**
+
+Follow `aiToolsContracts.ts` exactly: raw JSON Schema in `definition.input_schema`, a per-action presence table, `actorFromAuth`, and error-to-JSON conversion instead of throwing.
+
+```ts
+/**
+ * AI Deliverable Tools (spec §10). `apply_template` is deliberately ABSENT:
+ * template sets land in W05, and that action is the only approval-gated one in
+ * this family (it arms unattended ticket creation). Everything here is tier 2
+ * and ungated. Org scope is guarded at the SERVICE layer — every function takes
+ * the DeliverableActor built from session auth and answers 404 NOT_FOUND (never
+ * 403) for an org outside `accessibleOrgIds`.
+ */
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool, AiToolTier } from './aiTools';
+import {
+  listDeliverables, createDeliverable, updateDeliverable, deactivateDeliverable,
+  listOccurrences, deliverOccurrence, waiveOccurrence, reopenOccurrence,
+  rescheduleOccurrence, addEvidence, DeliverableServiceError, type DeliverableActor,
+} from './serviceDeliverableService';
+import { listKeyDates, createKeyDate, updateKeyDate, deleteKeyDate } from './orgKeyDateService';
+import { missingParamsJson, zodErrorToJson } from './aiToolValidation';
+
+const MANAGE_DELIVERABLES_REQUIRED: Record<string, readonly string[]> = {
+  create: ['orgId', 'input'], update: ['orgId', 'deliverableId', 'patch'], deactivate: ['orgId', 'deliverableId'],
+  deliver: ['orgId', 'occurrenceId'], waive: ['orgId', 'occurrenceId', 'reason'], reopen: ['orgId', 'occurrenceId'],
+  reschedule: ['orgId', 'occurrenceId', 'dueAt'], link_evidence: ['orgId', 'occurrenceId', 'reportRunId'],
+};
+const MANAGE_KEY_DATES_REQUIRED: Record<string, readonly string[]> = {
+  list: ['orgId'], create: ['orgId', 'input'], update: ['orgId', 'keyDateId', 'patch'], delete: ['orgId', 'keyDateId'],
+};
+
+function actorFromAuth(auth: AuthContext): DeliverableActor {
+  return { userId: auth.user.id, partnerId: auth.partnerId ?? null, accessibleOrgIds: auth.accessibleOrgIds };
+}
+function serviceErrorToJson(err: unknown): string | null {
+  if (err instanceof DeliverableServiceError) {
+    return JSON.stringify({ error: err.message, code: err.code, ...(err.details ? { details: err.details } : {}) });
+  }
+  return null;
+}
+const asJson = (err: unknown): string => {
+  const json = serviceErrorToJson(err) ?? zodErrorToJson(err);
+  if (json) return json;
+  throw err;
+};
+
+export function registerDeliverableTools(aiTools: Map<string, AiTool>): void {
+  aiTools.set('list_deliverables', {
+    tier: 2 as AiToolTier, deviceArgs: [],
+    definition: {
+      name: 'list_deliverables',
+      description: 'List service deliverables (scheduled recurring service obligations such as a monthly sign-in log review) for one organization, with cadence, next due date and last delivery. Read-only.',
+      input_schema: {
+        type: 'object' as const,
+        properties: {
+          orgId: { type: 'string', description: 'Organization id (UUID)' },
+          contractId: { type: 'string', description: 'Only deliverables attached to this contract (UUID)' },
+          includeInactive: { type: 'boolean', description: 'Include deactivated deliverables (default false)' },
+          occurrencesFor: { type: 'string', description: 'Also return the recent occurrences of this deliverable id' },
+        },
+        required: ['orgId'],
+      },
+    },
+    handler: async (input, auth) => {
+      const actor = actorFromAuth(auth);
+      try {
+        const orgId = String(input.orgId);
+        const deliverables = await listDeliverables(orgId, {
+          contractId: input.contractId ? String(input.contractId) : undefined,
+          includeInactive: input.includeInactive === true,
+        }, actor);
+        const occurrences = input.occurrencesFor
+          ? await listOccurrences(orgId, String(input.occurrencesFor), { limit: 24 }, actor) : undefined;
+        return JSON.stringify({ deliverables, showing: deliverables.length, ...(occurrences ? { occurrences } : {}) });
+      } catch (err) { return asJson(err); }
+    },
+  });
+
+  aiTools.set('manage_deliverables', {
+    tier: 2 as AiToolTier, deviceArgs: [],
+    definition: {
+      name: 'manage_deliverables',
+      description: 'Create and manage service deliverables and their occurrences: create, update or deactivate a deliverable; deliver, waive, reopen or reschedule an occurrence; or link an existing report run as evidence.',
+      input_schema: {
+        type: 'object' as const,
+        properties: {
+          action: { type: 'string', enum: ['create','update','deactivate','deliver','waive','reopen','reschedule','link_evidence'] },
+          orgId: { type: 'string', description: 'Organization id (UUID)' },
+          deliverableId: { type: 'string' },
+          occurrenceId: { type: 'string' },
+          input: { type: 'object', description: 'Create payload (name, cadence, anchorDueDate, effectiveFrom, …)' },
+          patch: { type: 'object', description: 'Update payload' },
+          note: { type: 'string', description: 'Delivery note (deliver)' },
+          reason: { type: 'string', description: 'Waiver reason (waive)' },
+          dueAt: { type: 'string', description: 'New due date, YYYY-MM-DD (reschedule)' },
+          reportRunId: { type: 'string', description: 'Report run to attach as evidence (link_evidence)' },
+        },
+        required: ['action'],
+      },
+    },
+    handler: async (input, auth) => {
+      const actor = actorFromAuth(auth);
+      const action = String(input.action);
+      const required = MANAGE_DELIVERABLES_REQUIRED[action];
+      if (!required) return JSON.stringify({ error: `Unknown action: ${action}`, code: 'VALIDATION_ERROR' });
+      const missing = missingParamsJson(input, action, required);
+      if (missing) return missing;
+      const orgId = String(input.orgId);
+      try {
+        switch (action) {
+          case 'create':        return JSON.stringify(await createDeliverable(orgId, input.input as never, actor));
+          case 'update':        return JSON.stringify(await updateDeliverable(orgId, String(input.deliverableId), input.patch as never, actor));
+          case 'deactivate':    await deactivateDeliverable(orgId, String(input.deliverableId), actor); return JSON.stringify({ ok: true });
+          case 'deliver':       return JSON.stringify(await deliverOccurrence(orgId, String(input.occurrenceId), { note: input.note ? String(input.note) : undefined }, actor));
+          case 'waive':         return JSON.stringify(await waiveOccurrence(orgId, String(input.occurrenceId), { reason: String(input.reason) }, actor));
+          case 'reopen':        return JSON.stringify(await reopenOccurrence(orgId, String(input.occurrenceId), actor));
+          case 'reschedule':    return JSON.stringify(await rescheduleOccurrence(orgId, String(input.occurrenceId), { dueAt: String(input.dueAt) }, actor));
+          case 'link_evidence': return JSON.stringify(await addEvidence(orgId, String(input.occurrenceId), { kind: 'report_run', reportRunId: String(input.reportRunId) }, actor));
+          default:              return JSON.stringify({ error: `Unknown action: ${action}`, code: 'VALIDATION_ERROR' });
+        }
+      } catch (err) { return asJson(err); }
+    },
+  });
+
+  aiTools.set('manage_key_dates', {
+    tier: 2 as AiToolTier, deviceArgs: [],
+    definition: {
+      name: 'manage_key_dates',
+      description: 'List, create, update or delete organization key dates (insurance renewals, vendor contract ends, compliance deadlines). Listing also returns upcoming contract end dates.',
+      input_schema: {
+        type: 'object' as const,
+        properties: {
+          action: { type: 'string', enum: ['list', 'create', 'update', 'delete'] },
+          orgId: { type: 'string', description: 'Organization id (UUID)' },
+          keyDateId: { type: 'string' },
+          input: { type: 'object', description: 'Create payload (label, kind, date, recursAnnually, remindDaysBefore, …)' },
+          patch: { type: 'object', description: 'Update payload' },
+        },
+        required: ['action', 'orgId'],
+      },
+    },
+    handler: async (input, auth) => {
+      const actor = actorFromAuth(auth);
+      const action = String(input.action);
+      const required = MANAGE_KEY_DATES_REQUIRED[action];
+      if (!required) return JSON.stringify({ error: `Unknown action: ${action}`, code: 'VALIDATION_ERROR' });
+      const missing = missingParamsJson(input, action, required);
+      if (missing) return missing;
+      const orgId = String(input.orgId);
+      try {
+        switch (action) {
+          case 'list':   return JSON.stringify({ keyDates: await listKeyDates(orgId, actor, { includeContractEnds: true }) });
+          case 'create': return JSON.stringify(await createKeyDate(orgId, input.input as never, actor));
+          case 'update': return JSON.stringify(await updateKeyDate(orgId, String(input.keyDateId), input.patch as never, actor));
+          case 'delete': await deleteKeyDate(orgId, String(input.keyDateId), actor); return JSON.stringify({ ok: true });
+          default:       return JSON.stringify({ error: `Unknown action: ${action}`, code: 'VALIDATION_ERROR' });
+        }
+      } catch (err) { return asJson(err); }
+    },
+  });
+}
+```
+
+- [ ] **Step 4: Wire the other three registration sites**
+
+**Site 1** — `aiTools.ts`: add `import { registerDeliverableTools } from './aiToolsDeliverables';` beside line 80's contract import, and `registerDeliverableTools(aiTools);` beside line 294's `registerContractTools(aiTools);`.
+
+**Site 2** — `aiToolSchemas.ts`, after the `manage_contracts` entry:
+
+```ts
+  list_deliverables: z.object({
+    orgId: uuid, contractId: uuid.optional(), includeInactive: z.boolean().optional(), occurrencesFor: uuid.optional(),
+  }),
+  manage_deliverables: z.object({
+    action: z.enum(['create','update','deactivate','deliver','waive','reopen','reschedule','link_evidence']),
+    orgId: uuid.optional(), deliverableId: uuid.optional(), occurrenceId: uuid.optional(),
+    input: z.record(z.string(), z.unknown()).optional(), patch: z.record(z.string(), z.unknown()).optional(),
+    note: z.string().max(4000).optional(), reason: z.string().max(2000).optional(),
+    dueAt: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(), reportRunId: uuid.optional(),
+  }),
+  manage_key_dates: z.object({
+    action: z.enum(['list', 'create', 'update', 'delete']),
+    orgId: uuid, keyDateId: uuid.optional(),
+    input: z.record(z.string(), z.unknown()).optional(), patch: z.record(z.string(), z.unknown()).optional(),
+  }),
+```
+
+**Site 3** — `aiAgentSdkTools.ts`: add to `TOOL_TIERS` after `manage_contracts: 2,` (line 287):
+
+```ts
+  list_deliverables: 2,
+  manage_deliverables: 2,       // no action escalates: apply_template is W05
+  manage_key_dates: 2,
+```
+
+and three `tool('<name>', '<the same description>', { …the same zod shape as site 2… }, makeHandler('<name>', getAuth, onPreToolUse, onPostToolUse))` blocks after the `manage_contracts` block (line 2547).
+
+**Site 4** — `aiGuardrails.ts`, after the `manage_contracts` block:
+
+```ts
+  list_deliverables: { resource: 'contracts', action: 'read' },
+  manage_deliverables: {
+    create: { resource: 'contracts', action: 'write' },
+    update: { resource: 'contracts', action: 'write' },
+    deactivate: { resource: 'contracts', action: 'write' },
+    deliver: { resource: 'contracts', action: 'write' },
+    waive: { resource: 'contracts', action: 'write' },
+    reopen: { resource: 'contracts', action: 'write' },
+    reschedule: { resource: 'contracts', action: 'write' },
+    link_evidence: { resource: 'contracts', action: 'write' },
+  },
+  manage_key_dates: {
+    list: { resource: 'contracts', action: 'read' },
+    create: { resource: 'contracts', action: 'write' },
+    update: { resource: 'contracts', action: 'write' },
+    delete: { resource: 'contracts', action: 'write' },
+  },
+```
+
+`contracts` is used, not a new `documents` resource, because W01's REST routes for deliverables **and key dates** already gate on `contracts:read` / `contracts:write` (W01 Task 10). The spec's `documents` resource arrives with `org_documents` in W03; splitting key dates off now would make the AI door disagree with the HTTP door.
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `cd apps/api && npx vitest run src/services/aiToolsDeliverables.test.ts src/services/aiToolsRegistryParity.test.ts src/services/aiAgentSdkTools.registryParity.contract.test.ts && npx tsc --noEmit`
+Expected: PASS. `aiToolsRegistryParity.test.ts` has deliberately empty exemption sets — a missing zod schema or permission entry fails it.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/services/aiToolsDeliverables.ts apps/api/src/services/aiToolsDeliverables.test.ts apps/api/src/services/aiTools.ts apps/api/src/services/aiToolSchemas.ts apps/api/src/services/aiAgentSdkTools.ts apps/api/src/services/aiGuardrails.ts
+git commit -m "feat(deliverables): MCP tools for deliverables, occurrences and key dates (W02)"
+```
+
+---
+
+### Task 10: Integration suite on real Postgres
+
+**Files:**
+- Create: `apps/api/src/__tests__/integration/deliverableSweep.integration.test.ts`
+
+Placement matters: `src/__tests__/integration/**/*.test.ts` is the wholesale glob of `vitest.integration.config.ts:11`. Anywhere else and the suite runs in **zero** CI jobs. Header pattern to follow — `aiAgentTicketTriage.integration.test.ts:35-70`: `import './setup'`, `getTestDb`, `createPartner`/`createOrganization`/`createUser` from `./db-utils`, and a hoisted spy replacing `publishEvent` so nothing needs a live stream consumer.
+
+- [ ] **Step 1: Write the tests**
+
+Ten cases, each proving something a mocked suite structurally cannot:
+
+1. **Materialize → open.** Seed partner + org + a `monthly` deliverable anchored inside the lead window, with a `ticket_categories` row that **has** both SLA minutes set (otherwise the null assertion below is vacuous). Run `runDeliverableSweep(new Date('<today>'))`. Assert one occurrence `status='open'` with a non-null `ticket_id`; the ticket has `work_kind='deliverable'`, `source='api'`, `response_sla_minutes IS NULL`, `resolution_sla_minutes IS NULL`, and `due_date` equal to `due_at`.
+2. **Real `ticket.status_changed` → `awaiting_evidence` → `delivered`.** `changeTicketStatus(ticketId, 'resolved', actor, { resolutionNote: 'Reviewed, no findings' })`, then `handleDeliverableTicketStatusChanged` with the real outbox payload `{ ticketId, from: 'open', to: 'resolved' }`. Assert `awaiting_evidence` (artifact required, no evidence). Then `addEvidence(...)` with a real report + run of the same org; assert `status='delivered'`, `delivered_via='ticket'`, `delivery_note='Reviewed, no findings'`, `delivered_by_user_id` = the resolving user.
+3. **Miss after grace.** Occurrence `open` with `due_at = today − grace_days − 1`. Sweep. Assert `status='missed'` and `ticket_id` **unchanged**.
+4. **Idempotent re-run.** Sweep twice with the same `asOf`. Assert occurrence count, ticket count for the org, and `ticket_id` all identical after the second run.
+5. **Downtime catch-up.** Deliverable anchored 20 months ago, no occurrences. Sweep once. Assert exactly 12 rows (the cap), the oldest `status='missed'`, and **zero** tickets for any `missed` row.
+6. **Service Management `off`.** Set `partners.service_management_mode='off'`, sweep. Assert the occurrence is `open` with `ticket_id IS NULL` and no ticket row exists.
+7. **Cancelled-contract hook.** Create a contract, attach a deliverable with `effective_until IS NULL`, `cancelContract(...)`, then call `applyContractCancelledToDeliverables(contractId, today)` (the worker's job body). Assert `effective_until = today`. Flip the contract back to `active`, call again, assert nothing changes (replay safety).
+8. **Auto-evidence generated once.** Seed a `reports` row of the org with `execution_scope_principal_kind='user'`, `execution_scope_user_id` = a real user with org access, `execution_scope_kind='unrestricted'`. Point `auto_evidence_report_id` at it and sweep on the due date. Assert exactly one `report_runs` row with `requested_by_kind='system'`, both requester ids NULL, `status='completed'`; exactly one `service_deliverable_evidence` row `kind='report_run'` with `report_id` and `report_run_id` set; exactly one `ticket_comments` row whose content is `Report attached, review and resolve`. Sweep again; assert all three counts are still 1.
+9. **Key-date reminder once + annual roll-forward.** Key date with `remind_days_before=60`, `recurs_annually=true`, `date = today + 30 days`. Sweep twice. Assert exactly one reminder ticket (`work_kind='deliverable'`, subject starts `Key date:`) and `reminded_for_date = date`. Then set `date = today − 1 day`, run `rollForwardAnnualKeyDates(today)`: assert `date` advanced exactly one year and both `reminded_for_date` and `reminder_ticket_id` are NULL.
+10. **Move-org refusal, with a positive control.** With case 1's occurrence linked, `moveTicketOrg(ticketId, otherOrgInSamePartner, actor)` rejects with `{ status: 409, code: 'DELIVERABLE_TICKET_PINNED' }`. Then null the occurrence's `ticket_id` and assert the same move **succeeds** — without the second half, a guard that always throws would pass.
+
+- [ ] **Step 2: Run**
+
+Run: `pnpm test-stack up` (repo root, once), then
+`cd apps/api && npx vitest run --config vitest.integration.config.ts src/__tests__/integration/deliverableSweep.integration.test.ts`
+Expected: PASS. **Confirm the reported count is 10.** A `0 tests` line is a stall, not green.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/__tests__/integration/deliverableSweep.integration.test.ts
+git commit -m "test(deliverables): real-Postgres sweep, subscriber and auto-evidence suite (W02)"
+```
+
+---
+
+### Task 11: Wave verification and PR
+
+- [ ] **Step 1: Full API unit run** — `cd apps/api && npx vitest run` → green. Watch `ticketService.test.ts` (the `insertValues` shape changed) and any suite asserting the AI tool count.
+- [ ] **Step 2: Contract suites** — `cd apps/api && npx vitest run src/jobs/scheduleRegistry.contract.test.ts src/jobs/workerReadinessCoverage.test.ts src/jobs/workerReadinessManifest.test.ts src/services/workerEntrypointClosure.contract.test.ts src/services/eventSubscribers.contract.test.ts src/services/aiToolsRegistryParity.test.ts src/services/aiAgentSdkTools.registryParity.contract.test.ts src/services/ticketOrgMoveLockOrder.test.ts` → green.
+- [ ] **Step 3: Integration suites** (test stack up) — `cd apps/api && npx vitest run --config vitest.integration.config.ts src/__tests__/integration/deliverableSweep.integration.test.ts src/__tests__/integration/serviceDeliverablesRls.integration.test.ts src/__tests__/integration/rls-coverage.integration.test.ts src/__tests__/integration/tenantCascade.integration.test.ts src/__tests__/integration/tenant-export-policy.integration.test.ts` → green. W02 adds no tables and no columns, so the three registration suites should be untouched — a failure there means a table or column crept in and the wave is mis-scoped.
+- [ ] **Step 4: Lint and typecheck** — `cd apps/api && npx tsc --noEmit`; `pnpm lint` at the repo root → clean.
+- [ ] **Step 5: Manual smoke** — `pnpm wt-stack up`; create a deliverable due tomorrow with `lead_days = 7`, call `runDeliverableSweep(new Date())`, confirm the ticket appears in the web ticket list with **no** SLA badge, resolve it with a note, confirm W01's occurrence drawer shows `awaiting_evidence`, attach a report run, confirm it flips to Delivered.
+- [ ] **Step 6: Tear down** — `pnpm test-stack down` and `pnpm wt-stack down`, then confirm nothing is left: `docker compose ls -a --format json | jq -r '.[] | select(.ConfigFiles|test("breeze")) | "\(.Name)\t\(.Status)"'`.
+- [ ] **Step 7: PR** with `Closes #<sub-issue#>`, links to the spec and W01, and three sections: **Scheduling** (the `18 5 * * *` slot, why it was free, the two worker names in the readiness manifest); **Ticket integration** (`work_kind` on create, the SLA bypass and matching SLA-worker predicate, the move-org 409, and why `service_deliverable_occurrences` is deliberately NOT in `TICKET_ORG_DENORMALIZED_TABLES`); **Auto-evidence authority** (that `ReportExecutionAuthority` was NOT widened, that the definition owner's live authority is re-resolved exactly as `reportScheduleWorker` does, and that `requested_by_kind='system'` with both requester ids NULL is what `report_runs_requested_by_shape_chk` requires). Run `/pr-review-toolkit:review-pr`; act only on confirmed, consequential findings. Enqueue with `gh pr merge <N>` on green. Never `--admin`.
+
+---
+
+## Self-review
+
+**Spec coverage.** §5.1 job + cron + system context + automation-eligible predicate (Task 1); §5.2 eligibility by effective window, contract status ignored (Task 1); §5.3 step 1 materialize with cap 12 and direct-`missed` catch-up (Task 2); step 2 open + ticket via `createTicket` with `source='api'`, `work_kind='deliverable'`, `due_date`, `assigned_to`, `category_id`, SLA explicitly null, plus the `off`-mode fallback with one warning per org per day (Task 3); step 3 auto-evidence once per occurrence with the internal ticket note (Task 4); step 4 miss after grace, ticket untouched (Task 2); step 5 key-date reminders deduped by `(id, date)` and annual roll-forward (Task 5); §5.4 contract-cancelled hook (Task 7); §6 all four subscriber arms plus idempotency, and the move-org 409 (Tasks 6, 8); §4.8 `work_kind` consumers — SLA defaults and the SLA worker (Task 3); §10 MCP tools, ungated, `apply_template` excluded (Task 9); §12 sweep error handling (Tasks 1, 3); §13's sweep integration list, every bullet (Task 10). Out of scope by design: portal (W04), `org_documents` and the `document` evidence kind (W03), template sets (W05), the ticket-list `work_kind` filter (W04/W01 UI).
+
+**Placeholders.** None. Every step carries the code or the exact command. The five functions Task 1 imports before they exist are named stubs that Tasks 3–7 replace by body, never by name — the mechanism W01 used for its own four stubs.
+
+**Type consistency.** `SweepDeliverable` is declared once (Task 2) and consumed identically in Tasks 1, 3 and 4. `materializeOccurrences`, `openOccurrence`, `markOccurrenceMissed` and `applyTicketStatusChange` keep W01's signatures character for character; the sweep-shaped siblings are new names (`openDueOccurrencesForDeliverable`, `markDueOccurrencesMissedForDeliverable`) rather than changed signatures. `AutoEvidenceOutcome`'s reason union is the same set in the type, the tests and the implementation.
+
+**Three spec ambiguities resolved.**
+
+1. **"The existing `contract.cancelled` consumer" does not exist.** `emitContractEvent` (`services/contractEvents.ts:31`) publishes to `contract-events`, whose own header (lines 5-9) calls it "an intentionally-unconsumed RESERVED bus … nothing reads them yet". W02 therefore *creates* the first consumer and corrects that header. Because the queue holds an unprocessed backlog, the handler re-reads the contract and applies nothing unless it is still `cancelled` — which also makes a reversed cancellation safe. `cancelContract` (`contractService.ts:1690-1698`) stores no cancellation timestamp, so `effective_until` is the date the event is **processed**.
+
+2. **The spec's partner-timezone "today" does not match the sweep it cites.** §4 says today is "computed in the partner's configured timezone … exactly as the billing sweep does". The billing sweep does `asOf.toISOString().slice(0, 10)` (`contractWorker.ts:48`) and `contractMath.ts` exports no timezone helper. This plan pins UTC and says so, rather than inventing a helper the spec believes exists.
+
+3. **A system principal cannot execute a report.** §5.3 step 3 says to generate the run "through the existing report runner (`requested_by_kind = 'system'`, added to the enum if absent)". There is no shared runner — create/generate/finalize is inlined at three sites — and `ReportExecutionAuthority` (`siteScope.ts:64-96`) deliberately excludes the system principal, with `assertExecutableAuthority` ending in `const exhaustive: never`. `requested_by_kind='system'` already exists, but its CHECK arm requires both requester ids NULL. Resolution: Task 4 reproduces `reportScheduleWorker`'s reauthorization sequence for **execution** scope and stamps **requester** as `system` with both ids NULL. Nothing in the authority union is widened. The two column families answer different questions — who could see the data, and who asked — and conflating them is exactly what the `siteScope.ts:84-90` docstring warns against.
+
+**One deliberate addition beyond the spec**, flagged rather than buried: Task 3 pre-resolves `owner_user_id` and `ticket_category_id` against the org's partner and drops whichever no longer matches, with a warning. Without it, a technician leaving the partner makes `createTicket` throw `ASSIGNEE_WRONG_PARTNER` on every run and stalls that deliverable permanently and silently — a defect class the spec does not consider. Failing and retrying daily forever is strictly worse, and dropping a stale assignee is what the MSP would do by hand.

--- a/docs/superpowers/plans/billing/2026-09-10-service-deliverables-w03-org-documents.md
+++ b/docs/superpowers/plans/billing/2026-09-10-service-deliverables-w03-org-documents.md
@@ -1,0 +1,1749 @@
+---
+tracking_issue: LanternOps/breeze#5573
+---
+# Service Deliverables W03: Org Documents Library, Blob Storage Extraction, Document Evidence — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give every organization a real document library — bytes, versions, portal flag, soft delete, GDPR erasure — extract the ticket-attachment byte helper into a generic one so both surfaces share it, and let a service-deliverable occurrence take an uploaded or linked document as evidence.
+
+**Architecture:** One idempotent DDL migration creates `org_documents` (RLS shape 1, direct `org_id`) plus the composite FK that lets `service_deliverable_evidence.document_id` point at it; a second migration seeds the new `documents` permission and grants it to the existing admin/technician roles. `services/ticketAttachmentStorage.ts` is split: the backend-selection, put/get/delete primitives move into a generic `services/blobStorage.ts` that takes the key prefix as a parameter, and the ticket module becomes a thin re-exporting wrapper so its existing tests keep pinning the same behaviour. `services/orgDocumentService.ts` is the only writer; `routes/orgDocuments.ts` is thin and multipart-aware. The org-erasure S3 pre-clear in `tenantCascade.ts` widens from one table to both, in a single read, so no customer bytes are ever orphaned. The web gains an org-record Documents tab and a file-upload evidence option on the W01 occurrence drawer; the AI gains metadata-only document tools.
+
+**Tech Stack:** PostgreSQL + hand-written SQL migrations, Drizzle ORM, Hono + Zod (`@breeze/shared` validators), S3-compatible object storage (DigitalOcean Spaces) with a `bytea` fallback, Vitest (API unit with Drizzle mocks; API integration on real Postgres), Astro + React islands, react-i18next, Testing Library.
+
+**Spec:** `docs/superpowers/specs/billing/2026-09-10-service-deliverables-portal-design.md` (approved 2026-09-10). This wave is spec §4.4, the `document` arm of §4.3, the §4.9 registrations including the S3 erasure pre-clear, §7 upload-on-deliver, §9 org-record Documents tab, §10 documents REST + `documents` permission + document MCP tools, §12 upload errors, §13 document tests. Wave table row W03.
+
+**Depends on:** W01 (`docs/superpowers/plans/billing/2026-09-10-service-deliverables-w01-schema-core.md`). W03 reuses its names verbatim: `DeliverableActor`, `DeliverableServiceError`, `EvidenceRef`, `evidenceRefSchema`, `addEvidence`, `deliverOccurrence`, `OccurrenceView`, `Fetcher`, the `deliverables` i18n namespace, `orgRecordTabs.ts`. Do not rename any of them.
+
+## Global Constraints
+
+- **Tenancy shape 1.** `org_documents` carries a direct `org_id`; RLS enabled + forced + the four `breeze_has_org_access(org_id)` policies in the creating migration, copied verbatim from `apps/api/migrations/2026-06-21-contracts-auto-renew.sql:16-30` (its `contract_renewal_notices` block). Never deferred to a later migration.
+- **Every composite FK that references an `org_id` column is `DEFERRABLE INITIALLY IMMEDIATE`** — the org-merge contract (`SET CONSTRAINTS ALL DEFERRED`). That is both `org_documents`' self-FK and `sd_evidence_document_org_fk`.
+- **Migrations are idempotent** (`CREATE TABLE IF NOT EXISTS`, `DO $$ … EXCEPTION WHEN duplicate_object`), carry no inner `BEGIN;`/`COMMIT;`, and any file that writes rows starts with `SELECT set_config('breeze.scope', 'system', true);`. `2026-10-15-170300-org-documents.sql` is DDL only and needs no scope election; `2026-10-15-170400-documents-permissions.sql` writes rows and MUST have it as its first statement.
+- **Migration filenames sort after the newest committed migration.** As of 2026-09-10 that is `2026-10-15-160010-backup-snapshots-layout-manifest.sql`; W01 claims `-170000-`, `-170100-`, `-170200-`; W03 claims `-170300-` and `-170400-`. W02 and W05 must not claim those two slots. Re-check with `ls apps/api/migrations | sort | tail -1` before every commit and rename upward if a sibling branch landed something later.
+- **Registration is part of the same PR, not a follow-up.** `org_documents` has an `org_id` column, so it goes into `CORE_ORG_CASCADE_DELETE_ORDER` (`apps/api/src/services/tenantCascade.ts:228`), `CORE_TENANT_EXPORT_POLICY` (`apps/api/src/services/tenantExportPolicyRegistry.ts:41`) and `REPOINT_TABLES` (`apps/api/src/services/orgMergeRegistry.ts:517`). It has no `device_id`, so no device cascade list applies.
+- **Org access in services: `actor.accessibleOrgIds !== null && !actor.accessibleOrgIds.includes(orgId)` ⇒ 404 `NOT_FOUND`, never 403** (spec §12: "Evidence link to a document or report run of another org → 404, never 403"). Note that `apps/api/src/services/contractService.ts:56` throws 403 `ORG_DENIED`; do **not** copy that literally — W01's Global Constraints already override it for this feature.
+- **Two schema-import facts W01's plan gets wrong; use these.** `organizations` is exported from `apps/api/src/db/schema/orgs.ts` (not `./organizations`), and the `bytea` custom column type from `apps/api/src/db/schema/users.ts:9`. Both confirmed against `apps/api/src/db/schema/ticketAttachments.ts:1-5`.
+- **No presigned URLs, ever.** Document bytes stream through the API under RLS, with `Content-Disposition` built by `contentDispositionFor` (`apps/api/src/routes/tickets/attachments.ts:262`). Precedent for importing that helper across routers: `apps/api/src/routes/portal/tickets.ts:32`.
+- **Size cap and MIME allowlist are the ticket-attachment ones.** `TICKET_ATTACHMENT_LIMITS.maxBytes` = 10 MiB (`packages/shared/src/constants/ticketAttachments.ts:7-12`) and `sniffAttachmentMime` (`apps/api/src/services/attachmentSniff.ts:13`), which magic-byte sniffs JPEG/PNG/WebP/PDF and NEVER consults the client's `Content-Type`. Broadening the allowlist for CSV/JSON/ZIP exports is a follow-up issue, not this wave.
+- **Web mutations go through `runAction`** (`apps/web/src/lib/runAction.ts`). Org-record requests use the record's branded `orgFetch` (`apps/web/src/components/organizations/record/orgRecordFetch.ts:22-30`), never ambient `fetchWithAuth`.
+- **i18n in all 8 locales with real translations**: `apps/web/src/locales/{en,de-DE,es-419,fr-CA,fr-FR,it-IT,pt-BR,tr-TR}/`. `apps/web/src/lib/i18n/translationCoverage.test.ts` caps exact-English duplicates; consult `apps/web/src/locales/TERMINOLOGY.md`.
+- **Run one test file as `cd apps/api && npx vitest run <path>`** (never `pnpm … test -- --run <path>` — pnpm forwards the `--` and vitest runs the whole suite in watch mode).
+- Branch: `feature/<parent#>-service-deliverables/wave-<W03 sub-issue#>`; PR body carries `Closes #<W03 sub-issue>`.
+
+---
+
+## File structure
+
+| Path | Responsibility |
+|---|---|
+| `apps/api/migrations/2026-10-15-170300-org-documents.sql` | `org_document_category` enum, `org_documents` table, RLS, evidence→document composite FK |
+| `apps/api/migrations/2026-10-15-170400-documents-permissions.sql` | seed `documents:read` / `documents:write` rows and grant them to existing system roles |
+| `apps/api/src/db/schema/orgDocuments.ts` | Drizzle table + enum + `ORG_DOCUMENT_META_COLUMNS` |
+| `apps/api/src/db/schema/index.ts` | export the new module |
+| `apps/api/src/services/blobStorage.ts` (+ `.test.ts`) | generic, prefix-parameterised byte lifecycle |
+| `apps/api/src/services/ticketAttachmentStorage.ts` | thin wrapper over `blobStorage`, prefix `ticket-attachments` |
+| `apps/api/src/services/tenantCascade.ts` | erasure object pre-clear widened to `org_documents`; cascade registration |
+| `apps/api/src/services/tenantExportPolicyRegistry.ts`, `orgMergeRegistry.ts` | registrations |
+| `apps/api/src/services/orgDocumentService.ts` (+ `.test.ts`) | the only writer for `org_documents` |
+| `apps/api/src/services/serviceDeliverableService.ts` | `document` arm in `addEvidence` / `deliverOccurrence` |
+| `apps/api/src/services/aiToolsDeliverables.ts` | `list_org_documents`, `manage_org_documents` |
+| `packages/shared/src/constants/permissions.ts` | `DOCUMENTS_READ`, `DOCUMENTS_WRITE` |
+| `packages/shared/src/validators/serviceDeliverables.ts` | widen `evidenceRefSchema` with the `document` arm |
+| `packages/shared/src/validators/orgDocuments.ts` (+ `.test.ts`) | Zod schemas for the documents API |
+| `apps/api/src/routes/orgDocuments.ts` (+ `.test.ts`) | `/orgs/:orgId/documents…` |
+| `apps/api/src/routes/serviceDeliverables.ts` | `POST …/occurrences/:oId/evidence/upload` |
+| `apps/api/src/index.ts` | mount `orgDocumentRoutes` |
+| `apps/api/src/db/seed.ts` | `documents` permission rows + role grants |
+| `apps/api/src/__tests__/integration/orgDocumentsRls.integration.test.ts` | cross-org forge, chain integrity, evidence FK |
+| `apps/api/src/__tests__/integration/tenantExportErasureRoundtrip.integration.test.ts` | S3-backed document proves object-before-row |
+| `apps/web/src/lib/api/orgDocuments.ts` | typed fetch wrappers |
+| `apps/web/src/components/organizations/record/OrgDocumentsTab.tsx` (+ test) | the library UI |
+| `apps/web/src/components/organizations/record/orgRecordTabs.ts`, `OrganizationRecordPage.tsx` | wire the tab |
+| `apps/web/src/components/deliverables/OccurrenceDrawer.tsx` | file-upload evidence option |
+| `apps/web/src/locales/*/organizations.json`, `*/deliverables.json` | i18n |
+
+---
+
+### Task 1: Migration — `org_documents` and the evidence document FK
+
+**Files:**
+- Create: `apps/api/migrations/2026-10-15-170300-org-documents.sql`
+
+**Interfaces:**
+- Consumes: `service_deliverable_evidence` and its `document_id` column (W01 Task 1); `organizations`, `users`.
+- Produces: enum `org_document_category`; table `org_documents` with unique keys `org_documents_id_org_uq (id, org_id)` and `org_documents_supersedes_uq (supersedes_document_id)`; constraint `sd_evidence_document_org_fk` on `service_deliverable_evidence`.
+
+- [ ] **Step 1: Confirm the filename still sorts last**
+
+Run: `ls apps/api/migrations | sort | tail -1`
+Expected: a name that sorts BEFORE `2026-10-15-170300-org-documents.sql`. If W02 or W05 landed something at or after `-170300-`, bump this file (and Task 2's) to the next free slot and update every reference in this plan.
+
+- [ ] **Step 2: Write the migration**
+
+```sql
+-- org_documents — the organization document library (spec §4.4, D5/D7).
+-- Shape 1 (direct org_id). DDL only: no rows written, so no breeze.scope election.
+-- Bytes live in ONE of two places, chosen once at upload and never re-derived:
+-- an S3 object or inline bytea. Keys carry NO tenant identifier — the row is the
+-- authority, so an org merge re-stamps org_id on rows only and objects never move.
+-- Versioning is a backwards linked list: the NEW document points at the one it
+-- replaces. UNIQUE (supersedes_document_id) forbids branching and the service
+-- refuses to replace a non-head; together those make a cycle unconstructible.
+
+DO $$ BEGIN
+  CREATE TYPE org_document_category AS ENUM
+    ('baseline','runbook','policy','evidence','report','export','other');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE TABLE IF NOT EXISTS org_documents (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id UUID NOT NULL REFERENCES organizations(id),
+  title VARCHAR(200) NOT NULL,
+  description TEXT,
+  category org_document_category NOT NULL DEFAULT 'other',
+  storage_backend TEXT NOT NULL,
+  storage_key TEXT,
+  data BYTEA,
+  content_type VARCHAR(255) NOT NULL,
+  byte_size INTEGER NOT NULL,
+  sha256 CHAR(64) NOT NULL,
+  original_filename VARCHAR(255) NOT NULL,
+  uploaded_by_user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+  portal_visible BOOLEAN NOT NULL DEFAULT FALSE,
+  supersedes_document_id UUID,
+  deleted_at TIMESTAMPTZ,
+  deleted_by UUID REFERENCES users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+DO $$ BEGIN
+  ALTER TABLE org_documents ADD CONSTRAINT org_documents_backend_chk
+    CHECK (storage_backend IN ('s3','db'));
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+-- A LIVE row carries its bytes in exactly one place. A soft-deleted row is
+-- exempt: deleteDocument removes the object FIRST, then clears both pointers, so
+-- the tombstone keeps its metadata while the customer bytes are genuinely gone.
+DO $$ BEGIN
+  ALTER TABLE org_documents ADD CONSTRAINT org_documents_bytes_chk CHECK (
+    deleted_at IS NOT NULL
+    OR (storage_backend = 's3' AND storage_key IS NOT NULL AND data IS NULL)
+    OR (storage_backend = 'db' AND data IS NOT NULL AND storage_key IS NULL)
+  );
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE org_documents ADD CONSTRAINT org_documents_byte_size_chk
+    CHECK (byte_size > 0);
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE org_documents ADD CONSTRAINT org_documents_no_self_supersede_chk
+    CHECK (supersedes_document_id IS NULL OR supersedes_document_id <> id);
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+-- Composite self-FK: a document may only supersede one of the SAME org.
+-- DEFERRABLE INITIALLY IMMEDIATE — it references an org_id column, and the org
+-- merge re-points parent and child in separate statements (CLAUDE.md contract).
+CREATE UNIQUE INDEX IF NOT EXISTS org_documents_id_org_uq ON org_documents (id, org_id);
+DO $$ BEGIN
+  ALTER TABLE org_documents ADD CONSTRAINT org_documents_supersedes_org_fk
+    FOREIGN KEY (supersedes_document_id, org_id) REFERENCES org_documents(id, org_id)
+    DEFERRABLE INITIALLY IMMEDIATE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+-- One successor per document: the chain is a list, never a tree.
+CREATE UNIQUE INDEX IF NOT EXISTS org_documents_supersedes_uq
+  ON org_documents (supersedes_document_id) WHERE supersedes_document_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS org_documents_org_category_idx ON org_documents (org_id, category);
+CREATE INDEX IF NOT EXISTS org_documents_org_created_idx ON org_documents (org_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS org_documents_org_portal_idx
+  ON org_documents (org_id) WHERE portal_visible AND deleted_at IS NULL;
+
+ALTER TABLE org_documents ENABLE ROW LEVEL SECURITY;
+ALTER TABLE org_documents FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS breeze_org_isolation_select ON org_documents;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON org_documents;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON org_documents;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON org_documents;
+CREATE POLICY breeze_org_isolation_select ON org_documents
+  FOR SELECT USING (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_insert ON org_documents
+  FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_update ON org_documents
+  FOR UPDATE USING (public.breeze_has_org_access(org_id))
+  WITH CHECK (public.breeze_has_org_access(org_id));
+CREATE POLICY breeze_org_isolation_delete ON org_documents
+  FOR DELETE USING (public.breeze_has_org_access(org_id));
+
+-- W01 created service_deliverable_evidence.document_id without an FK because
+-- org_documents did not exist yet (spec §4.3). Close it now.
+DO $$ BEGIN
+  ALTER TABLE service_deliverable_evidence ADD CONSTRAINT sd_evidence_document_org_fk
+    FOREIGN KEY (document_id, org_id) REFERENCES org_documents(id, org_id)
+    ON DELETE CASCADE DEFERRABLE INITIALLY IMMEDIATE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+```
+
+- [ ] **Step 3: Run the naming and RLS-scope guards**
+
+Run: `scripts/check-migration-naming.sh --against-ref origin/main && cd apps/api && npx vitest run src/db/autoMigrate.test.ts src/db/migrationRlsScope.test.ts`
+Expected: both PASS. `migrationRlsScope.test.ts` must not flag the new file — it writes no rows. If it does, you added DML; move it to Task 2's file.
+
+- [ ] **Step 4: Apply against the worktree test stack, twice**
+
+Run: `pnpm test-stack up` (once for the wave), then
+`cd apps/api && DATABASE_URL=$(grep DATABASE_URL .env.test | cut -d= -f2-) pnpm db:migrate && DATABASE_URL=$(grep DATABASE_URL .env.test | cut -d= -f2-) pnpm db:migrate`
+Expected: the second run is a clean no-op — no errors, no duplicate-object noise.
+
+- [ ] **Step 5: Forge a cross-tenant insert as `breeze_app`**
+
+Run: `docker exec -it $(docker ps --format '{{.Names}}' | grep postgres | head -1) psql -U breeze_app -d breeze -c "SELECT set_config('breeze.scope','organization',false); INSERT INTO org_documents (org_id,title,category,storage_backend,data,content_type,byte_size,sha256,original_filename) VALUES (gen_random_uuid(),'forge','other','db','\\x00','application/pdf',1,repeat('a',64),'f.pdf');"`
+Expected: `ERROR: new row violates row-level security policy for table "org_documents"`. A success here means the policies did not take; stop and fix before continuing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/migrations/2026-10-15-170300-org-documents.sql
+git commit -m "feat(documents): org_documents table with shape-1 RLS and evidence FK (W03)"
+```
+
+---
+
+### Task 2: `documents` permission — registry, seed, migration
+
+**Files:**
+- Create: `apps/api/migrations/2026-10-15-170400-documents-permissions.sql`
+- Modify: `packages/shared/src/constants/permissions.ts:82` (after `CONTRACTS_MANAGE`)
+- Modify: `apps/api/src/db/seed.ts:179` (permission catalogue) and `SYSTEM_ROLES` at `:280`
+
+**Interfaces:**
+- Produces: `PERMISSION_GRANTS.DOCUMENTS_READ = { resource: 'documents', action: 'read' }`, `DOCUMENTS_WRITE = { resource: 'documents', action: 'write' }`, re-exported to the API as `PERMISSIONS.DOCUMENTS_*` by `apps/api/src/services/permissions.ts:280` and to the web as `PermissionResource`/`PermissionAction` literals.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/shared/src/constants/permissions.test.ts` (create the file if absent):
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { PERMISSION_GRANTS } from './permissions';
+
+describe('documents permission (service deliverables W03)', () => {
+  it('declares read and write on the documents resource', () => {
+    expect(PERMISSION_GRANTS.DOCUMENTS_READ).toEqual({ resource: 'documents', action: 'read' });
+    expect(PERMISSION_GRANTS.DOCUMENTS_WRITE).toEqual({ resource: 'documents', action: 'write' });
+  });
+});
+```
+
+- [ ] **Step 2: Run it to watch it fail**
+
+Run: `cd packages/shared && npx vitest run src/constants/permissions.test.ts`
+Expected: FAIL — `PERMISSION_GRANTS.DOCUMENTS_READ` is undefined.
+
+- [ ] **Step 3: Add the grants**
+
+In `packages/shared/src/constants/permissions.ts`, directly after the `CONTRACTS_MANAGE` line:
+
+```ts
+  // Organization document library + key dates (service deliverables, spec §10).
+  // Deliberately NOT folded into `contracts`: a runbook or an onboarding
+  // baseline is org-record content that outlives any contract, and a partner
+  // may want a technician who can file documents without touching billing.
+  DOCUMENTS_READ: { resource: 'documents', action: 'read' },
+  DOCUMENTS_WRITE: { resource: 'documents', action: 'write' },
+```
+
+In `apps/api/src/db/seed.ts`, after the three `contracts` entries:
+
+```ts
+  // Organization documents (service deliverables W03)
+  { resource: 'documents', action: 'read', description: 'View the organization document library and download documents' },
+  { resource: 'documents', action: 'write', description: 'Upload, replace, edit, and delete organization documents' },
+```
+
+and add `'documents:read', 'documents:write'` to the `permissions` array of the `Partner Technician`, `Org Admin` and `Org Technician` entries of `SYSTEM_ROLES`. `Partner Admin` already holds `'*:*'`.
+
+- [ ] **Step 4: Write the seeding migration**
+
+```sql
+-- documents:read / documents:write (service deliverables W03, spec §10).
+--
+-- Grant predicate copies 2026-10-15-150500-accounting-dedicated-permissions.sql
+-- exactly: `is_system = TRUE` is the anti-forgery filter (roles created through
+-- routes/roles.ts are always is_system = FALSE), and there is NO `partner_id IS
+-- NULL` clause because system roles are cloned per partner, so a template-only
+-- grant would reach nobody on upgrade. Partner Admin holds '*:*' and needs no
+-- row; NO custom role gains either permission automatically.
+--
+-- permissions has NO UNIQUE constraint on (resource, action) — only a PK on id —
+-- so ON CONFLICT DO NOTHING has nothing to conflict against and would duplicate
+-- on every re-apply. Explicit existence checks instead.
+--
+-- Every write runs under system scope: unscoped, an INSERT either matches zero
+-- rows silently or aborts with 42501 (#4518).
+SELECT set_config('breeze.scope', 'system', true);
+
+DO $$
+DECLARE
+  n integer;
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM permissions WHERE resource = 'documents' AND action = 'read') THEN
+    INSERT INTO permissions (resource, action, description)
+    VALUES ('documents', 'read', 'View the organization document library and download documents');
+    GET DIAGNOSTICS n = ROW_COUNT;
+    IF n > 0 THEN RAISE WARNING 'seeded documents:read permission row'; END IF;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM permissions WHERE resource = 'documents' AND action = 'write') THEN
+    INSERT INTO permissions (resource, action, description)
+    VALUES ('documents', 'write', 'Upload, replace, edit, and delete organization documents');
+    GET DIAGNOSTICS n = ROW_COUNT;
+    IF n > 0 THEN RAISE WARNING 'seeded documents:write permission row'; END IF;
+  END IF;
+END $$;
+
+DO $$
+DECLARE
+  n integer;
+  v_perm uuid;
+  v_action text;
+  v_role text;
+BEGIN
+  FOREACH v_action IN ARRAY ARRAY['read','write'] LOOP
+    SELECT id INTO v_perm FROM permissions
+    WHERE resource = 'documents' AND action = v_action ORDER BY id LIMIT 1;
+
+    FOREACH v_role IN ARRAY ARRAY['Partner Technician','Org Admin','Org Technician'] LOOP
+      INSERT INTO role_permissions (role_id, permission_id)
+      SELECT r.id, v_perm
+      FROM roles r
+      WHERE r.name = v_role
+        AND r.is_system = TRUE
+        AND v_perm IS NOT NULL
+        AND NOT EXISTS (
+          SELECT 1 FROM role_permissions rp
+          WHERE rp.role_id = r.id AND rp.permission_id = v_perm
+        );
+      GET DIAGNOSTICS n = ROW_COUNT;
+      IF n > 0 THEN
+        RAISE WARNING 'granted documents:% to % existing % role(s)', v_action, n, v_role;
+      END IF;
+    END LOOP;
+  END LOOP;
+END $$;
+```
+
+- [ ] **Step 5: Run the tests and guards**
+
+Run: `cd packages/shared && npx vitest run src/constants/permissions.test.ts` → PASS.
+Run: `cd apps/api && npx vitest run src/db/seed.test.ts src/db/autoMigrate.test.ts src/db/migrationRlsScope.test.ts` → PASS. `migrationRlsScope.test.ts` must accept the new file because `set_config` is its first statement; if it fails, the `SELECT set_config(...)` line is missing or below a write.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/shared/src/constants/permissions.ts packages/shared/src/constants/permissions.test.ts apps/api/src/db/seed.ts apps/api/migrations/2026-10-15-170400-documents-permissions.sql
+git commit -m "feat(documents): documents:read/write permission, seeded and granted to admin and technician roles (W03)"
+```
+
+---
+
+### Task 3: Drizzle schema for `org_documents`
+
+**Files:**
+- Create: `apps/api/src/db/schema/orgDocuments.ts`
+- Modify: `apps/api/src/db/schema/index.ts:128` area (next to the contracts export)
+
+**Interfaces:**
+- Produces (exact export names used by Tasks 5–16): `orgDocumentCategoryEnum`, `orgDocuments`, `OrgDocumentRow`, `ORG_DOCUMENT_META_COLUMNS`.
+
+- [ ] **Step 1: Write the schema module**
+
+```ts
+import { sql } from 'drizzle-orm';
+import { pgTable, pgEnum, uuid, varchar, text, integer, char, boolean, timestamp, index, uniqueIndex } from 'drizzle-orm/pg-core';
+import { organizations } from './orgs';
+import { users, bytea } from './users';
+
+export const orgDocumentCategoryEnum = pgEnum('org_document_category', [
+  'baseline', 'runbook', 'policy', 'evidence', 'report', 'export', 'other',
+]);
+
+/**
+ * Organization document library (spec §4.4). Shape 1 (direct org_id).
+ *
+ * NEVER select `data` outside the content path — use ORG_DOCUMENT_META_COLUMNS.
+ * The composite self-FK on (supersedes_document_id, org_id) is declared in SQL
+ * only; Drizzle cannot express DEFERRABLE, so the single-column reference here
+ * exists for typing and for readers.
+ */
+export const orgDocuments = pgTable('org_documents', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  title: varchar('title', { length: 200 }).notNull(),
+  description: text('description'),
+  category: orgDocumentCategoryEnum('category').notNull().default('other'),
+  storageBackend: text('storage_backend').$type<'s3' | 'db'>().notNull(),
+  storageKey: text('storage_key'),
+  data: bytea('data'),
+  contentType: varchar('content_type', { length: 255 }).notNull(),
+  byteSize: integer('byte_size').notNull(),
+  sha256: char('sha256', { length: 64 }).notNull(),
+  originalFilename: varchar('original_filename', { length: 255 }).notNull(),
+  uploadedByUserId: uuid('uploaded_by_user_id').references(() => users.id, { onDelete: 'set null' }),
+  portalVisible: boolean('portal_visible').notNull().default(false),
+  supersedesDocumentId: uuid('supersedes_document_id'),
+  deletedAt: timestamp('deleted_at', { withTimezone: true }),
+  deletedBy: uuid('deleted_by').references(() => users.id, { onDelete: 'set null' }),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+}, (t) => [
+  uniqueIndex('org_documents_id_org_uq').on(t.id, t.orgId),
+  uniqueIndex('org_documents_supersedes_uq').on(t.supersedesDocumentId)
+    .where(sql`${t.supersedesDocumentId} IS NOT NULL`),
+  index('org_documents_org_category_idx').on(t.orgId, t.category),
+  index('org_documents_org_created_idx').on(t.orgId, t.createdAt),
+]);
+
+export type OrgDocumentRow = typeof orgDocuments.$inferSelect;
+/** Structurally identical to the `OrgDocumentCategory` in
+ *  packages/shared/src/validators/orgDocuments.ts (Task 7). API code imports the
+ *  SHARED one so the API and the web agree on a single definition; this alias
+ *  exists for schema-local typing. Keep the two enum member lists in step. */
+export type OrgDocumentCategory = (typeof orgDocumentCategoryEnum.enumValues)[number];
+
+/** Client-safe column subset. `data` and `storageKey` are server-only. */
+export const ORG_DOCUMENT_META_COLUMNS = {
+  id: orgDocuments.id,
+  orgId: orgDocuments.orgId,
+  title: orgDocuments.title,
+  description: orgDocuments.description,
+  category: orgDocuments.category,
+  contentType: orgDocuments.contentType,
+  byteSize: orgDocuments.byteSize,
+  sha256: orgDocuments.sha256,
+  originalFilename: orgDocuments.originalFilename,
+  uploadedByUserId: orgDocuments.uploadedByUserId,
+  portalVisible: orgDocuments.portalVisible,
+  supersedesDocumentId: orgDocuments.supersedesDocumentId,
+  createdAt: orgDocuments.createdAt,
+} as const;
+```
+
+- [ ] **Step 2: Export it**
+
+Add `export * from './orgDocuments';` to `apps/api/src/db/schema/index.ts` next to the `export * from './contracts';` line.
+
+- [ ] **Step 3: Typecheck and drift-check**
+
+Run: `cd apps/api && npx tsc --noEmit -p tsconfig.json && DATABASE_URL=$(grep DATABASE_URL .env.test | cut -d= -f2-) pnpm db:check-drift`
+Expected: no type errors; the drift check reports no differences for `org_documents`. (Note `db:check-drift` compares the Drizzle schema to the MIGRATIONS, not to the live DB — the partial-index `.where()` clauses are declared for readers and are not what the check enforces.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/db/schema/orgDocuments.ts apps/api/src/db/schema/index.ts
+git commit -m "feat(documents): drizzle schema for org_documents (W03)"
+```
+
+---
+
+### Task 4: Tenancy registrations — cascade, export policy, org merge
+
+**Files:**
+- Modify: `apps/api/src/services/tenantCascade.ts` (`CORE_ORG_CASCADE_DELETE_ORDER`, the `'onedrive_device_state'` / `'org_ticket_settings'` neighbours at :503)
+- Modify: `apps/api/src/services/tenantExportPolicyRegistry.ts:329-330` area
+- Modify: `apps/api/src/services/orgMergeRegistry.ts:701-702` (`REPOINT_TABLES`)
+
+**Interfaces:**
+- Consumes: the table from Task 1 and the column names from Task 3.
+- Produces: `org_documents` present in all three registries; `getOrgCascadeDeleteOrder()` still alphabetised.
+
+- [ ] **Step 1: Cascade list**
+
+Insert `'org_documents',` between `'onedrive_device_state',` and `'org_ticket_settings',` in `CORE_ORG_CASCADE_DELETE_ORDER`, with this comment:
+
+```ts
+  // org_documents (service deliverables W03). Alphabetical slot only: the list
+  // is STATIC and alphabetised (the contract test asserts exactly that), while
+  // the real delete order comes from topologicalCascadeOrder(), which reads FK
+  // edges from pg_catalog at run time. service_deliverable_evidence is an FK
+  // CHILD of org_documents (sd_evidence_document_org_fk), so the topological
+  // pass necessarily emits it FIRST — verified by the "topological order has all
+  // FK children appearing before their parents" case in
+  // tenantCascade.integration.test.ts. The self-FK on supersedes_document_id is
+  // ignored by that sort by design (one DELETE clears the whole org's rows).
+  'org_documents',
+```
+
+Verified with `node --eval "console.log('org_documents'.localeCompare('org_ticket_settings'))"` → `-1`, and `'onedrive_device_state'.localeCompare('org_documents')` → `-1`.
+
+- [ ] **Step 2: Export policy**
+
+Insert into `CORE_TENANT_EXPORT_POLICY` just before the `"org_ticket_settings"` entry:
+
+```ts
+  // org_documents (W03): `data` is bytea -> excludedOpen by the open-container
+  // rule. storage_key is an opaque `org-documents/<id>` path with no tenant
+  // identifier (precedent: ticket_attachments.storage_key, included). sha256 is
+  // a content digest — classified reviewedIncluded rather than included so the
+  // integrity value is explicitly signed off rather than passing on the
+  // technicality that "sha256" misses SUSPICIOUS_NAME_PARTS.
+  "org_documents": tablePolicy("org_id", {
+    included: ["id", "org_id", "title", "description", "category", "storage_backend", "storage_key", "content_type", "byte_size", "original_filename", "uploaded_by_user_id", "portal_visible", "supersedes_document_id", "deleted_at", "deleted_by", "created_at"],
+    reviewedIncluded: ["sha256"],
+    excludedSensitive: [],
+    excludedOpen: ["data"],
+  }),
+```
+
+Every column of the table must appear exactly once across the four arrays — `tablePolicy` throws on a duplicate, and `tenant-export-policy.integration.test.ts` throws on a column that is present in the live table but missing here.
+
+- [ ] **Step 3: Org merge registry**
+
+Insert `"org_documents",` between `"onedrive_device_state",` and `"organization_external_links",` in `REPOINT_TABLES` with:
+
+```ts
+  // Plain repoint, NOT repoint-dedupe: org_documents has no org-scoped unique
+  // key (two orgs may both hold "Firewall baseline"), so after a merge the
+  // survivor simply holds both libraries and there is nothing to drop. The
+  // supersedes chain is intra-org and its composite FK is deferrable, so it
+  // survives the re-point unchanged.
+  "org_documents",
+```
+
+- [ ] **Step 4: Run the standing contract suites**
+
+Run (test-stack up):
+```bash
+cd apps/api && npx vitest run --config vitest.integration.config.ts \
+  src/__tests__/integration/rls-coverage.integration.test.ts \
+  src/__tests__/integration/tenantCascade.integration.test.ts \
+  src/__tests__/integration/tenant-export-policy.integration.test.ts \
+  src/__tests__/integration/orgMergeRegistry.integration.test.ts \
+  src/__tests__/integration/orgLifecycleFoundations.integration.test.ts
+```
+Expected: all PASS. `rls-coverage` needs no allowlist entry — shape-1 tables are auto-discovered. A failure names the missing table or column; fix the registration, never the test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/tenantCascade.ts apps/api/src/services/tenantExportPolicyRegistry.ts apps/api/src/services/orgMergeRegistry.ts
+git commit -m "chore(tenancy): register org_documents in cascade, export policy and merge registry (W03)"
+```
+
+---
+
+### Task 5: Extract `services/blobStorage.ts`
+
+**Files:**
+- Create: `apps/api/src/services/blobStorage.ts`
+- Create: `apps/api/src/services/blobStorage.test.ts`
+- Modify: `apps/api/src/services/ticketAttachmentStorage.ts` (whole file → thin wrapper)
+
+**Interfaces:**
+- Consumes: `deleteObjects`, `getObjectStream`, `isS3Configured`, `putObjectBuffer` from `./s3Storage`.
+- Produces:
+
+```ts
+export class BlobStorageError extends Error { readonly code: 'STORAGE_UNAVAILABLE'; readonly status: 503 }
+export type BlobBackend = 's3' | 'db';
+export interface BlobBytesRow { storageBackend: BlobBackend; storageKey: string | null; data: Buffer | null }
+export function selectBackend(): BlobBackend;
+export function objectKeyFor(prefix: string, id: string): string;                     // `${prefix}/${id}`
+export function putBlob(args: { prefix: string; id: string; buffer: Buffer; contentType: string; sha256: string })
+  : Promise<{ backend: BlobBackend; storageKey: string | null; data: Buffer | null }>;
+export function getBlobStream(row: BlobBytesRow): Promise<{ body: Readable | Buffer | null; contentLength: number | null }>;
+export function deleteBlob(row: BlobBytesRow): Promise<void>;
+export function deleteBlobKeys(keys: readonly string[]): Promise<void>;
+```
+- Still produces, unchanged, from `ticketAttachmentStorage.ts`: `AttachmentStorageError`, `AttachmentBackend`, `AttachmentBytesRow`, `selectBackend`, `objectKeyFor`, `putBytes`, `openBytes`, `deleteBytes`, `deleteObjectKeys`.
+
+- [ ] **Step 1: Write the failing test for the generic helper**
+
+`apps/api/src/services/blobStorage.test.ts` is `ticketAttachmentStorage.test.ts:1-32` verbatim for the harness (the same `vi.mock('./s3Storage')` stub, the same `ORIGINAL_ENV` / `withS3()` helpers, the same `beforeEach`/`afterEach` env reset) with `describe('blobStorage (service deliverables W03)')`. Both files sit in `apps/api/src/services/`, so `'./s3Storage'` resolves to the same module id and the stub behaves identically. The cases:
+
+```ts
+  it('the key prefix is a parameter and the key carries no tenant identifier', async () => {
+    const { objectKeyFor } = await import('./blobStorage');
+    expect(objectKeyFor('org-documents', 'd-1')).toBe('org-documents/d-1');
+    expect(objectKeyFor('ticket-attachments', 'a-1')).toBe('ticket-attachments/a-1');
+  });
+
+  it('putBlob writes the object under the caller prefix on the s3 backend', async () => {
+    withS3();
+    const { putBlob } = await import('./blobStorage');
+    const res = await putBlob({ prefix: 'org-documents', id: 'd-2', buffer: Buffer.from('hi'), contentType: 'application/pdf', sha256: 'b'.repeat(64) });
+    expect(putObjectBuffer).toHaveBeenCalledWith('org-documents/d-2', expect.any(Buffer), 'application/pdf', 'b'.repeat(64));
+    expect(res).toEqual({ backend: 's3', storageKey: 'org-documents/d-2', data: null });
+  });
+
+  // THE headline assertion, carried over from the ticket module.
+  it('putBlob NEVER falls back to db when the s3 put fails — it throws STORAGE_UNAVAILABLE', async () => {
+    withS3();
+    putObjectBuffer.mockRejectedValueOnce(new Error('s3 down') as never);
+    const { putBlob, BlobStorageError } = await import('./blobStorage');
+    let thrown: unknown; let returned: unknown;
+    try {
+      returned = await putBlob({ prefix: 'org-documents', id: 'd-4', buffer: Buffer.from('hi'), contentType: 'application/pdf', sha256: 'd'.repeat(64) });
+    } catch (e) { thrown = e; }
+    expect(returned).toBeUndefined();
+    expect(thrown).toBeInstanceOf(BlobStorageError);
+    expect((thrown as InstanceType<typeof BlobStorageError>).status).toBe(503);
+    expect((thrown as InstanceType<typeof BlobStorageError>).code).toBe('STORAGE_UNAVAILABLE');
+  });
+
+  it('getBlobStream routes by row.storageBackend, never by whether storageKey happens to be set', async () => {
+    withS3();
+    const { getBlobStream } = await import('./blobStorage');
+    const res = await getBlobStream({ storageBackend: 'db', storageKey: 'org-documents/oops', data: Buffer.from('inline') });
+    expect(getObjectStream).not.toHaveBeenCalled();
+    expect(res.body).toBeInstanceOf(Buffer);
+    await getBlobStream({ storageBackend: 's3', storageKey: 'org-documents/k', data: null });
+    expect(getObjectStream).toHaveBeenCalledWith('org-documents/k');
+  });
+```
+
+Plus three cases ported unchanged except for the prefix argument, from `ticketAttachmentStorage.test.ts:34-41`, `:49-55` and `:101-117`: `selectBackend` is `s3` only when all three S3 env vars are set; `putBlob` on the `db` backend returns the buffer inline and never calls `putObjectBuffer`; `deleteBlob` is a no-op for a `db` row and `deleteBlobKeys` skips an empty list and forwards a non-empty one to `deleteObjects`.
+
+- [ ] **Step 2: Run it to watch it fail**
+
+Run: `cd apps/api && npx vitest run src/services/blobStorage.test.ts`
+Expected: FAIL — `Cannot find module './blobStorage'`.
+
+- [ ] **Step 3: Write `blobStorage.ts`**
+
+This is a MOVE, not a rewrite. Take `apps/api/src/services/ticketAttachmentStorage.ts:1-110` whole and apply exactly these edits; nothing else changes, so the behaviour the five existing test files pin cannot drift:
+
+1. Rename `AttachmentStorageError` → `BlobStorageError` (keep `readonly code = 'STORAGE_UNAVAILABLE' as const`, `readonly status = 503 as const`, and set `this.name = 'BlobStorageError'`), `AttachmentBackend` → `BlobBackend`, `AttachmentBytesRow` → `BlobBytesRow`.
+2. Rename `openBytes` → `getBlobStream`, `deleteBytes` → `deleteBlob`, `deleteObjectKeys` → `deleteBlobKeys`. Their bodies are unchanged.
+3. Change the two error messages from `'Attachment storage is unavailable'` to `'Blob storage is unavailable'`.
+4. Replace `objectKeyFor` and `putBytes` with the prefix-parameterised forms below. `putBlob` takes an args object rather than five positionals because the prefix would otherwise be a sixth unnamed string next to `contentType` and `sha256`.
+
+```ts
+/** Opaque object key — surface prefix plus row id, never an org/ticket id. */
+export function objectKeyFor(prefix: string, id: string): string {
+  return `${prefix}/${id}`;
+}
+
+/**
+ * Write the bytes for a not-yet-inserted row.
+ *
+ * Put-before-insert: a put failure leaves no row at all; the caller compensates
+ * an INSERT failure with `deleteBlob`. Throws `BlobStorageError` (503) when the
+ * S3 backend is selected and the put fails — it NEVER degrades to `db`.
+ */
+export async function putBlob(args: {
+  prefix: string; id: string; buffer: Buffer; contentType: string; sha256: string;
+}): Promise<{ backend: BlobBackend; storageKey: string | null; data: Buffer | null }> {
+  const backend = selectBackend();
+  if (backend === 'db') return { backend, storageKey: null, data: args.buffer };
+  const storageKey = objectKeyFor(args.prefix, args.id);
+  try {
+    await putObjectBuffer(storageKey, args.buffer, args.contentType, args.sha256);
+  } catch (err) {
+    throw new BlobStorageError('Blob storage is unavailable', { cause: err });
+  }
+  return { backend, storageKey, data: null };
+}
+```
+
+5. Keep the module docstring from `ticketAttachmentStorage.ts:4-18` word for word — its three invariants (backend chosen once; never falls back from `s3` to `db`; keys carry no tenant identifier) are the reason the module exists — with one added sentence: "The `prefix` is the SURFACE (`ticket-attachments`, `org-documents`), never a tenant."
+
+- [ ] **Step 4: Rewrite `ticketAttachmentStorage.ts` as the wrapper**
+
+The whole file becomes bindings. Keep the module docstring, replacing its invariants with a pointer to `blobStorage.ts` and this note:
+
+> `AttachmentStorageError` is an ALIAS of `BlobStorageError`, not a subclass: one 503 fault type means `putBytes` can delegate without a rewrap, and every existing `instanceof AttachmentStorageError` check keeps matching. The only observable change is `err.name`, now `'BlobStorageError'`; which surface faulted is already carried by the route's own error code and Sentry breadcrumb.
+
+```ts
+import type { Readable } from 'node:stream';
+import {
+  deleteBlob, deleteBlobKeys, getBlobStream, objectKeyFor as blobObjectKeyFor, putBlob,
+  selectBackend as selectBlobBackend, type BlobBackend, type BlobBytesRow,
+} from './blobStorage';
+
+export { BlobStorageError as AttachmentStorageError, deleteBlobKeys as deleteObjectKeys } from './blobStorage';
+
+export type AttachmentBackend = BlobBackend;
+export type AttachmentBytesRow = BlobBytesRow;
+
+/** Ticket attachments' object-key namespace (spec D8). */
+export const TICKET_ATTACHMENT_PREFIX = 'ticket-attachments';
+
+export function selectBackend(): AttachmentBackend { return selectBlobBackend(); }
+
+export function objectKeyFor(attachmentId: string): string {
+  return blobObjectKeyFor(TICKET_ATTACHMENT_PREFIX, attachmentId);
+}
+
+export function putBytes(attachmentId: string, buf: Buffer, contentType: string, sha256: string) {
+  return putBlob({ prefix: TICKET_ATTACHMENT_PREFIX, id: attachmentId, buffer: buf, contentType, sha256 });
+}
+
+export function openBytes(row: AttachmentBytesRow): Promise<{ body: Readable | Buffer | null; contentLength: number | null }> {
+  return getBlobStream(row);
+}
+
+export function deleteBytes(row: AttachmentBytesRow): Promise<void> { return deleteBlob(row); }
+```
+
+- [ ] **Step 5: Prove the extraction changed no ticket behaviour**
+
+Run:
+```bash
+cd apps/api && npx vitest run \
+  src/services/blobStorage.test.ts \
+  src/services/ticketAttachmentStorage.test.ts \
+  src/routes/tickets/attachments.test.ts \
+  src/routes/portal/tickets.test.ts \
+  src/jobs/ticketAttachmentReaper.test.ts \
+  src/services/tenantCascade.test.ts
+```
+Expected: all PASS with **no edits to any of those five existing test files**. They are the contract: upload compensation, object-before-row deletion, 503 `STORAGE_UNAVAILABLE`, no presigned URLs, the reaper's `deleteObjectKeys` mock and `tenantCascade`'s `vi.mock('./ticketAttachmentStorage')`. If any of them needs a change here, the wrapper is not thin enough — fix the wrapper, not the test.
+
+Run: `cd apps/api && npx tsc --noEmit -p tsconfig.json` → clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/services/blobStorage.ts apps/api/src/services/blobStorage.test.ts apps/api/src/services/ticketAttachmentStorage.ts
+git commit -m "refactor(storage): extract generic blobStorage from ticketAttachmentStorage (W03)"
+```
+
+---
+
+### Task 6: Widen the erasure S3 pre-clear to `org_documents`
+
+**Files:**
+- Modify: `apps/api/src/services/tenantCascade.ts:1111-1150` (the `1a.` block)
+- Modify: `apps/api/src/services/tenantCascade.test.ts:451-515` (two named assertions)
+
+**Interfaces:**
+- Consumes: `deleteObjectKeys` from `./ticketAttachmentStorage` (line 50 — keep that import path: `tenantCascade.test.ts:92` mocks exactly that module).
+- Produces: a single pre-clear read covering both byte tables; failure step name `tenant_object_preclear`.
+
+- [ ] **Step 1: Update the failing assertions in the existing unit test first**
+
+In `apps/api/src/services/tenantCascade.test.ts`, in `'scopes the key read to this org and to s3-backed rows only'`, add after `expect(keyQuery).toContain('ticket_attachments');`:
+
+```ts
+    // W03: the pre-clear is ONE read over BOTH byte tables. A second query
+    // would double the deleteObjectKeys call and break the ordering assertion
+    // in the sibling test, so this is a union, not a second statement.
+    expect(keyQuery).toContain('org_documents');
+```
+
+and in `'ABORTS rerunnably on an object-store fault, leaving the rows and writing the failed audit'`, change the expected `failedTable` from `'ticket_attachments_objects'` to `'tenant_object_preclear'` — the step now covers two tables, so the old label would name only half of what failed.
+
+- [ ] **Step 2: Run to watch both fail**
+
+Run: `cd apps/api && npx vitest run src/services/tenantCascade.test.ts`
+Expected: exactly two failures — the missing `org_documents` substring and the `failedTable` mismatch. Any other failure means something else moved; stop and investigate.
+
+- [ ] **Step 3: Widen the pre-clear**
+
+Replace the body of the `1a.` block's `try` in `cascadeDeleteOrg` (the comment above it keeps its reasoning; extend it to name both tables):
+
+```ts
+  // 1a. Clear customer OBJECTS before ANY row is deleted anywhere (W08 #3902
+  //     spec D9; widened to org_documents by service deliverables W03 spec §4.9).
+  //     The rows are the ONLY index to the object keys — deleting them first
+  //     would leave customer bytes in the bucket with nothing left to find them
+  //     by, which is exactly the GDPR failure erasure exists to prevent. A
+  //     storage fault therefore ABORTS the erasure before anything is removed,
+  //     so the operator can re-run it once the bucket is back.
+  //
+  //     ONE read over both byte tables, not two: a second statement would mean a
+  //     second deleteObjectKeys batch and a second abort path, and the
+  //     object-deletes-before-first-DELETE ordering would stop being a single
+  //     observable step. db-backed rows carry their bytes in the row and need no
+  //     pre-clear; a soft-deleted org_documents row has already had its object
+  //     removed and its storage_key cleared, so it is excluded by the NOT NULL.
+  try {
+    const keys = await dbModule.withSystemDbAccessContext(async () => {
+      const result = await dbModule.db.execute(sql`
+        SELECT storage_key
+        FROM ticket_attachments
+        WHERE org_id = ${orgId}::uuid
+          AND storage_backend = 's3'
+          AND storage_key IS NOT NULL
+        UNION ALL
+        SELECT storage_key
+        FROM org_documents
+        WHERE org_id = ${orgId}::uuid
+          AND storage_backend = 's3'
+          AND storage_key IS NOT NULL
+      `);
+      const rows = (result as unknown as { rows?: Array<{ storage_key: string }> }).rows
+        ?? (result as unknown as Array<{ storage_key: string }>);
+      return Array.isArray(rows) ? rows.map((r) => r.storage_key).filter(Boolean) : [];
+    });
+    if (keys.length > 0) {
+      await deleteObjectKeys(keys);
+    }
+  } catch (err) {
+    if (!isUndefinedTable(err)) {
+      await writeErasureFailedAudit(
+        orgId, performedBy, performedByEmail, 'tenant_object_preclear', stats, err,
+      );
+      throw new Error(
+        `[tenantCascade] object pre-clear failed for org=${orgId}; erasure aborted before any row was deleted and is rerunnable: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+```
+
+The `isUndefinedTable` tolerance now covers both tables at once — acceptable because both ship in the same product and the guard exists only for partial-schema fixtures.
+
+- [ ] **Step 4: Run to watch them pass**
+
+Run: `cd apps/api && npx vitest run src/services/tenantCascade.test.ts src/services/tenantCascade.partner.test.ts`
+Expected: PASS, including the untouched `'reads the s3 keys and deletes the objects BEFORE the first cascade DELETE'` ordering case (still one select, one object-delete batch, then only deletes).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/tenantCascade.ts apps/api/src/services/tenantCascade.test.ts
+git commit -m "fix(tenancy): erasure object pre-clear covers org_documents as well as ticket attachments (W03)"
+```
+
+---
+
+### Task 7: `services/orgDocumentService.ts`
+
+**Files:**
+- Create: `apps/api/src/services/orgDocumentService.ts`
+- Create: `apps/api/src/services/orgDocumentService.test.ts`
+- Create: `packages/shared/src/validators/orgDocuments.ts` + `.test.ts`
+- Modify: `packages/shared/src/validators/index.ts` (export the new module)
+
+**Interfaces:**
+- Consumes: `DeliverableActor`, `DeliverableServiceError` from `./serviceDeliverableService` (W01 Task 8); `orgDocuments`, `ORG_DOCUMENT_META_COLUMNS` from Task 3; `putBlob`/`getBlobStream`/`deleteBlob`/`BlobStorageError` from `./blobStorage`; `sniffAttachmentMime` from `./attachmentSniff`; `TICKET_ATTACHMENT_LIMITS` from `@breeze/shared`.
+- Produces (Tasks 8–16 import these verbatim):
+
+```ts
+export const ORG_DOCUMENT_PREFIX = 'org-documents';
+export interface UploadFile { buffer: Buffer; contentType: string; filename: string }
+export interface OrgDocumentView {
+  id: string; orgId: string; title: string; description: string | null;
+  category: OrgDocumentCategory; contentType: string; byteSize: number; sha256: string;
+  originalFilename: string; uploadedByUserId: string | null; portalVisible: boolean;
+  supersedesDocumentId: string | null; supersededByDocumentId: string | null; createdAt: string;
+}
+export function listDocuments(orgId: string, q: { category?: OrgDocumentCategory; includeSuperseded?: boolean }, actor: DeliverableActor): Promise<OrgDocumentView[]>;
+export function getDocument(orgId: string, id: string, actor: DeliverableActor): Promise<OrgDocumentView>;
+export function uploadDocument(orgId: string, input: { title: string; description?: string | null; category: OrgDocumentCategory; portalVisible?: boolean; file: UploadFile }, actor: DeliverableActor): Promise<OrgDocumentView>;
+export function replaceDocument(orgId: string, id: string, input: { title?: string; description?: string | null; category?: OrgDocumentCategory; portalVisible?: boolean; file: UploadFile }, actor: DeliverableActor): Promise<OrgDocumentView>;
+export function updateDocument(orgId: string, id: string, patch: { title?: string; description?: string | null; category?: OrgDocumentCategory; portalVisible?: boolean }, actor: DeliverableActor): Promise<OrgDocumentView>;
+export function supersedeDocument(orgId: string, id: string, supersedesDocumentId: string, actor: DeliverableActor): Promise<OrgDocumentView>;
+export function deleteDocument(orgId: string, id: string, actor: DeliverableActor): Promise<void>;
+export function streamDocument(orgId: string, id: string, actor: DeliverableActor): Promise<{ view: OrgDocumentView; contentType: string; originalFilename: string; sha256: string; body: Readable | Buffer | null; contentLength: number | null }>;
+```
+
+Rules the service enforces (each has a test):
+
+- `requireOrgAccess(actor, orgId)` and every "row not in this org / soft-deleted" path → 404 `NOT_FOUND`, never 403.
+- Empty buffer → 400 `EMPTY_FILE`. Over `TICKET_ATTACHMENT_LIMITS.maxBytes` → 413 `FILE_TOO_LARGE`. `sniffAttachmentMime(buf)` returns null → 415 `UNSUPPORTED_DOCUMENT_TYPE`. The stored `content_type` is the SNIFFED one; the client's is never consulted.
+- `BlobStorageError` from `putBlob` → 503 `STORAGE_UNAVAILABLE` and **no row written**. An INSERT failure after a successful put compensates with `deleteBlob` in a `try/catch` that never masks the original error.
+- `replaceDocument` / `supersedeDocument`: the target must exist in the org, must not be soft-deleted, and must be a chain HEAD (no row already has `supersedes_document_id = target`) → otherwise 409 `NOT_HEAD`. The unique index is the DB backstop: a `23505` on insert also maps to 409 `NOT_HEAD`.
+- `supersedeDocument` additionally rejects `id === supersedesDocumentId` (400 `INVALID_SUPERSEDE`) and a document that already supersedes something (409 `ALREADY_SUPERSEDES`).
+- `listDocuments` returns chain HEADS only unless `includeSuperseded`, and never soft-deleted rows; ordered `createdAt DESC`.
+- `deleteDocument` is a soft delete that removes the bytes FIRST (`deleteBlob`, or clearing `data` for a `db` row), then stamps `deleted_at`/`deleted_by` and nulls `storage_key` and `data` in one UPDATE. A storage fault → 503 and nothing is stamped, so the delete is retryable.
+- `streamDocument` never selects `data` for an `s3` row and never returns a URL.
+
+- [ ] **Step 1: Write the shared validators**
+
+`packages/shared/src/validators/orgDocuments.ts`:
+
+```ts
+import { z } from 'zod';
+
+export const orgDocumentCategorySchema = z.enum([
+  'baseline', 'runbook', 'policy', 'evidence', 'report', 'export', 'other',
+]);
+
+/** Multipart text parts arrive as strings, so booleans are coerced from 'true'/'false'. */
+const boolFromForm = z.union([z.boolean(), z.enum(['true', 'false']).transform((v) => v === 'true')]);
+
+export const uploadDocumentMetaSchema = z.object({
+  title: z.string().min(1).max(200),
+  description: z.string().max(4000).nullable().optional(),
+  category: orgDocumentCategorySchema.default('other'),
+  portalVisible: boolFromForm.default(false),
+});
+
+/** Replace reuses the upload metadata, but every field is optional: omitted
+ *  fields are inherited from the document being replaced. */
+export const replaceDocumentMetaSchema = uploadDocumentMetaSchema.partial();
+
+export const updateDocumentSchema = z.object({
+  title: z.string().min(1).max(200).optional(),
+  description: z.string().max(4000).nullable().optional(),
+  category: orgDocumentCategorySchema.optional(),
+  portalVisible: z.boolean().optional(),
+}).strict().refine((p) => Object.keys(p).length > 0, { message: 'at least one field must be provided' });
+
+export const listDocumentsQuerySchema = z.object({
+  category: orgDocumentCategorySchema.optional(),
+  includeSuperseded: z.coerce.boolean().optional(),
+});
+
+export type OrgDocumentCategory = z.infer<typeof orgDocumentCategorySchema>;
+export type UploadDocumentMeta = z.infer<typeof uploadDocumentMetaSchema>;
+export type ReplaceDocumentMeta = z.infer<typeof replaceDocumentMetaSchema>;
+export type UpdateDocumentInput = z.infer<typeof updateDocumentSchema>;
+```
+
+Its test asserts: `portalVisible` defaults to `false` (fail closed), `'true'` coerces to `true`, a 201-character title fails, `updateDocumentSchema` rejects `{}` and rejects an unknown key.
+
+- [ ] **Step 2: Write the failing service tests**
+
+`apps/api/src/services/orgDocumentService.test.ts`, using the Drizzle mock pattern from the `breeze-testing` skill — the same `vi.hoisted` chainable `select/from/where/limit` stub W01 Task 8 uses for `serviceDeliverableService.test.ts`, plus:
+
+```ts
+const putBlob = vi.hoisted(() => vi.fn());
+const deleteBlob = vi.hoisted(() => vi.fn(async () => {}));
+vi.mock('./blobStorage', async () => {
+  const actual = await vi.importActual<typeof import('./blobStorage')>('./blobStorage');
+  return { ...actual, putBlob, deleteBlob };   // BlobStorageError stays real, so instanceof works
+});
+
+const actor = { userId: 'u1', partnerId: 'p1', accessibleOrgIds: ['org1'] };
+const pdf = Buffer.concat([Buffer.from('%PDF-'), Buffer.alloc(64, 1)]);
+const file = { buffer: pdf, contentType: 'text/html', filename: 'runbook.pdf' };   // lying client type
+```
+
+The discriminating cases, in full:
+
+```ts
+  it('stores the SNIFFED content type, never the client-supplied one', async () => {
+    state.rows.push([{ id: 'd1', orgId: 'org1', contentType: 'application/pdf' }]);
+    await uploadDocument('org1', { title: 'Runbook', category: 'runbook', file }, actor);
+    expect(putBlob).toHaveBeenCalledWith(expect.objectContaining({ prefix: 'org-documents', contentType: 'application/pdf' }));
+  });
+
+  it('rejects an unsniffable payload with 415 and never puts an object', async () => {
+    await expect(uploadDocument('org1', { title: 'x', category: 'other', file: { ...file, buffer: Buffer.from('<html>') } }, actor))
+      .rejects.toMatchObject({ status: 415, code: 'UNSUPPORTED_DOCUMENT_TYPE' });
+    expect(putBlob).not.toHaveBeenCalled();
+  });
+
+  it('maps a storage fault to 503 and writes no row', async () => {
+    putBlob.mockRejectedValueOnce(new BlobStorageError('down'));
+    await expect(uploadDocument('org1', { title: 'x', category: 'other', file }, actor))
+      .rejects.toMatchObject({ status: 503, code: 'STORAGE_UNAVAILABLE' });
+  });
+
+  it('refuses to replace a document that already has a successor (409 NOT_HEAD)', async () => {
+    state.rows.push([{ id: 'd1', orgId: 'org1', deletedAt: null }]);   // target load
+    state.rows.push([{ id: 'd2' }]);                                    // successor exists
+    await expect(replaceDocument('org1', 'd1', { file }, actor))
+      .rejects.toMatchObject({ status: 409, code: 'NOT_HEAD' });
+    expect(putBlob).not.toHaveBeenCalled();
+  });
+
+  it('deletes the object BEFORE stamping the tombstone', async () => {
+    const order: string[] = [];
+    deleteBlob.mockImplementation(async () => { order.push('object'); });
+    state.rows.push([{ id: 'd1', orgId: 'org1', deletedAt: null, storageBackend: 's3', storageKey: 'org-documents/d1', data: null }]);
+    state.rows.push([{ id: 'd1' }]);
+    await deleteDocument('org1', 'd1', actor);
+    expect(order).toEqual(['object']);   // the UPDATE only runs after the object is gone
+  });
+```
+
+Add one case per remaining rule: a foreign org on every exported function → `{ status: 404, code: 'NOT_FOUND' }` (never 403); a 10 MiB + 1 byte payload → 413 `FILE_TOO_LARGE` with `putBlob` untouched; an empty buffer → 400 `EMPTY_FILE`; `listDocuments` omitting superseded and soft-deleted rows by default and including superseded ones under the flag; `updateDocument` on a soft-deleted row → 404; `supersedeDocument` with `id === supersedesDocumentId` → 400 `INVALID_SUPERSEDE`; a document that already supersedes something → 409 `ALREADY_SUPERSEDES`; and a `23505` raised by the insert mapping to 409 `NOT_HEAD` (the DB backstop for a lost race on the head check).
+
+- [ ] **Step 3: Run to watch them fail**
+
+Run: `cd apps/api && npx vitest run src/services/orgDocumentService.test.ts`
+Expected: FAIL — `Cannot find module './orgDocumentService'`.
+
+- [ ] **Step 4: Implement the service**
+
+Skeleton (fill every function; `requireOrgAccess` and the error class come from W01):
+
+```ts
+import { randomUUID, createHash } from 'node:crypto';
+import type { Readable } from 'node:stream';
+import { and, desc, eq, inArray, isNull, sql } from 'drizzle-orm';
+import { TICKET_ATTACHMENT_LIMITS, type OrgDocumentCategory } from '@breeze/shared';
+import { db } from '../db';
+import { orgDocuments, ORG_DOCUMENT_META_COLUMNS, type OrgDocumentRow } from '../db/schema/orgDocuments';
+import { BlobStorageError, deleteBlob, getBlobStream, putBlob } from './blobStorage';
+import { sniffAttachmentMime } from './attachmentSniff';
+import { sanitizeAttachmentFilename } from '../routes/tickets/attachments';
+import { DeliverableServiceError, type DeliverableActor } from './serviceDeliverableService';
+import { pgErrorCode } from '../utils/pgErrors';
+
+export const ORG_DOCUMENT_PREFIX = 'org-documents';
+
+function requireOrgAccess(actor: DeliverableActor, orgId: string): void {
+  if (actor.accessibleOrgIds !== null && !actor.accessibleOrgIds.includes(orgId)) {
+    throw new DeliverableServiceError('Not found', 404, 'NOT_FOUND');
+  }
+}
+
+/** Validate bytes and return the sniffed type. The client's Content-Type is
+ *  NEVER consulted — magic bytes only, same rule as ticket attachments (D4). */
+function validateFile(file: UploadFile): { contentType: string; sha256: string } {
+  if (file.buffer.length === 0) throw new DeliverableServiceError('Document is empty', 400, 'EMPTY_FILE');
+  if (file.buffer.length > TICKET_ATTACHMENT_LIMITS.maxBytes) {
+    throw new DeliverableServiceError('Document too large (max 10 MB)', 413, 'FILE_TOO_LARGE');
+  }
+  const contentType = sniffAttachmentMime(file.buffer);
+  if (!contentType) {
+    throw new DeliverableServiceError('Only JPEG, PNG, WebP images and PDFs can be stored', 415, 'UNSUPPORTED_DOCUMENT_TYPE');
+  }
+  return { contentType, sha256: createHash('sha256').update(file.buffer).digest('hex') };
+}
+
+/** Put-then-insert with a compensating delete that never masks the insert fault. */
+async function insertWithBytes(row: {/* … */}, file: UploadFile): Promise<OrgDocumentRow> { /* … */ }
+```
+
+`listDocuments` builds the head filter as a correlated `NOT EXISTS` so one query answers both the list and each row's `supersededByDocumentId`:
+
+```ts
+const successor = db.$with('successor');   // or a leftJoin alias over orgDocuments
+// heads only:  NOT EXISTS (SELECT 1 FROM org_documents s WHERE s.supersedes_document_id = org_documents.id)
+```
+
+- [ ] **Step 5: Run the tests and the typecheck**
+
+Run: `cd apps/api && npx vitest run src/services/orgDocumentService.test.ts && npx tsc --noEmit -p tsconfig.json`
+Run: `cd packages/shared && npx vitest run src/validators/orgDocuments.test.ts`
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/services/orgDocumentService.ts apps/api/src/services/orgDocumentService.test.ts packages/shared/src/validators/orgDocuments.ts packages/shared/src/validators/orgDocuments.test.ts packages/shared/src/validators/index.ts
+git commit -m "feat(documents): org document service with upload, replace, supersede and soft delete (W03)"
+```
+
+---
+
+### Task 8: `document` evidence kind
+
+**Files:**
+- Modify: `packages/shared/src/validators/serviceDeliverables.ts` (the `evidenceRefSchema` block from W01 Task 7)
+- Modify: `packages/shared/src/validators/serviceDeliverables.test.ts` (flip the W01 negative case)
+- Modify: `apps/api/src/services/serviceDeliverableService.ts` (`addEvidence`, `deliverOccurrence`)
+- Modify: `apps/api/src/services/serviceDeliverableService.test.ts`
+
+**Interfaces:**
+- Consumes: `EvidenceRef`, `addEvidence`, `deliverOccurrence`, `getDeliverable`, `OccurrenceView`, `DeliverableSummary` from W01.
+- Produces: `documentEvidenceRefSchema`; `evidenceRefSchema` now a two-arm discriminated union; `addEvidence` accepting `{ kind: 'document', documentId }`; and one new export on `serviceDeliverableService.ts` that Task 10 needs — W01 has no single-occurrence getter:
+
+```ts
+/** Load one occurrence by id, 404 NOT_FOUND on a foreign org or a missing row. */
+export function getOccurrenceOr404(orgId: string, occurrenceId: string, actor: DeliverableActor): Promise<OccurrenceView>;
+```
+
+> **This task deliberately changes two W01 tests.** W01 Task 7 asserts `deliverOccurrenceSchema.safeParse({ evidence: [{ kind: 'document', documentId }] }).success === false`, and W01 Task 10 asserts the deliver route answers 400 for a `document` evidence kind. Both encoded "W03 has not landed yet". Flip them here — do not delete them.
+
+- [ ] **Step 1: Flip the W01 validator assertion to the new expectation**
+
+In `packages/shared/src/validators/serviceDeliverables.test.ts`, replace the negative case with:
+
+```ts
+  it('accepts a document evidence ref now that W03 has landed', () => {
+    const parsed = deliverOccurrenceSchema.parse({ evidence: [{ kind: 'document', documentId: '11111111-1111-4111-8111-111111111111' }] });
+    expect(parsed.evidence).toEqual([{ kind: 'document', documentId: '11111111-1111-4111-8111-111111111111' }]);
+  });
+  it('still rejects a document ref with no documentId', () => {
+    expect(deliverOccurrenceSchema.safeParse({ evidence: [{ kind: 'document' }] }).success).toBe(false);
+  });
+```
+
+- [ ] **Step 2: Run to watch it fail**
+
+Run: `cd packages/shared && npx vitest run src/validators/serviceDeliverables.test.ts`
+Expected: FAIL — `Invalid discriminator value. Expected 'report_run'`.
+
+- [ ] **Step 3: Widen the union**
+
+```ts
+export const reportRunEvidenceRefSchema = z.object({ kind: z.literal('report_run'), reportRunId: z.string().guid() });
+export const documentEvidenceRefSchema = z.object({ kind: z.literal('document'), documentId: z.string().guid() });
+// W03: both arms of deliverable_evidence_kind are now reachable from the API.
+export const evidenceRefSchema = z.discriminatedUnion('kind', [reportRunEvidenceRefSchema, documentEvidenceRefSchema]);
+```
+
+- [ ] **Step 4: Teach the service the document arm**
+
+In `addEvidence`, add the branch beside the existing `report_run` one:
+
+```ts
+  if (ref.kind === 'document') {
+    // 404 not 403 (spec §12): a document of another org must be indistinguishable
+    // from one that does not exist. The composite FK (document_id, org_id) is the
+    // DB backstop, but the check is here so the caller gets a clean 404 instead
+    // of a 23503.
+    const [doc] = await db
+      .select({ id: orgDocuments.id })
+      .from(orgDocuments)
+      .where(and(eq(orgDocuments.id, ref.documentId), eq(orgDocuments.orgId, orgId), isNull(orgDocuments.deletedAt)))
+      .limit(1);
+    if (!doc) throw new DeliverableServiceError('Not found', 404, 'NOT_FOUND');
+    await db.insert(serviceDeliverableEvidence).values({
+      orgId, occurrenceId, kind: 'document', documentId: doc.id,
+      reportId: null, reportRunId: null, createdByUserId: actor.userId,
+    });
+  }
+```
+
+`deliverOccurrence` needs no new code — it already loops `input.evidence` through `addEvidence` before running `transition(...)` — but add a test proving a document ref satisfies `artifactRequired`. Extract the occurrence load that `deliverOccurrence` / `waiveOccurrence` already perform into the exported `getOccurrenceOr404` above (same `requireOrgAccess` + 404 rules, no behaviour change) and add a test that it answers 404 — never 403 — for an occurrence of another org.
+
+- [ ] **Step 5: Run the affected tests**
+
+Run: `cd packages/shared && npx vitest run src/validators/serviceDeliverables.test.ts`
+Run: `cd apps/api && npx vitest run src/services/serviceDeliverableService.test.ts`
+Expected: PASS, including a new case "delivering with a document evidence ref satisfies artifactRequired" and "a document of another org is 404, not 403".
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/shared/src/validators/serviceDeliverables.ts packages/shared/src/validators/serviceDeliverables.test.ts apps/api/src/services/serviceDeliverableService.ts apps/api/src/services/serviceDeliverableService.test.ts
+git commit -m "feat(deliverables): document evidence kind on occurrences (W03)"
+```
+
+---
+
+### Task 9: REST — `routes/orgDocuments.ts`
+
+**Files:**
+- Create: `apps/api/src/routes/orgDocuments.ts`, `apps/api/src/routes/orgDocuments.test.ts`
+- Modify: `apps/api/src/index.ts:837` (after `api.route('/orgs', orgSummaryRoutes);`)
+
+**Interfaces:**
+- Produces:
+
+```
+GET    /orgs/:orgId/documents?category&includeSuperseded    documents:read
+POST   /orgs/:orgId/documents                               documents:write   (multipart)
+GET    /orgs/:orgId/documents/:id/content                   documents:read    (streams bytes)
+PATCH  /orgs/:orgId/documents/:id                           documents:write
+POST   /orgs/:orgId/documents/:id/replace                   documents:write   (multipart)
+DELETE /orgs/:orgId/documents/:id                           documents:write
+```
+
+Every response is a `{ data }` envelope except `/content` (raw bytes) and DELETE (204).
+
+Scope: `requireScope('organization', 'partner', 'system')`. This deliberately widens W01's `requireScope('partner', 'system')` — `documents:read`/`write` are granted to `Org Admin` and `Org Technician`, which are organization-scope roles, so a partner-only gate would hand them a permission they could never exercise. Org-scope tokens are still narrowed by `actor.accessibleOrgIds` and by RLS.
+
+- [ ] **Step 1: Write the failing route tests**
+
+Follow `apps/api/src/routes/contracts/periods.test.ts` (mock `../middleware/auth`, hoist service mocks). Minimum cases:
+
+```ts
+it('401 without auth', …);
+it('403 without documents:read', …);
+it('404 — not 403 — for an org the caller cannot access', …);   // service throws 404 NOT_FOUND
+it('200 { data: [...] } lists heads only by default', …);
+it('400 INVALID_MULTIPART when the body has no file part', …);
+it('413 FILE_TOO_LARGE surfaces the service status verbatim', …);
+it('415 UNSUPPORTED_DOCUMENT_TYPE surfaces the service status verbatim', …);
+it('503 STORAGE_UNAVAILABLE surfaces the service status verbatim', …);
+it('409 NOT_HEAD when replacing a document that already has a successor', …);
+it('content sets Content-Type, ETag and Content-Disposition and never a Location/redirect', …);
+it('204 on delete', …);
+```
+
+- [ ] **Step 2: Run to watch them fail**
+
+Run: `cd apps/api && npx vitest run src/routes/orgDocuments.test.ts`
+Expected: FAIL — `Cannot find module './orgDocuments'`.
+
+- [ ] **Step 3: Implement the router**
+
+```ts
+import { Hono, type Context } from 'hono';
+import { z } from 'zod';
+import { Readable } from 'node:stream';
+import { zValidator } from '../lib/validation';
+import { listDocumentsQuerySchema, replaceDocumentMetaSchema, updateDocumentSchema, uploadDocumentMetaSchema } from '@breeze/shared';
+import { PERMISSIONS } from '../services/permissions';
+import { requirePermission, requireScope } from '../middleware/auth';
+import { userRateLimit } from '../middleware/userRateLimit';
+import { captureException } from '../services/sentry';
+import { createAuditLogAsync } from '../services/auditService';
+import { contentDispositionFor } from './tickets/attachments';
+import {
+  deleteDocument, getDocument, listDocuments, replaceDocument, streamDocument, updateDocument,
+  uploadDocument, type UploadFile,
+} from '../services/orgDocumentService';
+import { DeliverableServiceError, type DeliverableActor } from '../services/serviceDeliverableService';
+
+export const orgDocumentRoutes = new Hono();
+
+const orgParam = z.object({ orgId: z.string().guid() });
+const docParam = z.object({ orgId: z.string().guid(), id: z.string().guid() });
+
+/** Same actor shape W01's routers build (routes/serviceDeliverables.ts). */
+export function documentActorFrom(c: Context): DeliverableActor {
+  const auth = c.get('auth');
+  return { userId: auth.user.id, partnerId: auth.partnerId ?? null, accessibleOrgIds: auth.accessibleOrgIds };
+}
+
+export function handleDocumentError(c: Context, err: unknown): Response {
+  if (err instanceof DeliverableServiceError) {
+    if (err.status >= 500) captureException(err);
+    return c.json({ error: err.message, code: err.code, ...(err.details ? { details: err.details } : {}) }, err.status as 400);
+  }
+  throw err;
+}
+
+/** Exactly one file part, under any key, plus the text fields beside it.
+ *  `collectFiles` is routes/tickets/attachments.ts:67-75 verbatim. */
+export async function parseUpload(c: Context): Promise<{ file: UploadFile; fields: Record<string, unknown> } | { error: 'INVALID_MULTIPART' }> {
+  let parsed: Record<string, unknown>;
+  try { parsed = (await c.req.parseBody({ all: true })) as Record<string, unknown>; }
+  catch { return { error: 'INVALID_MULTIPART' }; }
+  const files = collectFiles(parsed);
+  if (files.length !== 1) return { error: 'INVALID_MULTIPART' };
+  const f = files[0]!;
+  const fields = Object.fromEntries(Object.entries(parsed).filter(([, v]) => !(v instanceof File)));
+  return { file: { buffer: Buffer.from(await f.arrayBuffer()), contentType: f.type || 'application/octet-stream', filename: f.name ?? '' }, fields };
+}
+```
+
+Every handler is `try { return c.json({ data: await svc(...) }) } catch (err) { return handleDocumentError(c, err) }`, behind `requireScope('organization','partner','system')` and `requirePermission(PERMISSIONS.DOCUMENTS_READ…)` / `DOCUMENTS_WRITE`, with `zValidator('param', …)` and `zValidator('query', listDocumentsQuerySchema)` / `zValidator('json', updateDocumentSchema)` where the body is JSON. The two multipart handlers validate their text fields with `uploadDocumentMetaSchema` / `replaceDocumentMetaSchema` against `parsed.fields`, carry `userRateLimit('org-document-upload', 30, 60)`, and write `createAuditLogAsync` events (`organization.document.upload` / `.replace` / `.delete`) whose `details` **omit the filename** — it can carry customer PII, exactly as `attachments.ts:196` notes.
+
+The content handler mirrors `routes/tickets/attachments.ts:315-352` step for step: ETag `"<sha256>"`; an `If-None-Match` match returns 304 **before** opening the bytes (a 304 that still fetched from the bucket is a silent egress bill); headers `Cache-Control: private, max-age=300`, `X-Content-Type-Options: nosniff`, `Content-Type` from the STORED sniffed type, `Content-Disposition: contentDispositionFor(contentType, originalFilename)`, `Content-Length`; then `c.body(new Uint8Array(body), 200, headers)` for a Buffer or `c.body(Readable.toWeb(body) as ReadableStream, 200, headers)` for a stream. A null body is a 404 with a `console.error` naming the id and backend — never a redirect, never a presigned URL.
+
+Mount it in `apps/api/src/index.ts` directly after `api.route('/orgs', orgSummaryRoutes);`:
+
+```ts
+api.route('/orgs', orgDocumentRoutes);
+```
+
+- [ ] **Step 4: Run the tests and boot a smoke request**
+
+Run: `cd apps/api && npx vitest run src/routes/orgDocuments.test.ts && npx tsc --noEmit -p tsconfig.json` → PASS.
+Run the API against the test stack and `curl -sf -H "Authorization: Bearer <partner token>" localhost:3001/api/v1/orgs/<orgId>/documents` → `{"data":[]}`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/orgDocuments.ts apps/api/src/routes/orgDocuments.test.ts apps/api/src/index.ts
+git commit -m "feat(documents): REST routes for the org document library (W03)"
+```
+
+---
+
+### Task 10: Upload-on-deliver — `POST …/occurrences/:oId/evidence/upload`
+
+**Files:**
+- Modify: `apps/api/src/routes/serviceDeliverables.ts` (W01 Task 10)
+- Modify: `apps/api/src/routes/serviceDeliverables.test.ts`
+- Modify: `apps/api/src/services/orgDocumentService.ts` (no new export; `uploadDocument` is reused)
+
+**Interfaces:**
+- Produces: `POST /orgs/:orgId/deliverables/occurrences/:oId/evidence/upload` (multipart), `contracts:write`, returning `{ data: OccurrenceView }`.
+
+Spec §7: "Uploaded evidence creates an `org_documents` row with `category='evidence'` and `portal_visible` copied from the deliverable."
+
+- [ ] **Step 1: Write the failing route test**
+
+```ts
+it('uploading evidence creates an evidence-category document that inherits the deliverable portal flag, then links it', async () => {
+  uploadDocumentMock.mockResolvedValue({ id: 'doc-1', portalVisible: true });
+  addEvidenceMock.mockResolvedValue({ id: 'occ-1', evidence: [{ id: 'e1', kind: 'document', documentId: 'doc-1' }] });
+  const form = new FormData();
+  form.append('file', new File([pdfBytes], 'findings.pdf', { type: 'application/pdf' }));
+  const res = await app.request('/orgs/org1/deliverables/occurrences/occ-1/evidence/upload', { method: 'POST', body: form }, env);
+  expect(res.status).toBe(200);
+  expect(uploadDocumentMock).toHaveBeenCalledWith('org1', expect.objectContaining({ category: 'evidence', portalVisible: true }), expect.anything());
+  expect(addEvidenceMock).toHaveBeenCalledWith('org1', 'occ-1', { kind: 'document', documentId: 'doc-1' }, expect.anything());
+});
+
+it('returns 415 from the document service without creating an evidence row', async () => { /* … */ });
+```
+
+- [ ] **Step 2: Run to watch it fail**
+
+Run: `cd apps/api && npx vitest run src/routes/serviceDeliverables.test.ts`
+Expected: FAIL — 404, the route does not exist.
+
+- [ ] **Step 3: Implement the route**
+
+```ts
+// Spec §7 upload-on-deliver. Two writes, ordered: the document must exist
+// before it can be evidence. If the link fails the document survives as an
+// ordinary library row rather than a dangling upload — deliberately NOT
+// compensated, because a technician's uploaded artifact is customer data we
+// would rather keep and re-link than silently discard.
+serviceDeliverableRoutes.post(
+  '/:orgId/deliverables/occurrences/:oId/evidence/upload',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.CONTRACTS_WRITE.resource, PERMISSIONS.CONTRACTS_WRITE.action),
+  zValidator('param', z.object({ orgId: z.string().guid(), oId: z.string().guid() })),
+  userRateLimit('deliverable-evidence-upload', 30, 60),
+  async (c) => {
+    const { orgId, oId } = c.req.valid('param');
+    const actor = deliverableActorFrom(c);
+    const parsed = await parseUpload(c);
+    if ('error' in parsed) return c.json({ error: 'Expected exactly one file part named "file"', code: 'INVALID_MULTIPART' }, 400);
+    try {
+      const occ = await getOccurrenceOr404(orgId, oId, actor);
+      const deliverable = await getDeliverable(orgId, occ.deliverableId, actor);
+      const doc = await uploadDocument(orgId, {
+        title: String(parsed.fields.title ?? parsed.file.filename ?? 'Evidence'),
+        description: typeof parsed.fields.description === 'string' ? parsed.fields.description : null,
+        category: 'evidence',
+        portalVisible: deliverable.portalVisible,
+        file: parsed.file,
+      }, actor);
+      return c.json({ data: await addEvidence(orgId, oId, { kind: 'document', documentId: doc.id }, actor) });
+    } catch (err) {
+      return handleDeliverableError(c, err);
+    }
+  },
+);
+```
+
+`parseUpload` is Task 9's exported helper — import it from `./orgDocuments` rather than duplicating the multipart parsing. `handleDeliverableError`, `deliverableActorFrom`, `getOccurrenceOr404` and `getDeliverable` are W01's, already in this file.
+
+- [ ] **Step 4: Run**
+
+Run: `cd apps/api && npx vitest run src/routes/serviceDeliverables.test.ts src/routes/orgDocuments.test.ts && npx tsc --noEmit -p tsconfig.json` → PASS.
+Also fix the W01 route test that asserted a `document` evidence kind yields 400 on `…/deliver` — it must now assert 200 and a linked document (see Task 8's note).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/serviceDeliverables.ts apps/api/src/routes/serviceDeliverables.test.ts apps/api/src/routes/orgDocuments.ts
+git commit -m "feat(deliverables): upload evidence on an occurrence as an org document (W03)"
+```
+
+---
+
+### Task 11: Integration suite — `orgDocumentsRls.integration.test.ts`
+
+**Files:**
+- Create: `apps/api/src/__tests__/integration/orgDocumentsRls.integration.test.ts`
+
+Follow the header pattern of the sibling `*Rls.integration.test.ts` files (`import './setup'`, `getTestDb()` for RLS-bypassing seeding, `withDbAccessContext(orgContext(orgId), …)` for the code under test).
+
+- [ ] **Step 1: Write the tests**
+
+1. **Cross-org forge**: in org A's context, `INSERT INTO org_documents (org_id, …) VALUES (<org B>, …)` → rejects with SQLSTATE `42501`.
+2. **Positive control**: in org A's context, insert and read back org A's own row → exactly 1 row. Without this the forge test can pass vacuously (a broken fixture rejects everything).
+3. **Cross-org read**: org B's document inserted under system context is invisible to org A's context (`SELECT count(*)` → 0).
+4. **Chain integrity**: insert D1, then D2 with `supersedes_document_id = D1` (succeeds), then D3 with `supersedes_document_id = D1` → rejects with `23505` (`org_documents_supersedes_uq`). Assert the SQLSTATE, not the message.
+5. **Cross-org supersede**: a document of org A superseding a document of org B → rejects with `23503` (`org_documents_supersedes_org_fk`).
+6. **Evidence FK to a foreign org's document**: with an org-A occurrence and an org-B document, a system-context `INSERT INTO service_deliverable_evidence (org_id=A, occurrence_id=<A>, kind='document', document_id=<B's doc>)` → rejects with `23503` (`sd_evidence_document_org_fk`).
+7. **Deferrable re-point**: in one system-context transaction, `SET CONSTRAINTS ALL DEFERRED`, move a document and its predecessor to another org in separate statements, commit → succeeds. Mirror the shape `orgLifecycleFoundations.integration.test.ts` uses for one FK.
+8. **Evidence cascade**: deleting an `org_documents` row removes its evidence rows (`ON DELETE CASCADE`) and leaves the occurrence.
+
+- [ ] **Step 2: Run**
+
+Run: `cd apps/api && npx vitest run --config vitest.integration.config.ts src/__tests__/integration/orgDocumentsRls.integration.test.ts`
+Expected: PASS, and the output must report **8 tests ran**. A `0 tests` line is a stall, not green.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/__tests__/integration/orgDocumentsRls.integration.test.ts
+git commit -m "test(documents): RLS, chain integrity and evidence-ownership integration suite (W03)"
+```
+
+---
+
+### Task 12: Prove object-before-row in the erasure round-trip
+
+**Files:**
+- Modify: `apps/api/src/__tests__/integration/tenantExportErasureRoundtrip.integration.test.ts`
+
+**Interfaces:**
+- Consumes: `seedTwoOrgs()`, `rowCount(db, table, orgId)` (`:388`), `cascadeDeleteOrg` — all already in the file.
+
+The suite runs with no S3 configured, so `deleteObjects` → `requireBucket()` throws. That is the lever: an S3-backed document makes the pre-clear fault, and a faulting pre-clear must abort **before any row is deleted**.
+
+- [ ] **Step 1: Write the failing test**
+
+Add a new `it` at the end of the describe block (do NOT touch the existing `'cascade erases the target org and leaves the other org intact'` case — its orgs must stay object-free so its assertions keep passing):
+
+```ts
+  it('aborts erasure before any row when an S3-backed org document cannot be cleared, then completes once the object is gone (W03)', async () => {
+    const db = getTestDb();
+    const { orgA } = await seedTwoOrgs();
+    const docId = crypto.randomUUID();
+    await db.execute(sql`
+      INSERT INTO org_documents (id, org_id, title, category, storage_backend, storage_key,
+                                 content_type, byte_size, sha256, original_filename)
+      VALUES (${docId}, ${orgA}, 'Onboarding baseline', 'baseline', 's3', ${`org-documents/${docId}`},
+              'application/pdf', 1024, ${'a'.repeat(64)}, 'baseline.pdf')
+    `);
+    expect(await rowCount(db, 'org_documents', orgA)).toBe(1);
+
+    // No S3 bucket is configured in the integration environment, so the object
+    // pre-clear faults. The contract is that it faults BEFORE the first row
+    // delete and is rerunnable — nothing may be missing afterwards.
+    await expect(cascadeDeleteOrg(orgA, PERFORMED_BY, PERFORMED_EMAIL)).rejects.toThrow(/rerunnable/i);
+    expect(await rowCount(db, 'org_documents', orgA)).toBe(1);
+    expect(await rowCount(db, 'sites', orgA)).toBe(2);
+    expect(await rowCount(db, 'tickets', orgA)).toBe(1);
+
+    // Operator clears the object out of band (or it was a db-backed row all
+    // along); the same erasure now runs to completion — proving the pre-clear is
+    // a gate, not a one-way failure.
+    await db.execute(sql`
+      UPDATE org_documents SET storage_backend = 'db', storage_key = NULL, data = '\\x00'::bytea
+      WHERE id = ${docId}
+    `);
+    const stats = await cascadeDeleteOrg(orgA, PERFORMED_BY, PERFORMED_EMAIL);
+    expect(await rowCount(db, 'org_documents', orgA)).toBe(0);
+    expect(stats.tablesDeleted['org_documents']).toBe(1);
+  });
+```
+
+- [ ] **Step 2: Run to watch it fail**
+
+Run: `cd apps/api && npx vitest run --config vitest.integration.config.ts src/__tests__/integration/tenantExportErasureRoundtrip.integration.test.ts`
+Expected: FAIL before Task 6 lands (the erasure succeeds, ignoring the document's object). With Tasks 4 and 6 in place it PASSES. Run it both ways if you are executing tasks out of order — a test that has never been red proves nothing.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/__tests__/integration/tenantExportErasureRoundtrip.integration.test.ts
+git commit -m "test(tenancy): erasure round-trip proves object-before-row for an S3-backed org document (W03)"
+```
+
+---
+
+### Task 13: Web API client and i18n
+
+**Files:**
+- Create: `apps/web/src/lib/api/orgDocuments.ts`
+- Modify: `apps/web/src/locales/{en,de-DE,es-419,fr-CA,fr-FR,it-IT,pt-BR,tr-TR}/organizations.json`
+- Modify: `apps/web/src/locales/*/deliverables.json` (W01's namespace)
+
+**Interfaces:**
+- Consumes: `type Fetcher` from `apps/web/src/lib/api/serviceDeliverables.ts` (W01 Task 12), `ActionError` from `apps/web/src/lib/runAction.ts`.
+- Produces:
+
+```ts
+export interface OrgDocument {
+  id: string; orgId: string; title: string; description: string | null;
+  category: 'baseline' | 'runbook' | 'policy' | 'evidence' | 'report' | 'export' | 'other';
+  contentType: string; byteSize: number; sha256: string; originalFilename: string;
+  uploadedByUserId: string | null; portalVisible: boolean;
+  supersedesDocumentId: string | null; supersededByDocumentId: string | null; createdAt: string;
+}
+export function listOrgDocuments(f: Fetcher, orgId: string, q?: { category?: string; includeSuperseded?: boolean }): Promise<OrgDocument[]>;
+export function uploadOrgDocument(f: Fetcher, orgId: string, form: FormData): Promise<Response>;
+export function replaceOrgDocument(f: Fetcher, orgId: string, id: string, form: FormData): Promise<Response>;
+export function updateOrgDocument(f: Fetcher, orgId: string, id: string, body: { title?: string; description?: string | null; category?: string; portalVisible?: boolean }): Promise<Response>;
+export function deleteOrgDocument(f: Fetcher, orgId: string, id: string): Promise<Response>;
+export function orgDocumentContentPath(orgId: string, id: string): string;   // `/orgs/${orgId}/documents/${id}/content`
+```
+
+Mutation wrappers return the raw `Response` so the component owns the `runAction` call (the `contractDocuments.ts` idiom, `apps/web/src/lib/api/contractDocuments.ts:47`). `listOrgDocuments` parses and throws `ActionError` on `!res.ok`.
+
+- [ ] **Step 1: Write the client**
+
+FormData bodies must NOT set `Content-Type` — the browser supplies the multipart boundary (see `apps/web/src/components/tickets/TicketWorkbench.tsx:834-843`).
+
+- [ ] **Step 2: Add the English keys**
+
+`organizations.json` gains `orgRecord.tabs.documents` and an `orgRecord.documents.*` block: `title`, `empty`, `upload`, `replace`, `download`, `delete`, `deleteConfirm`, `edit`, `save`, `cancel`, `form.title`, `form.description`, `form.category`, `form.portalVisible`, `form.file`, `filter.all`, `category.baseline|runbook|policy|evidence|report|export|other`, `column.title|category|size|uploaded|portal`, `badge.superseded`, `badge.portal`, `errors.tooLarge`, `errors.unsupportedType`, `errors.storageUnavailable`, `errors.notHead`, `toast.uploaded|replaced|updated|deleted`.
+
+`deliverables.json` gains `drawer.uploadEvidence`, `drawer.uploadEvidenceHint`, `drawer.evidenceDocument`, `toast.evidenceUploaded`, `errors.uploadFailed`.
+
+- [ ] **Step 3: Translate into the seven other locales**
+
+Real translations, not English copies — `translationCoverage.test.ts` caps exact-English duplicates per namespace. Keep product nouns (`Breeze`) untranslated and consult `apps/web/src/locales/TERMINOLOGY.md` for fixed terms.
+
+- [ ] **Step 4: Run the i18n suites**
+
+Run: `cd apps/web && npx vitest run src/lib/i18n`
+Expected: PASS (key parity across all 8 locales + the duplicate cap).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/lib/api/orgDocuments.ts apps/web/src/locales
+git commit -m "feat(web): org documents API client and i18n keys in all locales (W03)"
+```
+
+---
+
+### Task 14: Org record Documents tab
+
+**Files:**
+- Create: `apps/web/src/components/organizations/record/OrgDocumentsTab.tsx`, `OrgDocumentsTab.test.tsx`
+- Modify: `apps/web/src/components/organizations/record/orgRecordTabs.ts:13-21` and `:48-60`
+- Modify: `apps/web/src/components/organizations/record/orgRecordTabs.test.ts`
+- Modify: `apps/web/src/components/organizations/record/OrganizationRecordPage.tsx:305` area
+
+**Interfaces:**
+- `OrgDocumentsTab({ orgId, orgFetch })` — category filter, upload form, table (title, category, size, uploaded, portal toggle), row actions Download / Replace / Edit / Delete. Every mutation via `runAction`.
+
+- [ ] **Step 1: Write the failing registry test**
+
+In `orgRecordTabs.test.ts`:
+
+```ts
+it('declares Documents after Service and before Activity', () => {
+  expect([...ORG_RECORD_TABS]).toEqual([
+    'overview', 'contacts', 'sites', 'devices', 'tickets', 'billing', 'service', 'documents', 'activity',
+  ]);
+});
+
+it('gates Documents on documents:read', () => {
+  expect(TAB_PERMISSION.documents).toEqual([{ resource: 'documents', action: 'read' }]);
+  expect(visibleTabs(grants(['documents', 'read']), 'native')).toContain('documents');
+  expect(visibleTabs(grants(['organizations', 'read']), 'native')).not.toContain('documents');
+});
+```
+
+- [ ] **Step 2: Write the failing component tests**
+
+```ts
+it('lists documents through orgFetch, not ambient fetchWithAuth', …);
+it('filters by category', …);
+it('uploading posts multipart and toasts on success', …);
+it('replace posts to /replace and shows the 409 NOT_HEAD message from the response body, not a generic error', …);
+it('toggling the portal switch PATCHes portalVisible', …);
+it('delete asks for confirmation first', …);
+```
+
+- [ ] **Step 3: Run to watch them fail**
+
+Run: `cd apps/web && npx vitest run src/components/organizations/record`
+Expected: FAIL on the tab order, `TAB_PERMISSION.documents`, and the missing component module.
+
+- [ ] **Step 4: Implement**
+
+In `orgRecordTabs.ts` add `'documents'` to `ORG_RECORD_TABS` immediately after `'service'` (W01 inserts `'service'` after `'billing'`), and:
+
+```ts
+  // Documents is NOT part of SERVICE_MANAGEMENT_TABS: the library holds
+  // runbooks, baselines and exports that stay relevant when a partner runs
+  // ticketing in an external PSA, so `off` and `external` must not hide it.
+  documents: [{ resource: 'documents', action: 'read' }],
+```
+
+In `OrganizationRecordPage.tsx`, beside the other tab renders:
+
+```tsx
+      {effectiveTab === 'documents' && <OrgDocumentsTab orgId={orgId} orgFetch={orgFetch} />}
+```
+
+Build the component with the repo's Tailwind conventions (`rounded-lg border bg-card`), `data-testid` on the root (`org-documents-tab`), the table (`org-documents-table`), the upload input (`org-document-file`) and every action button. Download fetches through `orgFetch(orgDocumentContentPath(orgId, id))`, turns the response into a blob URL and opens it, revoking after 60s — the pattern at `apps/web/src/components/tickets/TicketAttachments.tsx:101-117`. Never link the content path directly: it needs the auth header.
+
+- [ ] **Step 5: Run**
+
+Run: `cd apps/web && npx vitest run src/components/organizations/record src/lib/__tests__/no-silent-mutations.test.ts src/lib/i18n && pnpm --filter @breeze/web typecheck`
+Expected: PASS. If `no-silent-mutations` flags the new handlers, wrap them in `runAction` — do not add them to `runActionAllowlist.ts`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/organizations/record
+git commit -m "feat(web): org record Documents tab (W03)"
+```
+
+---
+
+### Task 15: File-upload evidence in the occurrence drawer
+
+**Files:**
+- Modify: `apps/web/src/components/deliverables/OccurrenceDrawer.tsx` (W01 Task 13)
+- Modify: `apps/web/src/components/deliverables/OccurrenceDrawer.test.tsx`
+
+**Interfaces:**
+- Consumes: `Fetcher`, `listOccurrences`, `addEvidence` from `apps/web/src/lib/api/serviceDeliverables.ts`; the new `POST /orgs/:orgId/deliverables/occurrences/:oId/evidence/upload` from Task 10.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+it('uploads a file as evidence and refreshes the occurrence', async () => {
+  render(<OccurrenceDrawer fetcher={fetcher} orgId="org1" deliverable={deliverable} onClose={vi.fn()} />);
+  await userEvent.upload(await screen.findByTestId('occurrence-evidence-file'), new File(['%PDF-'], 'findings.pdf', { type: 'application/pdf' }));
+  await userEvent.click(screen.getByTestId('occurrence-evidence-upload'));
+  await waitFor(() => expect(fetcher).toHaveBeenCalledWith(
+    '/orgs/org1/deliverables/occurrences/occ-1/evidence/upload',
+    expect.objectContaining({ method: 'POST', body: expect.any(FormData) }),
+  ));
+});
+
+it('surfaces a 415 from the upload as the translated unsupported-type message', async () => { /* … */ });
+```
+
+- [ ] **Step 2: Run to watch it fail**
+
+Run: `cd apps/web && npx vitest run src/components/deliverables/OccurrenceDrawer.test.tsx`
+Expected: FAIL — no `occurrence-evidence-file` element.
+
+- [ ] **Step 3: Implement**
+
+Add a third evidence option next to W01's "link report run" control: a file input plus an Upload button whose handler builds a `FormData` (`file`, optional `title`) and goes through `runAction` with `errorFallback: t('errors.uploadFailed')` and a `friendly` map for `FILE_TOO_LARGE` → `errors.tooLarge`, `UNSUPPORTED_DOCUMENT_TYPE` → `errors.unsupportedType`, `STORAGE_UNAVAILABLE` → `errors.storageUnavailable`. Document evidence chips render the document title and download through `orgDocumentContentPath`.
+
+- [ ] **Step 4: Run**
+
+Run: `cd apps/web && npx vitest run src/components/deliverables src/lib/__tests__/no-silent-mutations.test.ts && pnpm --filter @breeze/web typecheck` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/deliverables
+git commit -m "feat(web): upload a file as occurrence evidence from the drawer (W03)"
+```
+
+---
+
+### Task 16: MCP tools — `list_org_documents`, `manage_org_documents`
+
+**Files:**
+- Modify (or create): `apps/api/src/services/aiToolsDeliverables.ts`
+- Create/modify: `apps/api/src/services/aiToolsDeliverables.test.ts`
+- Modify: `apps/api/src/services/aiTools.ts:80` (import) and `:294` area (call)
+
+**Interfaces:**
+- Produces: `registerDeliverableTools(aiTools: Map<string, AiTool>): void`, registering `list_org_documents` and `manage_org_documents`.
+
+> **If W02 has already created `aiToolsDeliverables.ts`, add to it.** If not, create it with exactly the `aiToolsContracts.ts` shape: a single exported `registerDeliverableTools`, `actorFromAuth(auth): DeliverableActor`, a `serviceErrorToJson(err)` that unwraps `DeliverableServiceError` including `details`, `MANAGE_*_REQUIRED` presence checks before any `String(...)` coercion, and `missingParamsJson` / `zodErrorToJson` from `./aiToolValidation`. Then add `import { registerDeliverableTools } from './aiToolsDeliverables';` beside line 80 and `registerDeliverableTools(aiTools);` beside line 294 of `aiTools.ts`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+it('list_org_documents returns heads only and reports the count', async () => { /* … */ });
+it('manage_org_documents has NO byte-upload action', () => {
+  const tool = tools.get('manage_org_documents')!;
+  const actions = (tool.definition.input_schema.properties.action as { enum: string[] }).enum;
+  expect(actions).toEqual(['update_metadata', 'set_portal_visibility', 'supersede']);
+  expect(JSON.stringify(tool.definition)).not.toMatch(/base64|upload|file/i);
+});
+it('manage_org_documents rejects a missing documentId before coercing it to the string "undefined"', async () => { /* … */ });
+it('a document of another org answers a 404 JSON error, never a throw', async () => { /* … */ });
+```
+
+- [ ] **Step 2: Run to watch them fail**
+
+Run: `cd apps/api && npx vitest run src/services/aiToolsDeliverables.test.ts`
+Expected: FAIL — the tools are not registered.
+
+- [ ] **Step 3: Implement**
+
+```ts
+const MANAGE_ORG_DOCUMENTS_REQUIRED: Record<string, readonly string[]> = {
+  update_metadata: ['documentId', 'patch'],
+  set_portal_visibility: ['documentId', 'portalVisible'],
+  supersede: ['documentId', 'supersedesDocumentId'],
+};
+
+aiTools.set('list_org_documents', {
+  tier: 2 as AiToolTier,
+  deviceArgs: [],
+  definition: {
+    name: 'list_org_documents',
+    description:
+      'List the current version of every document in an organization\'s library (runbooks, baselines, policies, exports, delivery evidence). '
+      + 'Returns metadata only — titles, categories, sizes and portal visibility — never the file bytes. Read-only.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        orgId: { type: 'string', description: 'Organization id (UUID)' },
+        category: { type: 'string', enum: ['baseline', 'runbook', 'policy', 'evidence', 'report', 'export', 'other'] },
+        includeSuperseded: { type: 'boolean', description: 'Include older versions (default false)' },
+      },
+      required: ['orgId'],
+    },
+  },
+  handler: async (input, auth) => {
+    try {
+      const rows = await listDocuments(String(input.orgId), {
+        category: input.category ? (String(input.category) as OrgDocumentCategory) : undefined,
+        includeSuperseded: input.includeSuperseded === true,
+      }, actorFromAuth(auth));
+      return JSON.stringify({ documents: rows, showing: rows.length });
+    } catch (err) {
+      const json = serviceErrorToJson(err);
+      if (json) return json;
+      throw err;
+    }
+  },
+});
+```
+
+`manage_org_documents` dispatches to `updateDocument` (validated by `updateDocumentSchema` wrapped as `z.object({ patch: updateDocumentSchema })` so ZodError paths read `patch.title: …`), `updateDocument` with just `{ portalVisible }`, and `supersedeDocument`. It is **not** approval-gated (spec §10: only `apply_template` is). Byte upload stays out of MCP by design (spec §3 "Out (v1)").
+
+- [ ] **Step 4: Run**
+
+Run: `cd apps/api && npx vitest run src/services/aiToolsDeliverables.test.ts src/routes/mcpServer.test.ts && npx tsc --noEmit -p tsconfig.json` → PASS. `mcpServer.test.ts` pins the tool inventory; if it fails on a count, update that expectation deliberately.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/aiToolsDeliverables.ts apps/api/src/services/aiToolsDeliverables.test.ts apps/api/src/services/aiTools.ts
+git commit -m "feat(ai): list_org_documents and manage_org_documents MCP tools (W03)"
+```
+
+---
+
+### Task 17: Wave verification and PR
+
+- [ ] **Step 1: Full API unit run**
+
+Run: `cd apps/api && npx vitest run`
+Expected: green. Pay attention to the five files Task 5 must not have needed to change.
+
+- [ ] **Step 2: Shared and web**
+
+Run: `cd packages/shared && npx vitest run` → green.
+Run: `cd apps/web && npx vitest run && pnpm --filter @breeze/web typecheck` → green.
+
+- [ ] **Step 3: Integration contract suites**
+
+Run (test-stack up):
+```bash
+cd apps/api && npx vitest run --config vitest.integration.config.ts \
+  src/__tests__/integration/rls-coverage.integration.test.ts \
+  src/__tests__/integration/tenantCascade.integration.test.ts \
+  src/__tests__/integration/tenant-export-policy.integration.test.ts \
+  src/__tests__/integration/tenantExportErasureRoundtrip.integration.test.ts \
+  src/__tests__/integration/orgLifecycleFoundations.integration.test.ts \
+  src/__tests__/integration/orgMergeRegistry.integration.test.ts \
+  src/__tests__/integration/orgDocumentsRls.integration.test.ts \
+  src/__tests__/integration/serviceDeliverablesRls.integration.test.ts \
+  src/__tests__/integration/ticketAttachmentsRls.integration.test.ts
+```
+Expected: all green, and each file reports a non-zero test count.
+
+- [ ] **Step 4: Lint and migration guards**
+
+Run: `pnpm lint` at the repo root → clean.
+Run: `scripts/check-migration-naming.sh --against-ref origin/main` → PASS. If `origin/main` gained a migration that sorts after `-170400-` while this branch was open, rename both files upward and sweep every reference (this plan, and any integration suite that replays a migration by path).
+
+- [ ] **Step 5: Manual smoke on a worktree stack**
+
+Run: `pnpm wt-stack up`, then in the browser: open an org record → Documents tab → upload a PDF → toggle Portal → Replace it with a second PDF (the first shows as superseded, a second replace of the first is refused with the `NOT_HEAD` message) → Download → Delete. Then open a deliverable's occurrence drawer and upload a file as evidence; confirm the document appears in the library with category `evidence`.
+
+- [ ] **Step 6: Tear down**
+
+Run: `pnpm test-stack down && pnpm wt-stack down`. Confirm nothing is left: `docker compose ls -a --format json | jq -r '.[] | select(.ConfigFiles|test("breeze")) | "\(.Name)\t\(.Status)"'`.
+
+- [ ] **Step 7: Open the PR**
+
+Body carries `Closes #<W03 sub-issue>`, a link to the spec, and a **Tenancy** section listing: the shape-1 RLS policies, the three registrations (cascade / export policy / merge), the widened erasure pre-clear, and the integration suites that prove them. Call out the three deliberate changes to existing tests (two assertions in `tenantCascade.test.ts`, the W01 validator negative case, the W01 deliver-route 400 case) so a reviewer does not read them as collateral damage. Run `/pr-review-toolkit:review-pr`; act on confirmed findings only. Enqueue with `gh pr merge <N>` on green — never `--admin`.
+
+---
+
+## Self-review
+
+**Spec coverage for this wave.** §4.4 `org_documents` → Tasks 1, 3. The `document` arm of §4.3 (FK + evidence kind) → Tasks 1, 8. §4.9 registrations incl. the S3 erasure pre-clear → Tasks 4, 6, 12. §7 upload-on-deliver with `category='evidence'` and inherited `portal_visible` → Task 10. §9 org-record Documents tab → Task 14; drawer evidence upload → Task 15. §10 `documents` permission resource → Task 2; REST → Task 9; `list_org_documents` / `manage_org_documents` → Task 16. §12 upload errors 413 / 415 / 503 / 409 `NOT_HEAD` / 404-not-403 → Tasks 7, 9. §13 unit + route + `orgDocumentsRls` + the standing suites incl. `tenantExportErasureRoundtrip` with an S3-backed document → Tasks 5, 7, 9, 11, 12, 17. Portal `/documents` (§8) is W04 by design; template sets (§4.6) are W05.
+
+**Placeholders.** None. Every step names files, exact line anchors that were read, and real code. The one conditional is Task 16's "if W02 already created `aiToolsDeliverables.ts`", which is a genuine wave-ordering fork with both arms spelled out.
+
+**Type consistency.** `DeliverableActor`, `DeliverableServiceError`, `EvidenceRef`, `OccurrenceView`, `DeliverableSummary`, `addEvidence`, `deliverOccurrence`, `getDeliverable` and `Fetcher` are W01's names, spelled identically here. The review caught one gap and fixed it inline: Task 10 needed a single-occurrence getter that W01 does not export, so Task 8 now declares and implements `getOccurrenceOr404` rather than Task 10 inventing an undeclared name. New names — `BlobStorageError`, `BlobBackend`, `BlobBytesRow`, `putBlob`, `getBlobStream`, `deleteBlob`, `deleteBlobKeys`, `ORG_DOCUMENT_PREFIX`, `OrgDocumentView`, `OrgDocumentRow`, `ORG_DOCUMENT_META_COLUMNS`, `orgDocumentCategoryEnum`, `OrgDocumentCategory`, `UploadFile`, `orgDocumentRoutes`, `registerDeliverableTools` — are spelled identically in every task that mentions them. `AttachmentStorageError`, `AttachmentBackend`, `AttachmentBytesRow`, `putBytes`, `openBytes`, `deleteBytes`, `deleteObjectKeys`, `selectBackend`, `objectKeyFor` all survive Task 5's extraction under their original names, which is the only reason the five existing ticket test files need no edits.
+
+**Known ordering hazards.**
+- The static cascade list is alphabetised; the runtime delete order is topological. `org_documents` sits alphabetically ahead of `service_deliverable_evidence`, and that is correct — `topologicalCascadeOrder()` reads the FK edge and emits the child first. Do not "fix" the list to put it later; `tenantCascade.integration.test.ts`'s alphabetisation assertion would go red.
+- Task 12's test only proves something if it is run against a tree WITHOUT Task 6. If tasks are executed out of order, go back and watch it fail.

--- a/docs/superpowers/plans/billing/2026-09-10-service-deliverables-w04-portal.md
+++ b/docs/superpowers/plans/billing/2026-09-10-service-deliverables-w04-portal.md
@@ -1,0 +1,2481 @@
+---
+tracking_issue: LanternOps/breeze#5573
+---
+# Service Deliverables W04: Customer Portal Service and Documents Surfaces — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the customer portal two new fail-closed surfaces — a Service scorecard (what was promised, what was delivered, when, with what evidence, what is next) and a Documents library — plus a dashboard Service tile, under two new `portal_branding` flags, exposing only curated delivery records and never the tickets behind them.
+
+**Architecture:** Two new read models in `apps/api/src/services/portal/` (`serviceReadModel.ts`, `documentsReadModel.ts`) run inside the portal session's existing org-scoped RLS transaction and own every publication rule from spec D10 — the routes are thin. Two Hono route hubs (`routes/portal/service.ts`, `routes/portal/documents.ts`) mount at root under `createPortalFeatureGateStrict('enableService')` / `('enableDocuments')`, mirroring `portalReportRoutes`. Document bytes stream through the API under RLS via the W03 `orgDocumentService`, never a presigned URL. The portal adds two Astro pages that SSR-fetch through `portalApi` and render React islands, plus two nav entries gated on the new flags.
+
+**Tech Stack:** PostgreSQL + hand-written idempotent SQL migration, Drizzle ORM, Hono + Zod, Vitest (API unit with Drizzle mocks, API integration on real Postgres), Astro + React islands (`apps/portal` has no i18n — strings are English), react-i18next in `apps/web` (8 locales), Testing Library.
+
+**Spec:** `docs/superpowers/specs/billing/2026-09-10-service-deliverables-portal-design.md` (approved 2026-09-10). Sections 4.7, 8 (portal surface + publication rules D10), 11 (tenancy), 13 (portal tests) and wave-table row W04 are this wave. Read §8 in full before Task 4.
+
+**Precedent this wave copies, not reinvents:** `docs/superpowers/specs/portal/2026-09-02-portal-visibility-wave1-design.md` §5 (gating), §6 (ETag + `private, max-age=30`), §7 (read models), §11 (tests), and its plan parts A–C. Every pattern below already exists in `apps/api/src/routes/portal/{dashboard,reports}.ts`, `apps/api/src/services/portal/actionItemsReadModel.ts`, `apps/portal/src/pages/{dashboard,security,reports}/index.astro`.
+
+**Depends on:** W01 (tables `service_deliverables`, `service_deliverable_occurrences`, `service_deliverable_evidence`, `organization_key_dates`; Drizzle exports `serviceDeliverables`, `serviceDeliverableOccurrences`, `serviceDeliverableEvidence`, `organizationKeyDates`), **W02** (the sweep that produces occurrences and delivery records), **W03** (`org_documents` table, its Drizzle export `orgDocuments`, and `apps/api/src/services/orgDocumentService.ts`). Do not start until W02 and W03 have merged to `main` and this branch is rebased on them.
+
+## Global Constraints
+
+- **Tenancy:** every read in this wave runs **inside the ambient portal org transaction** set by `portalAuthMiddleware` (`apps/api/src/routes/portal/auth.ts:356` — `scope: 'organization'`, `accessibleOrgIds: [orgId]`, `accessiblePartnerIds: []`, `userId: null`). **No `runOutsideDbContext`, no `withSystemDbAccessContext`, anywhere in this wave.** Spec §11: "Portal routes run as the portal session's org; no system escalation in any portal read model." All tables read here are shape 1 (direct `org_id`), so `breeze_has_org_access(org_id)` is the only policy exercised.
+- **Org id is server-derived.** Every read model takes `orgId` from `auth.user.orgId`; no route ever accepts an org id as input.
+- **Timezone** comes from `auth.timezone` (hydrated once by `portalAuthMiddleware`, `apps/api/src/routes/portal/schemas.ts:44-51`). Read models take it as a parameter and never resolve it themselves.
+- **Every new read-model function has a unit test asserting the compiled SQL carries the org predicate**, using `new PgDialect().sqlToQuery(where as SQL).params` and `toContain(ORG_ID)` — the pattern in `apps/api/src/services/portal/actionItemsReadModel.test.ts:52-56`. Asserting only the mocked return value is vacuous (memory: `drizzle_condition_deep_search_matches_enum_values_vacuous` — assert on the bound Param, never on a deep object search).
+- **Fail closed:** both new flags default `false` for every existing org; `createPortalFeatureGateStrict` (`apps/api/src/routes/portal/featureFlags.ts:80-99`) returns 403 when the `portal_branding` row is missing **or** the flag is not exactly `true`.
+- **Publication rules (spec §8, D10) live in the read model, not the route.** Restated as invariants every task must preserve:
+  1. No response in this wave contains a ticket id, ticket number, ticket subject, ticket URL, or any field whose name contains "ticket".
+  2. Document evidence appears when the document is `portal_visible = true` and not soft-deleted, **regardless of `enable_documents`** (that flag governs the library page only).
+  3. Report-run evidence appears only when `enable_reports` is true **and** the parent report has `portal_self_service = true` (`apps/api/src/services/portal/reportsSelfService.ts:174-180` is the existing access rule — the portal already refuses every other run).
+  4. A `delivered` occurrence with `artifact_required = true` and no portal-visible evidence reports `artifactState: 'held_by_msp'`. Nothing pretends evidence exists.
+- **Never invent zeros:** the dashboard tile carries `status: TileStatus` (`'ok' | 'no_data' | 'not_configured' | 'stale'`) and `null` values when a source is missing, matching `packages/shared/src/types/portalVisibility.ts:1-5`.
+- **Migration** is DDL-only (two `ADD COLUMN IF NOT EXISTS`), so no `breeze.scope` election is required; idempotent; no inner `BEGIN;`/`COMMIT;`. Filename must sort after the newest committed migration AND must not collide with a sibling wave. Slots claimed by the other plans in this feature, read from their own File-structure tables: W01 `-170000-`, `-170100-`, `-170200-`; W03 `-170300-` (org_documents) and `-170400-` (documents permissions); W05 `-170500-`. **This wave therefore uses `2026-10-15-170600-`.** Re-check with `ls apps/api/migrations | sort | tail -3` before committing and rename upward if `main` gained a later one — shipped migrations are content-hash immutable, so the time to get this right is before the push.
+- **Column rule:** adding a column to a table already in `CORE_ORG_CASCADE_DELETE_ORDER` breaks `tenant-export-policy.integration.test.ts`. `portal_branding` is such a table (`apps/api/src/services/tenantExportPolicyRegistry.ts:358`), so both new columns get `included` entries in the **same PR**. No new tables, so no cascade, merge-registry or RLS-allowlist changes.
+- **Portal (`apps/portal`) contract tests that WILL fail if you skip a step:** `lib/visibilityGate.test.ts:83-98` (gate-code parity with the API source), `lib/disabledPageCoverage.test.ts:85-116` (every page fed by a gated API method must branch on the gate 403 in its frontmatter) and `:193-204` (every signed-in page sits behind `PORTAL_PROTECTED_PREFIXES`), `lib/noInlineStyles.test.ts` (no `style={{...}}` — production CSP sets `style-src-attr 'none'`), `lib/basePathCoverage.test.ts` (hand-authored internal links go through `withBase()`).
+- **Web (`apps/web`) mutations** go through `runAction` (`apps/web/src/lib/runAction.ts`); every user-visible string added to `apps/web` needs a real translation in all 8 locales under `apps/web/src/locales/{en,de-DE,es-419,fr-CA,fr-FR,it-IT,pt-BR,tr-TR}/` — `apps/web/src/lib/i18n/translationCoverage.test.ts` caps exact-English duplicates.
+- **Running one test file:** `cd apps/api && npx vitest run <path>` and `cd apps/portal && npx vitest run <path>` and `cd apps/web && npx vitest run <path>`. **Never** `pnpm --filter <pkg> test -- --run <path>` (the `--` is forwarded literally, vitest stays in watch mode and runs the whole suite). Integration suites: `cd apps/api && npx vitest run --config vitest.integration.config.ts <path>` with `pnpm test-stack up` first and `pnpm test-stack down` when finished.
+- **Branch:** `feature/<parent#>-service-deliverables/wave-<W04 sub-issue#>`; PR body contains `Closes #<W04 sub-issue>`.
+
+---
+
+## File structure
+
+| Path | Responsibility |
+|---|---|
+| `apps/api/migrations/2026-10-15-170600-portal-branding-service-documents-flags.sql` | `enable_service`, `enable_documents` columns |
+| `apps/api/src/db/schema/portal.ts:36-40` area | the two Drizzle columns beside the five Wave-1 flags |
+| `apps/api/src/services/portal/portalFlags.ts:11-17` | both keys in `PORTAL_VISIBILITY_FLAG_KEYS` |
+| `apps/api/src/routes/portal/featureFlags.ts` | two `STRICT_PORTAL_FEATURES` entries + `createPortalFeatureGateAny` |
+| `apps/api/src/services/tenantExportPolicyRegistry.ts:358` | both columns `included` in `portal_branding` |
+| `packages/shared/src/validators/portal.ts:7-21` | both flags on `updatePortalSettingsSchema` |
+| `apps/api/src/routes/orgPortalSettings.ts` | defaults, row type, projection, response, `current` map |
+| `apps/api/src/routes/portal/branding.ts:105-113` | both flags in the authenticated branding projection |
+| `apps/web/src/components/settings/OrgPortalSettingsEditor.tsx` | two visibility toggles + enable-all + save body |
+| `apps/web/src/locales/*/settings.json` | two toggle label/description pairs ×8 locales |
+| `packages/shared/src/types/portalService.ts` (+ export from `types/index.ts`) | every DTO this wave returns |
+| `apps/api/src/services/portal/serviceReadModel.ts` (+ `.test.ts`) | `serviceOverview`, `deliverableOccurrences`, publication rules, `serviceTile` |
+| `apps/api/src/services/portal/documentsReadModel.ts` (+ `.test.ts`) | `documentsForOrg`, `portalVisibleDocument` |
+| `apps/api/src/services/portal/dashboard.ts` | `serviceTile` added to the `Promise.all` |
+| `apps/api/src/routes/portal/service.ts` (+ `.test.ts`) | `GET /service`, `GET /service/:deliverableId/occurrences` |
+| `apps/api/src/routes/portal/documents.ts` (+ `.test.ts`) | `GET /documents`, `GET /documents/:id/content` |
+| `apps/api/src/routes/portal/index.ts` | auth + gate mounts for both prefixes |
+| `apps/api/src/routes/portal/schemas.ts` | `portalOccurrenceListSchema`, `portalDocumentParamSchema`, `portalDeliverableParamSchema` |
+| `apps/api/src/__tests__/integration/portalServiceRls.integration.test.ts` | cross-org forge of every new route's read model |
+| `apps/portal/src/lib/{api,navItems,visibilityGate,protectedPaths}.ts` | client, nav, gate codes, protected prefixes |
+| `apps/portal/src/pages/service/index.astro` (+ `index.test.ts`) | Service page |
+| `apps/portal/src/pages/documents/index.astro` (+ `index.test.ts`) | Documents page |
+| `apps/portal/src/components/portal/ServiceScorecard.tsx` (+ `.test.tsx`) | groups, deliverable rows, occurrence history |
+| `apps/portal/src/components/portal/DocumentLibrary.tsx` (+ `.test.tsx`) | category groups, download links |
+| `apps/portal/src/components/portal/DashboardTiles.tsx` | the Service ledger row |
+
+---
+
+### Task 1: Flags — migration, Drizzle, flag registry, export policy
+
+**Files:**
+- Create: `apps/api/migrations/2026-10-15-170600-portal-branding-service-documents-flags.sql`
+- Modify: `apps/api/src/db/schema/portal.ts:34-40` (the five Wave-1 flags block)
+- Modify: `apps/api/src/services/portal/portalFlags.ts:11-17`
+- Modify: `apps/api/src/services/portal/portalFlags.test.ts:20-30`
+- Modify: `apps/api/src/routes/portal/featureFlags.ts:57-78`
+- Modify: `apps/api/src/services/tenantExportPolicyRegistry.ts:358`
+
+**Interfaces:**
+- Produces: columns `portal_branding.enable_service`, `portal_branding.enable_documents`; Drizzle `portalBranding.enableService`, `portalBranding.enableDocuments`; `PortalVisibilityFlag` widened to seven keys; 403 codes `PORTAL_SERVICE_DISABLED`, `PORTAL_DOCUMENTS_DISABLED`.
+
+- [ ] **Step 1: Confirm the filename still sorts last**
+
+```bash
+ls apps/api/migrations | sort | tail -3
+```
+Expected: nothing sorting after `2026-10-15-170600-…`. The sibling waves occupy `-170000-` through `-170500-` (see Global Constraints). If `main` gained a later migration, bump this file's time component above it and update every reference in this plan.
+
+- [ ] **Step 2: Write the migration**
+
+```sql
+-- Service deliverables W04 (spec §4.7, D10): two fail-closed customer-portal
+-- visibility flags. Existing portal_branding RLS, FORCE RLS and breeze_app
+-- grants already cover every column of this table, so nothing else is needed.
+-- DDL only: no rows are written, so no breeze.scope election.
+-- autoMigrate owns the transaction; do not add BEGIN or COMMIT.
+
+ALTER TABLE portal_branding
+  ADD COLUMN IF NOT EXISTS enable_service
+    boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS enable_documents
+    boolean NOT NULL DEFAULT false;
+```
+
+- [ ] **Step 3: Write the failing flag-registry test**
+
+In `apps/api/src/services/portal/portalFlags.test.ts`, extend the existing `PORTAL_VISIBILITY_FLAG_KEYS` assertion (line 22) to the seven-key list:
+
+```ts
+    expect(PORTAL_VISIBILITY_FLAG_KEYS).toEqual([
+      'enableDashboard',
+      'enableSecurity',
+      'enableBackups',
+      'enableReports',
+      'enableSupportUsage',
+      'enableService',
+      'enableDocuments'
+    ]);
+```
+
+And in `apps/api/src/routes/portal/featureFlags.test.ts`, add two rows to the `it.each` table at line 61:
+
+```ts
+    ['enableService', 'PORTAL_SERVICE_DISABLED'],
+    ['enableDocuments', 'PORTAL_DOCUMENTS_DISABLED'],
+```
+
+- [ ] **Step 4: Run to verify failure**
+
+Run: `cd apps/api && npx vitest run src/services/portal/portalFlags.test.ts src/routes/portal/featureFlags.test.ts`
+Expected: FAIL — the arrays differ by two entries and `STRICT_PORTAL_FEATURES` has no `enableService` key.
+
+- [ ] **Step 5: Add the Drizzle columns**
+
+In `apps/api/src/db/schema/portal.ts`, immediately after `enableSupportUsage` (line 40):
+
+```ts
+  // Service deliverables W04 (spec §4.7, D10): the Service scorecard and the
+  // org document library. Same fail-closed shape as the five flags above.
+  enableService: boolean('enable_service').notNull().default(false),
+  enableDocuments: boolean('enable_documents').notNull().default(false),
+```
+
+- [ ] **Step 6: Widen the flag registry and the strict-gate table**
+
+In `apps/api/src/services/portal/portalFlags.ts`, append `'enableService'` and `'enableDocuments'` to `PORTAL_VISIBILITY_FLAG_KEYS`. `onPortalFlagsChanged` is unchanged — neither new flag provisions anything.
+
+In `apps/api/src/routes/portal/featureFlags.ts`, add to `STRICT_PORTAL_FEATURES`:
+
+```ts
+  enableService: {
+    error: 'Service delivery is not enabled for this portal',
+    code: 'PORTAL_SERVICE_DISABLED',
+  },
+  enableDocuments: {
+    error: 'Documents are not enabled for this portal',
+    code: 'PORTAL_DOCUMENTS_DISABLED',
+  },
+```
+
+- [ ] **Step 7: Add `createPortalFeatureGateAny`**
+
+Document evidence is published under `enable_service` regardless of `enable_documents` (spec §8), but the download link it renders points at `/portal/documents/:id/content`. A gate on `enableDocuments` alone would 403 exactly the evidence the Service page just told the customer exists. Append to `apps/api/src/routes/portal/featureFlags.ts`:
+
+```ts
+/**
+ * Passes when ANY of `flags` is true on the org's portal_branding row. Still
+ * fail-closed: a missing row or all-false refuses, answering with the FIRST
+ * flag's message so the customer is told about the surface they asked for.
+ *
+ * The one legitimate use is the document CONTENT route: spec §8 publishes a
+ * portal-visible document as delivery evidence under enable_service even when
+ * enable_documents (the library page) is off, so the bytes must stay reachable
+ * under either flag while the library listing stays gated on its own.
+ */
+export function createPortalFeatureGateAny(
+  ...flags: readonly [PortalVisibilityFlag, ...PortalVisibilityFlag[]]
+): MiddlewareHandler {
+  return async (c, next) => {
+    const auth = c.get('portalAuth');
+    if (!auth) {
+      return c.json({ error: 'Authentication required' }, 401);
+    }
+    const [row] = await db
+      .select(Object.fromEntries(flags.map((f) => [f, portalBranding[f]])))
+      .from(portalBranding)
+      .where(eq(portalBranding.orgId, auth.user.orgId))
+      .limit(1);
+    if (flags.some((f) => row?.[f] === true)) return next();
+    return c.json(STRICT_PORTAL_FEATURES[flags[0]], 403);
+  };
+}
+```
+
+Add a test in `featureFlags.test.ts`: with `dbState.rows = [{ enableDocuments: false, enableService: true }]` the gate passes; with both false it answers 403 `PORTAL_DOCUMENTS_DISABLED`; with no row at all it answers 403; and the captured `dbState.where` params contain the org id.
+
+- [ ] **Step 8: Classify both columns in the export policy**
+
+In `apps/api/src/services/tenantExportPolicyRegistry.ts:358`, append `"enable_service","enable_documents"` to the end of `portal_branding`'s `included` array. They are ordinary boolean settings — not credentials, not open containers.
+
+- [ ] **Step 9: Run to verify pass**
+
+Run: `cd apps/api && npx vitest run src/services/portal/portalFlags.test.ts src/routes/portal/featureFlags.test.ts && npx tsc --noEmit`
+Expected: PASS, no type errors.
+
+With the test stack up (`pnpm test-stack up`):
+
+Run: `cd apps/api && npx vitest run --config vitest.integration.config.ts src/__tests__/integration/tenant-export-policy.integration.test.ts src/__tests__/integration/tenantExportErasureRoundtrip.integration.test.ts src/__tests__/integration/rls-coverage.integration.test.ts`
+Expected: PASS. A failure naming `enable_service` means Step 8 was skipped.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add apps/api/migrations/2026-10-15-170600-portal-branding-service-documents-flags.sql \
+  apps/api/src/db/schema/portal.ts apps/api/src/services/portal/portalFlags.ts \
+  apps/api/src/services/portal/portalFlags.test.ts apps/api/src/routes/portal/featureFlags.ts \
+  apps/api/src/routes/portal/featureFlags.test.ts apps/api/src/services/tenantExportPolicyRegistry.ts
+git commit -m "feat(portal): enable_service and enable_documents visibility flags (W04)"
+```
+
+---
+
+### Task 2: MSP write surface for the two flags
+
+**Files:**
+- Modify: `packages/shared/src/validators/portal.ts:7-21`
+- Modify: `apps/api/src/routes/orgPortalSettings.ts:23-96,186-192`
+- Modify: `apps/api/src/routes/orgPortalSettings.test.ts:305-340`
+- Modify: `apps/api/src/routes/portal/branding.ts:105-113`
+- Test: `apps/api/src/routes/orgPortalSettings.test.ts`, `packages/shared/src/validators/portal.test.ts`
+
+**Interfaces:**
+- Consumes: `PORTAL_VISIBILITY_FLAG_KEYS` (Task 1).
+- Produces: `PATCH /orgs/organizations/:id/portal-settings` accepts and returns `enableService`, `enableDocuments`; `GET /portal/branding` returns both.
+
+- [ ] **Step 1: Write the failing route test**
+
+In `apps/api/src/routes/orgPortalSettings.test.ts`, extend the "persists visibility flags and invokes the W09 seam" case (line 305) so the request sets `enableService: true` and the expected `current` map carries all seven keys:
+
+```ts
+    const res = await patch({ enableDashboard: true, enableReports: true, enableService: true });
+    …
+    expect(onPortalFlagsChanged).toHaveBeenCalledWith({
+      orgId: ORG_ID,
+      createdBy: 'u-1',
+      requested: { enableDashboard: true, enableReports: true, enableService: true },
+      current: {
+        enableDashboard: true, enableSecurity: false, enableBackups: false,
+        enableReports: true, enableSupportUsage: false,
+        enableService: true, enableDocuments: false
+      }
+    });
+```
+Add `enableService: true, enableDocuments: false` to that case's `dbUpsertReturning` row and `enableService: false, enableDocuments: false` to the shared `FULL_ROW` fixture.
+
+In `packages/shared/src/validators/portal.test.ts`, add:
+
+```ts
+  it('accepts the W04 service and documents flags', () => {
+    expect(updatePortalSettingsSchema.safeParse({ enableService: true, enableDocuments: false }).success).toBe(true);
+  });
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/api && npx vitest run src/routes/orgPortalSettings.test.ts` and `cd packages/shared && npx vitest run src/validators/portal.test.ts`
+Expected: FAIL — the `.strict()` schema rejects the unknown keys, and `current` is short two entries.
+
+- [ ] **Step 3: Implement**
+
+`packages/shared/src/validators/portal.ts`, after `enableSupportUsage` (line 16):
+
+```ts
+  enableService: z.boolean().optional(),
+  enableDocuments: z.boolean().optional(),
+```
+
+`apps/api/src/routes/orgPortalSettings.ts` — four edits, all mechanical:
+- `PORTAL_SETTINGS_DEFAULTS` (line 23): add `enableService: false, enableDocuments: false`.
+- `PortalSettingsRow` (line 39): add `enableService: boolean; enableDocuments: boolean;`.
+- `portalSettingsColumns()` (line 62): add `enableService: portalBranding.enableService, enableDocuments: portalBranding.enableDocuments`.
+- `toResponse` (line 78): add `enableService: row.enableService, enableDocuments: row.enableDocuments`.
+- the `current:` literal (line 186): add `enableService: row.enableService, enableDocuments: row.enableDocuments`.
+
+`apps/api/src/routes/portal/branding.ts`, after `enableSupportUsage` (line 113):
+
+```ts
+      enableSupportUsage: portalBranding.enableSupportUsage,
+      enableService: portalBranding.enableService,
+      enableDocuments: portalBranding.enableDocuments
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd apps/api && npx vitest run src/routes/orgPortalSettings.test.ts src/routes/portal/branding.test.ts && npx tsc --noEmit`
+Run: `cd packages/shared && npx vitest run src/validators/portal.test.ts && npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/shared/src/validators/portal.ts packages/shared/src/validators/portal.test.ts \
+  apps/api/src/routes/orgPortalSettings.ts apps/api/src/routes/orgPortalSettings.test.ts \
+  apps/api/src/routes/portal/branding.ts
+git commit -m "feat(portal): read and write the service and documents flags (W04)"
+```
+
+---
+
+### Task 3: MSP web toggles and translations
+
+**Files:**
+- Modify: `apps/web/src/components/settings/OrgPortalSettingsEditor.tsx:8-22,48-85,124-131,141-158`
+- Modify: `apps/web/src/components/settings/OrgPortalSettingsEditor.test.tsx:25-40,113-160`
+- Modify: `apps/web/src/locales/{en,de-DE,es-419,fr-CA,fr-FR,it-IT,pt-BR,tr-TR}/settings.json`
+
+**Interfaces:**
+- Consumes: the PATCH contract from Task 2.
+- Produces: `data-testid="org-portal-toggle-enableService"`, `data-testid="org-portal-toggle-enableDocuments"`.
+
+- [ ] **Step 1: Write the failing component test**
+
+In `OrgPortalSettingsEditor.test.tsx`, add `enableService: false, enableDocuments: false` to the settings fixture (line ~31), then extend the two existing lists (line 120 and line 150) with `'enableService'` and `'enableDocuments'` so both "enable all" and "save all" cover seven flags.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/web && npx vitest run src/components/settings/OrgPortalSettingsEditor.test.tsx`
+Expected: FAIL — `org-portal-toggle-enableService` is not in the document.
+
+- [ ] **Step 3: Implement**
+
+In `OrgPortalSettingsEditor.tsx`:
+- `PortalSettings` type (line 8): add `enableService: boolean; enableDocuments: boolean;`.
+- `VisibilityToggleKey` union (line 48): add `| 'enableService' | 'enableDocuments'`.
+- `VISIBILITY_TOGGLES` (line 56): append two entries following the existing shape:
+
+```ts
+  {
+    key: 'enableService',
+    labelKey: 'orgPortalSettingsEditor.visibility.toggles.enableService.label',
+    descriptionKey: 'orgPortalSettingsEditor.visibility.toggles.enableService.description',
+  },
+  {
+    key: 'enableDocuments',
+    labelKey: 'orgPortalSettingsEditor.visibility.toggles.enableDocuments.label',
+    descriptionKey: 'orgPortalSettingsEditor.visibility.toggles.enableDocuments.description',
+  },
+```
+- `enableAllVisibility` (line 124): add `enableService: true, enableDocuments: true`.
+- the `runAction` PATCH body (line 141): add `enableService: draft.enableService, enableDocuments: draft.enableDocuments`.
+
+No new markup — the existing `VISIBILITY_TOGGLES.map` renders both.
+
+- [ ] **Step 4: Add real translations in all 8 locales**
+
+Under `orgPortalSettingsEditor.visibility.toggles` in each `settings.json`. English:
+
+```json
+"enableService": {
+  "label": "Service",
+  "description": "Show scheduled deliverables, what was delivered, and key dates."
+},
+"enableDocuments": {
+  "label": "Documents",
+  "description": "Let customers download the documents you have shared with them."
+}
+```
+
+Translate — do not paste English into the other seven. de-DE: "Service" / "Zeigt geplante Leistungen, Erbrachtes und wichtige Termine." and "Dokumente" / "Ermöglicht Kunden den Download freigegebener Dokumente."; es-419: "Servicio" / "Muestra los entregables programados, lo entregado y las fechas clave." and "Documentos" / "Permite a los clientes descargar los documentos que compartiste."; fr-CA and fr-FR: "Service" / "Affiche les livrables planifiés, ce qui a été livré et les dates clés." and "Documents" / "Permet aux clients de télécharger les documents partagés."; it-IT: "Servizio" / "Mostra i deliverable pianificati, quanto consegnato e le date chiave." and "Documenti" / "Consente ai clienti di scaricare i documenti condivisi."; pt-BR: "Serviço" / "Mostra as entregas programadas, o que foi entregue e as datas importantes." and "Documentos" / "Permite que os clientes baixem os documentos compartilhados."; tr-TR: "Hizmet" / "Planlanan teslimatları, teslim edilenleri ve önemli tarihleri gösterir." and "Belgeler" / "Müşterilerin paylaşılan belgeleri indirmesine izin verir."
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `cd apps/web && npx vitest run src/components/settings/OrgPortalSettingsEditor.test.tsx src/lib/i18n`
+Expected: PASS, including `translationCoverage.test.ts` (the duplicate-English cap is why Step 4 must be real translations).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/settings apps/web/src/locales
+git commit -m "feat(web): service and documents portal visibility toggles (W04)"
+```
+
+---
+
+### Task 4: Shared DTO types
+
+**Files:**
+- Create: `packages/shared/src/types/portalService.ts`
+- Create: `packages/shared/src/types/portalService.test.ts`
+- Modify: `packages/shared/src/types/index.ts:845` area (add `export * from './portalService';`)
+
+**Interfaces:**
+- Consumes: `TileStatus` from `./portalVisibility`.
+- Produces (both the API read models and `apps/portal` import these):
+
+```ts
+import type { TileStatus } from './portalVisibility';
+
+/** Where a row on the Service page came from. Spec §8 keeps these discriminated
+ *  so a future Projects module adds 'project' / 'project_milestone' arms to the
+ *  same page instead of a second page. */
+export type PortalServiceGroupSource = 'contract' | 'standalone';
+export type PortalKeyDateSource = 'key_date' | 'contract_end';
+
+export type PortalDeliverableCadence =
+  | 'monthly' | 'quarterly' | 'semiannual' | 'annual' | 'one_time';
+
+/** Customer-facing rollup of a deliverable's current standing. */
+export type PortalDeliverableStatus = 'on_track' | 'due_soon' | 'late' | 'missed';
+
+/**
+ * Customer-facing occurrence state. `awaiting_evidence` is deliberately ABSENT:
+ * it means the MSP resolved its internal ticket but has not attached the
+ * artifact, which is a workflow detail of the MSP, not a fact about the
+ * customer's service. It maps to 'in_progress' (spec D10: curated delivery
+ * records only, never the ticket behind them).
+ */
+export type PortalOccurrenceStatus =
+  | 'scheduled' | 'in_progress' | 'delivered' | 'missed' | 'waived';
+
+/** What the customer can actually open for a delivery. */
+export type PortalArtifactState = 'attached' | 'report' | 'none' | 'held_by_msp';
+
+export interface PortalEvidenceRef {
+  kind: 'document' | 'report_run';
+  /** Set for kind 'document'; download at /api/v1/portal/documents/<id>/content. */
+  documentId: string | null;
+  /** Set for kind 'report_run'; download at /api/v1/portal/reports/runs/<id>/pdf. */
+  reportRunId: string | null;
+  title: string;
+  createdAt: string;
+}
+
+export interface PortalDeliveryRecord {
+  at: string;
+  late: boolean;
+  note: string | null;
+  artifactState: PortalArtifactState;
+  evidence: PortalEvidenceRef[];
+}
+
+export interface PortalDeliverableDto {
+  id: string;
+  name: string;
+  description: string | null;
+  cadence: PortalDeliverableCadence;
+  artifactRequired: boolean;
+  lastDelivered: PortalDeliveryRecord | null;
+  nextDue: string | null;
+  status: PortalDeliverableStatus;
+}
+
+export interface PortalServiceGroupDto {
+  source: PortalServiceGroupSource;
+  contract: { id: string; name: string } | null;
+  deliverables: PortalDeliverableDto[];
+}
+
+export interface PortalKeyDateDto {
+  source: PortalKeyDateSource;
+  id: string;
+  label: string;
+  kind: string;
+  date: string;
+  notes: string | null;
+}
+
+export interface PortalServiceOverviewDto {
+  asOf: string;
+  timezone: string;
+  groups: PortalServiceGroupDto[];
+  keyDates: PortalKeyDateDto[];
+}
+
+export interface PortalOccurrenceDto {
+  id: string;
+  name: string;
+  periodStart: string;
+  periodEnd: string;
+  dueAt: string;
+  rescheduled: boolean;
+  status: PortalOccurrenceStatus;
+  deliveredAt: string | null;
+  late: boolean;
+  note: string | null;
+  artifactState: PortalArtifactState;
+  evidence: PortalEvidenceRef[];
+}
+
+export interface PortalOccurrencesDto {
+  asOf: string;
+  timezone: string;
+  deliverable: { id: string; name: string; cadence: PortalDeliverableCadence };
+  occurrences: PortalOccurrenceDto[];
+}
+
+export type PortalDocumentCategory =
+  | 'baseline' | 'runbook' | 'policy' | 'evidence' | 'report' | 'export' | 'other';
+
+export interface PortalDocumentDto {
+  id: string;
+  title: string;
+  description: string | null;
+  category: PortalDocumentCategory;
+  contentType: string;
+  byteSize: number;
+  originalFilename: string;
+  createdAt: string;
+}
+
+export interface PortalDocumentGroupDto {
+  category: PortalDocumentCategory;
+  documents: PortalDocumentDto[];
+}
+
+export interface PortalDocumentsDto {
+  asOf: string;
+  timezone: string;
+  groups: PortalDocumentGroupDto[];
+}
+
+/** Dashboard tile (spec §8): 90-day delivery record plus the next due item. */
+export interface ServiceTileDto {
+  status: TileStatus;
+  windowDays: 90;
+  deliveredOnTime: number | null;
+  deliveredLate: number | null;
+  missed: number | null;
+  nextDue: { name: string; dueAt: string } | null;
+  asOf: string;
+}
+```
+
+- [ ] **Step 1: Write the failing type test**
+
+```ts
+// packages/shared/src/types/portalService.test.ts
+import { describe, expectTypeOf, it } from 'vitest';
+import type {
+  PortalArtifactState, PortalOccurrenceStatus, PortalServiceOverviewDto, ServiceTileDto,
+} from './portalService';
+
+describe('portal service DTOs', () => {
+  it('never exposes a ticket anywhere in the overview', () => {
+    // Compile-time proof of spec D10: the portal shows the delivery record, not
+    // the ticket. A future field called ticketId would fail this immediately.
+    expectTypeOf<keyof PortalServiceOverviewDto>().toEqualTypeOf<'asOf' | 'timezone' | 'groups' | 'keyDates'>();
+  });
+  it('hides awaiting_evidence from the customer vocabulary', () => {
+    expectTypeOf<PortalOccurrenceStatus>().not.toEqualTypeOf<'awaiting_evidence'>();
+  });
+  it('carries the four artifact states', () => {
+    expectTypeOf<PortalArtifactState>().toEqualTypeOf<'attached' | 'report' | 'none' | 'held_by_msp'>();
+  });
+  it('windows the service tile at 90 days', () => {
+    expectTypeOf<ServiceTileDto['windowDays']>().toEqualTypeOf<90>();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd packages/shared && npx vitest run src/types/portalService.test.ts`
+Expected: FAIL, module not found.
+
+- [ ] **Step 3: Write `portalService.ts` exactly as in the Interfaces block, and add `export * from './portalService';` to `packages/shared/src/types/index.ts` next to the `portalVisibility` export (line 845).**
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd packages/shared && npx vitest run src/types/portalService.test.ts && npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/shared/src/types
+git commit -m "feat(shared): portal service and documents DTOs (W04)"
+```
+
+---
+
+### Task 5: `serviceReadModel.ts` — publication rules and `serviceOverview`
+
+**Files:**
+- Create: `apps/api/src/services/portal/serviceReadModel.ts`
+- Create: `apps/api/src/services/portal/serviceReadModel.test.ts`
+
+**Interfaces:**
+- Consumes: `serviceDeliverables`, `serviceDeliverableOccurrences`, `serviceDeliverableEvidence`, `organizationKeyDates` (W01 Task 3); `orgDocuments` (W03); `contracts`, `reports`, `reportRuns`, `portalBranding` from `../../db/schema`; `summarizeStatus` from `../serviceDeliverableService` (W01 Task 8).
+- Produces:
+
+```ts
+export function artifactStateFor(args: {
+  artifactRequired: boolean; delivered: boolean; evidence: readonly PortalEvidenceRef[];
+}): PortalArtifactState;
+export function portalOccurrenceStatus(dbStatus: string): PortalOccurrenceStatus;
+export async function serviceOverview(
+  orgId: string, args: { timezone: string; now: Date },
+): Promise<PortalServiceOverviewDto>;
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// apps/api/src/services/portal/serviceReadModel.test.ts
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import type { SQL } from 'drizzle-orm';
+
+const state = vi.hoisted(() => ({ rows: [] as unknown[][], wheres: [] as unknown[] }));
+
+vi.mock('../../db', () => ({
+  db: {
+    select: vi.fn(() => {
+      const chain: Record<string, unknown> = {};
+      for (const m of ['from', 'where', 'orderBy', 'limit', 'innerJoin', 'leftJoin']) {
+        chain[m] = vi.fn((arg: unknown) => {
+          if (m === 'where') state.wheres.push(arg);
+          return chain;
+        });
+      }
+      chain.then = (resolve: (rows: unknown[]) => unknown) =>
+        Promise.resolve(state.rows.shift() ?? []).then(resolve);
+      return chain;
+    }),
+  },
+}));
+
+import { artifactStateFor, portalOccurrenceStatus, serviceOverview } from './serviceReadModel';
+
+const ORG_ID = '11111111-1111-4111-8111-111111111111';
+const NOW = new Date('2026-10-15T12:00:00Z');
+
+describe('artifactStateFor (spec §8 D10)', () => {
+  it('is held_by_msp when a required artifact has no portal-visible evidence', () => {
+    expect(artifactStateFor({ artifactRequired: true, delivered: true, evidence: [] }))
+      .toBe('held_by_msp');
+  });
+  it('is none when no artifact was required', () => {
+    expect(artifactStateFor({ artifactRequired: false, delivered: true, evidence: [] })).toBe('none');
+  });
+  it('is none for an undelivered occurrence even when an artifact is required', () => {
+    expect(artifactStateFor({ artifactRequired: true, delivered: false, evidence: [] })).toBe('none');
+  });
+  it('prefers an attached document over a report run', () => {
+    const doc = { kind: 'document' as const, documentId: 'd1', reportRunId: null, title: 'Findings', createdAt: '' };
+    const run = { kind: 'report_run' as const, documentId: null, reportRunId: 'r1', title: 'Scan', createdAt: '' };
+    expect(artifactStateFor({ artifactRequired: true, delivered: true, evidence: [run, doc] })).toBe('attached');
+    expect(artifactStateFor({ artifactRequired: true, delivered: true, evidence: [run] })).toBe('report');
+  });
+});
+
+describe('portalOccurrenceStatus', () => {
+  it('hides awaiting_evidence behind in_progress', () => {
+    expect(portalOccurrenceStatus('awaiting_evidence')).toBe('in_progress');
+    expect(portalOccurrenceStatus('open')).toBe('in_progress');
+    expect(portalOccurrenceStatus('scheduled')).toBe('scheduled');
+    expect(portalOccurrenceStatus('delivered')).toBe('delivered');
+    expect(portalOccurrenceStatus('missed')).toBe('missed');
+    expect(portalOccurrenceStatus('waived')).toBe('waived');
+  });
+});
+
+describe('serviceOverview', () => {
+  beforeEach(() => { state.rows.length = 0; state.wheres.length = 0; });
+
+  function seed(opts: { enableReports: boolean; evidence: unknown[] }) {
+    state.rows.push([{ enableReports: opts.enableReports }]);          // branding read
+    state.rows.push([{                                                  // deliverables + contract
+      id: 'd1', name: 'Sign-in log review', description: 'Monthly review',
+      cadence: 'monthly', artifactRequired: true, leadDays: 7,
+      effectiveFrom: '2026-01-01', effectiveUntil: null, active: true,
+      contractId: 'c1', contractName: 'Best plan',
+    }]);
+    state.rows.push([{                                                  // occurrences
+      id: 'o1', deliverableId: 'd1', status: 'delivered', dueAt: '2026-09-30',
+      originalDueAt: '2026-09-30', periodStart: '2026-09-01', periodEnd: '2026-09-30',
+      deliveredAt: new Date('2026-10-02T09:00:00Z'), deliveryNote: 'Reviewed',
+    }]);
+    state.rows.push(opts.evidence);                                     // evidence join
+    state.rows.push([]);                                                // key dates
+    state.rows.push([]);                                                // contract end dates
+  }
+
+  it('never leaks a ticket into the payload', async () => {
+    seed({ enableReports: true, evidence: [] });
+    const dto = await serviceOverview(ORG_ID, { timezone: 'America/Denver', now: NOW });
+    expect(JSON.stringify(dto)).not.toMatch(/ticket/i);
+  });
+
+  it('scopes every query to the session org', async () => {
+    seed({ enableReports: true, evidence: [] });
+    await serviceOverview(ORG_ID, { timezone: 'UTC', now: NOW });
+    expect(state.wheres.length).toBeGreaterThan(0);
+    for (const where of state.wheres) {
+      expect(new PgDialect().sqlToQuery(where as SQL).params).toContain(ORG_ID);
+    }
+  });
+
+  it('marks a late delivery of a required artifact with no evidence as held_by_msp', async () => {
+    seed({ enableReports: true, evidence: [] });
+    const dto = await serviceOverview(ORG_ID, { timezone: 'UTC', now: NOW });
+    expect(dto.groups[0]!.source).toBe('contract');
+    expect(dto.groups[0]!.contract).toEqual({ id: 'c1', name: 'Best plan' });
+    expect(dto.groups[0]!.deliverables[0]!.lastDelivered).toMatchObject({
+      late: true, note: 'Reviewed', artifactState: 'held_by_msp', evidence: [],
+    });
+  });
+
+  it('publishes report-run evidence only when reports are on and the definition is self-service', async () => {
+    const run = {
+      occurrenceId: 'o1', evidenceId: 'e1', kind: 'report_run', documentId: null,
+      documentTitle: null, documentPortalVisible: null, documentDeletedAt: null,
+      reportRunId: 'r1', reportName: 'Vulnerability review', reportPortalSelfService: true,
+      createdAt: new Date('2026-10-02T09:05:00Z'),
+    };
+    seed({ enableReports: false, evidence: [run] });
+    const off = await serviceOverview(ORG_ID, { timezone: 'UTC', now: NOW });
+    expect(off.groups[0]!.deliverables[0]!.lastDelivered!.evidence).toEqual([]);
+    expect(off.groups[0]!.deliverables[0]!.lastDelivered!.artifactState).toBe('held_by_msp');
+
+    state.rows.length = 0;
+    seed({ enableReports: true, evidence: [{ ...run, reportPortalSelfService: false }] });
+    const notSelfService = await serviceOverview(ORG_ID, { timezone: 'UTC', now: NOW });
+    expect(notSelfService.groups[0]!.deliverables[0]!.lastDelivered!.evidence).toEqual([]);
+
+    state.rows.length = 0;
+    seed({ enableReports: true, evidence: [run] });
+    const on = await serviceOverview(ORG_ID, { timezone: 'UTC', now: NOW });
+    expect(on.groups[0]!.deliverables[0]!.lastDelivered!.evidence).toEqual([
+      { kind: 'report_run', documentId: null, reportRunId: 'r1', title: 'Vulnerability review', createdAt: '2026-10-02T09:05:00.000Z' },
+    ]);
+    expect(on.groups[0]!.deliverables[0]!.lastDelivered!.artifactState).toBe('report');
+  });
+
+  it('hides a document that is not portal-visible or is soft-deleted', async () => {
+    const base = {
+      occurrenceId: 'o1', evidenceId: 'e2', kind: 'document', documentId: 'doc1',
+      documentTitle: 'Findings', reportRunId: null, reportName: null,
+      reportPortalSelfService: null, createdAt: new Date('2026-10-02T09:05:00Z'),
+    };
+    for (const hidden of [
+      { ...base, documentPortalVisible: false, documentDeletedAt: null },
+      { ...base, documentPortalVisible: true, documentDeletedAt: new Date() },
+    ]) {
+      state.rows.length = 0;
+      seed({ enableReports: true, evidence: [hidden] });
+      const dto = await serviceOverview(ORG_ID, { timezone: 'UTC', now: NOW });
+      expect(dto.groups[0]!.deliverables[0]!.lastDelivered!.evidence).toEqual([]);
+    }
+  });
+
+  it('publishes a portal-visible document even when documents are off', async () => {
+    // Spec §8: enable_documents governs the LIBRARY page only. The branding read
+    // in this read model asks for enableReports and nothing else, so a document
+    // cannot be filtered by a flag this model never reads.
+    seed({ enableReports: false, evidence: [{
+      occurrenceId: 'o1', evidenceId: 'e3', kind: 'document', documentId: 'doc1',
+      documentTitle: 'Findings', documentPortalVisible: true, documentDeletedAt: null,
+      reportRunId: null, reportName: null, reportPortalSelfService: null,
+      createdAt: new Date('2026-10-02T09:05:00Z'),
+    }] });
+    const dto = await serviceOverview(ORG_ID, { timezone: 'UTC', now: NOW });
+    expect(dto.groups[0]!.deliverables[0]!.lastDelivered!.artifactState).toBe('attached');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/api && npx vitest run src/services/portal/serviceReadModel.test.ts`
+Expected: FAIL, module not found.
+
+- [ ] **Step 3: Implement `serviceOverview` and its pure helpers**
+
+Query plan — six selects, all in the ambient org transaction, all carrying an explicit `org_id` predicate even though RLS already enforces it (defence in depth, and it is what the SQL-predicate test asserts):
+
+1. `portal_branding` → `{ enableReports }` for this org (rule 3 needs it; `enableDocuments` is deliberately **not** read here).
+2. `service_deliverables` left-joined to `contracts` on `(contractId, orgId)` where `orgId = $1 AND portal_visible AND active AND effective_from <= today AND (effective_until IS NULL OR effective_until >= today)`, ordered by `sortOrder, name`. `today` is `now` rendered in `args.timezone` as `YYYY-MM-DD` (use the existing `Intl.DateTimeFormat(… { timeZone })` helper convention in `services/portal/sqlTimestamp.ts`; if a helper is not exported there, add `isoDateInTimezone(now, tz)` to this module and unit-test it with `America/Denver` at `2026-10-01T03:00:00Z` → `2026-09-30`).
+3. `service_deliverable_occurrences` where `orgId = $1 AND deliverableId IN (…)`, ordered `dueAt desc` — one round trip for every deliverable, then bucketed in JS.
+4. `service_deliverable_evidence` left-joined to `org_documents` on `(documentId, orgId)` and to `reports` on `(reportId, orgId)`, selecting `documentPortalVisible`, `documentDeletedAt`, `documentTitle`, `reportName`, `reportPortalSelfService`, where `orgId = $1 AND occurrenceId IN (…the occurrence ids that matter…)`.
+5. `organization_key_dates` where `orgId = $1 AND portal_visible AND date >= today`, ordered `date asc`, limit 20.
+6. `contracts` where `orgId = $1 AND end_date IS NOT NULL AND end_date >= today AND status NOT IN ('draft','cancelled')`, ordered `end_date asc`.
+
+Then, in JS:
+
+```ts
+export function artifactStateFor(args: {
+  artifactRequired: boolean; delivered: boolean; evidence: readonly PortalEvidenceRef[];
+}): PortalArtifactState {
+  if (args.evidence.some((e) => e.kind === 'document')) return 'attached';
+  if (args.evidence.some((e) => e.kind === 'report_run')) return 'report';
+  return args.delivered && args.artifactRequired ? 'held_by_msp' : 'none';
+}
+
+const OCCURRENCE_STATUS: Record<string, PortalOccurrenceStatus> = {
+  scheduled: 'scheduled',
+  open: 'in_progress',
+  awaiting_evidence: 'in_progress',
+  delivered: 'delivered',
+  missed: 'missed',
+  waived: 'waived',
+};
+export function portalOccurrenceStatus(dbStatus: string): PortalOccurrenceStatus {
+  return OCCURRENCE_STATUS[dbStatus] ?? 'in_progress';
+}
+
+/** Rules 2 and 3 of the publication contract, applied to one evidence row. */
+function publishableEvidence(row: EvidenceJoinRow, enableReports: boolean): PortalEvidenceRef | null {
+  if (row.kind === 'document') {
+    if (row.documentPortalVisible !== true || row.documentDeletedAt !== null) return null;
+    return { kind: 'document', documentId: row.documentId, reportRunId: null,
+             title: row.documentTitle ?? 'Document', createdAt: row.createdAt.toISOString() };
+  }
+  if (!enableReports || row.reportPortalSelfService !== true) return null;
+  return { kind: 'report_run', documentId: null, reportRunId: row.reportRunId,
+           title: row.reportName ?? 'Report', createdAt: row.createdAt.toISOString() };
+}
+```
+
+`lastDelivered` is the newest occurrence with `status === 'delivered'`; `late` is `deliveredAtISODate > dueAt` (derived, never stored — spec §4.2). `nextDue` is the smallest `dueAt >= today` among occurrences whose status is `scheduled`, `open` or `awaiting_evidence`; `null` when there is none.
+
+`status` reuses `summarizeStatus` from `../serviceDeliverableService` so the portal and the MSP page can never disagree. It can return `'inactive'`; the deliverable query already excludes inactive rows, so treat `'inactive'` as "drop this deliverable from the payload" rather than inventing a fifth customer-facing word:
+
+```ts
+const rollup = summarizeStatus(
+  { active: d.active, effectiveFrom: d.effectiveFrom, effectiveUntil: d.effectiveUntil, leadDays: d.leadDays },
+  occ.map((o) => ({ status: o.status as OccurrenceStatus, dueAt: o.dueAt })),
+  today,
+);
+if (rollup === 'inactive') continue;   // predicate drift, not a customer state
+```
+
+Grouping: one group per distinct `contractId` (`source: 'contract'`, `contract: { id, name }`), ordered by contract name; then at most one `source: 'standalone'` group with `contract: null` for deliverables with no contract, appended last. Groups with no surviving deliverables are omitted.
+
+`keyDates`: query-5 rows map to `{ source: 'key_date', id, label, kind, date, notes }`; query-6 rows map to `{ source: 'contract_end', id: contract.id, label: contract.name, kind: 'contract_end', date: contract.endDate, notes: null }`. Concatenate and sort by `date` ascending.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd apps/api && npx vitest run src/services/portal/serviceReadModel.test.ts && npx tsc --noEmit`
+Expected: PASS, no type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/portal/serviceReadModel.ts apps/api/src/services/portal/serviceReadModel.test.ts
+git commit -m "feat(portal): service overview read model with D10 publication rules (W04)"
+```
+
+---
+
+### Task 6: `deliverableOccurrences` and `serviceTile`
+
+**Files:**
+- Modify: `apps/api/src/services/portal/serviceReadModel.ts`
+- Modify: `apps/api/src/services/portal/serviceReadModel.test.ts`
+- Modify: `apps/api/src/services/portal/dashboard.ts:42-77`
+- Modify: `apps/api/src/services/portal/dashboard.test.ts`
+- Modify: `packages/shared/src/types/portalVisibility.ts:92-102` (`DashboardDto`)
+
+**Interfaces:**
+- Consumes: `artifactStateFor`, `portalOccurrenceStatus`, `publishableEvidence` (Task 5).
+- Produces:
+
+```ts
+export async function deliverableOccurrences(
+  orgId: string, deliverableId: string,
+  args: { timezone: string; now: Date; limit?: number },
+): Promise<PortalOccurrencesDto | null>;   // null = no portal-visible deliverable with that id in this org
+export async function serviceTile(
+  orgId: string, args: { timezone: string; now: Date },
+): Promise<ServiceTileDto | null>;         // null = enable_service is off for this org
+```
+and `DashboardDto` gains an optional `service?: ServiceTileDto`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `serviceReadModel.test.ts`:
+
+```ts
+describe('deliverableOccurrences', () => {
+  beforeEach(() => { state.rows.length = 0; state.wheres.length = 0; });
+
+  it('returns null for a deliverable that is not a portal-visible row of this org', async () => {
+    state.rows.push([]);  // deliverable lookup finds nothing (RLS or portal_visible=false)
+    await expect(deliverableOccurrences(ORG_ID, 'other-org-deliverable', { timezone: 'UTC', now: NOW }))
+      .resolves.toBeNull();
+  });
+
+  it('caps the history at 24 and marks a rescheduled occurrence', async () => {
+    state.rows.push([{ id: 'd1', name: 'Firewall rule review', cadence: 'quarterly', artifactRequired: true }]);
+    state.rows.push([{
+      id: 'o1', status: 'awaiting_evidence', dueAt: '2026-10-31', originalDueAt: '2026-09-30',
+      periodStart: '2026-08-01', periodEnd: '2026-10-31', deliveredAt: null, deliveryNote: null,
+    }]);
+    state.rows.push([]);  // evidence
+    state.rows.push([{ enableReports: true }]);
+
+    const dto = await deliverableOccurrences(ORG_ID, 'd1', { timezone: 'UTC', now: NOW, limit: 999 });
+    expect(dto!.occurrences[0]).toMatchObject({
+      status: 'in_progress', rescheduled: true, late: false, artifactState: 'none',
+    });
+    expect(JSON.stringify(dto)).not.toMatch(/ticket/i);
+    // limit is clamped to 24 regardless of the caller.
+    const limitCall = state.wheres.length;
+    expect(limitCall).toBeGreaterThan(0);
+  });
+});
+
+describe('serviceTile', () => {
+  beforeEach(() => { state.rows.length = 0; state.wheres.length = 0; });
+
+  it('returns null when enable_service is off', async () => {
+    state.rows.push([{ enableService: false }]);
+    await expect(serviceTile(ORG_ID, { timezone: 'UTC', now: NOW })).resolves.toBeNull();
+  });
+
+  it('returns null when the org has no portal_branding row at all', async () => {
+    state.rows.push([]);
+    await expect(serviceTile(ORG_ID, { timezone: 'UTC', now: NOW })).resolves.toBeNull();
+  });
+
+  it('counts the 90-day record and names the next due item', async () => {
+    state.rows.push([{ enableService: true }]);
+    state.rows.push([{ onTime: 5, late: 1, missed: 2 }]);
+    state.rows.push([{ name: 'Monthly sign-in log review', dueAt: '2026-10-31' }]);
+    await expect(serviceTile(ORG_ID, { timezone: 'UTC', now: NOW })).resolves.toEqual({
+      status: 'ok', windowDays: 90, deliveredOnTime: 5, deliveredLate: 1, missed: 2,
+      nextDue: { name: 'Monthly sign-in log review', dueAt: '2026-10-31' },
+      asOf: NOW.toISOString(),
+    });
+  });
+
+  it('reports no_data rather than a fabricated zero when nothing has been scheduled', async () => {
+    state.rows.push([{ enableService: true }]);
+    state.rows.push([{ onTime: 0, late: 0, missed: 0 }]);
+    state.rows.push([]);
+    const tile = await serviceTile(ORG_ID, { timezone: 'UTC', now: NOW });
+    expect(tile).toMatchObject({ status: 'no_data', deliveredOnTime: null, nextDue: null });
+  });
+});
+```
+
+In `apps/api/src/services/portal/dashboard.test.ts`, add to the existing orchestration test a `serviceTile` mock and assert two cases: when it resolves a tile, `dto.service` is that tile; when it resolves `null`, `'service' in dto` is `false`.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/api && npx vitest run src/services/portal/serviceReadModel.test.ts src/services/portal/dashboard.test.ts`
+Expected: FAIL — `deliverableOccurrences` / `serviceTile` are not exported.
+
+- [ ] **Step 3: Implement**
+
+`deliverableOccurrences`:
+1. Select the deliverable: `orgId = $1 AND id = $2 AND portal_visible = true`. Empty → return `null`. **404-not-403**: the route turns `null` into a bare 404, so a cross-org id is indistinguishable from a non-existent one.
+2. Select occurrences for it, `orderBy(desc(dueAt))`, `.limit(Math.min(args.limit ?? 24, 24))`. Spec §8 says "last 24 occurrences"; the cap is enforced here and not trusted from the query string.
+3. Select the evidence join for those occurrence ids (same select as Task 5 query 4).
+4. Select `portal_branding.enableReports` for rule 3.
+Map each row: `status: portalOccurrenceStatus(row.status)`, `rescheduled: row.dueAt !== row.originalDueAt`, `late: row.deliveredAt !== null && isoDateInTimezone(row.deliveredAt, tz) > row.dueAt`, `note: row.deliveryNote`, `evidence` filtered through `publishableEvidence`, `artifactState: artifactStateFor({ artifactRequired, delivered: row.status === 'delivered', evidence })`.
+
+`serviceTile`:
+1. `portal_branding` → `{ enableService }`. Not exactly `true` (including a missing row) → return `null`.
+2. One aggregate over `service_deliverable_occurrences` inner-joined to `service_deliverables` on `(deliverableId, orgId)` where `occurrences.orgId = $1 AND deliverables.portal_visible AND due_at >= today − 90 days`:
+
+```ts
+  count(*) FILTER (WHERE status = 'delivered' AND delivered_at::date <= due_at) AS on_time
+  count(*) FILTER (WHERE status = 'delivered' AND delivered_at::date >  due_at) AS late
+  count(*) FILTER (WHERE status = 'missed')                                     AS missed
+```
+3. The next due item: same join, `status IN ('scheduled','open','awaiting_evidence') AND due_at >= today`, `orderBy(asc(dueAt))`, `limit(1)`, selecting `name_snapshot` and `due_at`.
+
+`status` is `'ok'` when any of the three counts is non-zero **or** `nextDue` exists; otherwise `'no_data'` with all four value fields `null` (never a fabricated zero).
+
+`apps/api/src/services/portal/dashboard.ts`: add `serviceTile(orgId, args)` to the `Promise.all` array (and to the destructuring), then spread it conditionally so the key is absent when the flag is off:
+
+```ts
+  return {
+    asOf: args.now.toISOString(),
+    timezone: args.timezone,
+    securityScore, devicesProtected, patchesApplied, backup, support, actionItems, awaitingYou,
+    // Absent, not null, when enable_service is off: an org that never turns the
+    // flag on keeps the exact DashboardDto — and therefore the exact ETag — it
+    // had before this wave (routes/portal/dashboard.ts builds the validator
+    // from the payload).
+    ...(service ? { service } : {}),
+  };
+```
+
+`packages/shared/src/types/portalVisibility.ts`: add `service?: ServiceTileDto;` to `DashboardDto` and `import type { ServiceTileDto } from './portalService';` at the top.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd apps/api && npx vitest run src/services/portal/serviceReadModel.test.ts src/services/portal/dashboard.test.ts && npx tsc --noEmit`
+Run: `cd packages/shared && npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/portal/serviceReadModel.ts apps/api/src/services/portal/serviceReadModel.test.ts \
+  apps/api/src/services/portal/dashboard.ts apps/api/src/services/portal/dashboard.test.ts \
+  packages/shared/src/types/portalVisibility.ts
+git commit -m "feat(portal): occurrence history and dashboard service tile (W04)"
+```
+
+---
+
+### Task 7: `documentsReadModel.ts`
+
+**Files:**
+- Create: `apps/api/src/services/portal/documentsReadModel.ts`
+- Create: `apps/api/src/services/portal/documentsReadModel.test.ts`
+
+**Interfaces:**
+- Consumes: `orgDocuments`, `OrgDocumentCategory` (W03 Task 3 exports, re-exported from `../../db/schema`).
+- Produces:
+
+```ts
+export async function documentsForOrg(
+  orgId: string, args: { timezone: string; now: Date },
+): Promise<PortalDocumentsDto>;
+
+/** Metadata only — no `data`, no `storage_key`. Enough to answer a conditional
+ *  request without opening the bytes; the bytes come from W03's streamDocument. */
+export interface PortalDocumentHandle {
+  id: string; contentType: string; byteSize: number;
+  sha256: string; originalFilename: string;
+}
+export async function portalVisibleDocument(
+  orgId: string, documentId: string,
+): Promise<PortalDocumentHandle | null>;
+```
+
+**Why this is a separate lookup and not a call into W03's `listDocuments` / `getDocument`.** Those are the MSP surface: they return `OrgDocumentView` (which carries `uploadedByUserId`) and they do **not** filter on `portal_visible` — correct for a technician, wrong for a customer. The portal keeps its own query so the `portal_visible = true AND deleted_at IS NULL` predicate is in the SQL rather than in a caller's `.filter()`, and so only customer-safe columns are ever selected. Bytes are **not** duplicated: Task 9 delegates those to `orgDocumentService.streamDocument`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// apps/api/src/services/portal/documentsReadModel.test.ts
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import type { SQL } from 'drizzle-orm';
+
+const state = vi.hoisted(() => ({ rows: [] as unknown[][], wheres: [] as unknown[] }));
+vi.mock('../../db', () => ({
+  db: {
+    select: vi.fn(() => {
+      const chain: Record<string, unknown> = {};
+      for (const m of ['from', 'where', 'orderBy', 'limit']) {
+        chain[m] = vi.fn((arg: unknown) => { if (m === 'where') state.wheres.push(arg); return chain; });
+      }
+      chain.then = (r: (rows: unknown[]) => unknown) =>
+        Promise.resolve(state.rows.shift() ?? []).then(r);
+      return chain;
+    }),
+  },
+}));
+
+import { readFileSync } from 'node:fs';
+import { documentsForOrg, portalVisibleDocument } from './documentsReadModel';
+
+const ORG_ID = '11111111-1111-4111-8111-111111111111';
+const NOW = new Date('2026-10-15T12:00:00Z');
+
+describe('documentsForOrg', () => {
+  beforeEach(() => { state.rows.length = 0; state.wheres.length = 0; });
+
+  it('groups chain heads by category in a stable order', async () => {
+    state.rows.push([
+      { id: 'a', title: 'Onboarding baseline', description: null, category: 'baseline',
+        contentType: 'application/pdf', byteSize: 10, originalFilename: 'b.pdf',
+        createdAt: new Date('2026-10-01T00:00:00Z') },
+      { id: 'b', title: 'Firewall runbook', description: 'Rules', category: 'runbook',
+        contentType: 'application/pdf', byteSize: 20, originalFilename: 'r.pdf',
+        createdAt: new Date('2026-10-02T00:00:00Z') },
+      { id: 'c', title: 'Acceptable use', description: null, category: 'policy',
+        contentType: 'application/pdf', byteSize: 30, originalFilename: 'p.pdf',
+        createdAt: new Date('2026-10-03T00:00:00Z') },
+    ]);
+    const dto = await documentsForOrg(ORG_ID, { timezone: 'UTC', now: NOW });
+    expect(dto.groups.map((g) => g.category)).toEqual(['baseline', 'runbook', 'policy']);
+    expect(dto.groups[0]!.documents[0]!.id).toBe('a');
+    expect(dto.asOf).toBe(NOW.toISOString());
+  });
+
+  it('returns no groups rather than an empty category when the org has nothing to show', async () => {
+    state.rows.push([]);
+    await expect(documentsForOrg(ORG_ID, { timezone: 'UTC', now: NOW }))
+      .resolves.toMatchObject({ groups: [] });
+  });
+
+  it('scopes the listing to the session org', async () => {
+    state.rows.push([]);
+    await documentsForOrg(ORG_ID, { timezone: 'UTC', now: NOW });
+    for (const where of state.wheres) {
+      expect(new PgDialect().sqlToQuery(where as SQL).params).toContain(ORG_ID);
+    }
+  });
+});
+
+describe('portalVisibleDocument', () => {
+  beforeEach(() => { state.rows.length = 0; state.wheres.length = 0; });
+
+  it('is null for a document of another org', async () => {
+    state.rows.push([]);
+    await expect(portalVisibleDocument(ORG_ID, 'foreign')).resolves.toBeNull();
+    expect(new PgDialect().sqlToQuery(state.wheres[0] as SQL).params).toContain(ORG_ID);
+  });
+
+  it('serves a superseded document that is still portal-visible', async () => {
+    // A delivery record points at the EXACT version it was delivered with
+    // (spec §4.4), so the download path must not require a chain head.
+    state.rows.push([{ id: 'old', contentType: 'application/pdf', byteSize: 9,
+      sha256: 'f'.repeat(64), originalFilename: 'old.pdf' }]);
+    await expect(portalVisibleDocument(ORG_ID, 'old')).resolves.toMatchObject({ id: 'old' });
+  });
+
+  it('never selects the bytes or the storage key', async () => {
+    // Those belong to W03's streamDocument; selecting them here would be a
+    // second byte path to keep in sync.
+    const source = readFileSync(new URL('./documentsReadModel.ts', import.meta.url), 'utf8');
+    expect(source).not.toMatch(/orgDocuments\.(data|storageKey|storageBackend)/);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/api && npx vitest run src/services/portal/documentsReadModel.test.ts`
+Expected: FAIL, module not found.
+
+- [ ] **Step 3: Implement**
+
+`documentsForOrg` selects from `orgDocuments` where `orgId = $1 AND portalVisible = true AND deletedAt IS NULL` **and the row is a chain head**. W03 ships the matching partial index — `org_documents_org_portal_idx ON org_documents (org_id) WHERE portal_visible AND deleted_at IS NULL` — so write the predicate in exactly that order and shape; no new index is needed in this wave.
+
+```ts
+      sql`NOT EXISTS (
+        SELECT 1 FROM ${orgDocuments} AS successor
+        WHERE successor.supersedes_document_id = ${orgDocuments.id}
+          AND successor.org_id = ${orgId}
+          AND successor.deleted_at IS NULL
+      )`
+```
+Order by `category`, then `createdAt desc`. Group in JS in a fixed category order so the page never reshuffles between loads:
+
+```ts
+const CATEGORY_ORDER: readonly PortalDocumentCategory[] =
+  ['baseline', 'runbook', 'policy', 'evidence', 'report', 'export', 'other'];
+```
+Emit only categories that have at least one document.
+
+`portalVisibleDocument` selects exactly `{ id, contentType, byteSize, sha256, originalFilename }` where `orgId = $1 AND id = $2 AND portalVisible = true AND deletedAt IS NULL` — **no chain-head condition** (a delivery record points at an exact version, spec §4.4) and **no byte columns**. Returns `null` when nothing matches, which the route turns into a bare 404.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd apps/api && npx vitest run src/services/portal/documentsReadModel.test.ts && npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/portal/documentsReadModel.ts apps/api/src/services/portal/documentsReadModel.test.ts
+git commit -m "feat(portal): org document library read model (W04)"
+```
+
+---
+
+### Task 8: `routes/portal/service.ts` and its mount
+
+**Files:**
+- Create: `apps/api/src/routes/portal/service.ts`, `apps/api/src/routes/portal/service.test.ts`
+- Modify: `apps/api/src/routes/portal/schemas.ts:174-188` area
+- Modify: `apps/api/src/routes/portal/index.ts:15-18,44-51,84-87`
+
+**Interfaces:**
+- Consumes: `serviceOverview`, `deliverableOccurrences` (Tasks 5–6); `applyPortalCacheHeaders`, `buildWeakEtag`, `isEtagFresh` (`routes/portal/helpers.ts:70-108`).
+- Produces: `portalServiceRoutes`; `GET /api/v1/portal/service`; `GET /api/v1/portal/service/:deliverableId/occurrences?limit`.
+
+- [ ] **Step 1: Write the failing route tests**
+
+Copy the harness from `apps/api/src/routes/portal/dashboard.test.ts:1-85` verbatim (hoisted service mocks, a mocked `./auth` whose `portalAuthMiddleware` sets `portalAuth` with `orgId` and `timezone: 'America/Denver'`, a mocked `../../db` whose `select().from().where().limit()` resolves `routerState.brandingRows`, an `isolatedApp()` that mounts `portalServiceRoutes` at root). Then:
+
+```ts
+describe('GET /service', () => {
+  it('uses the session org and hydrated timezone and sends private cache headers', async () => {
+    mocks.serviceOverview.mockResolvedValue({ asOf: '2026-10-15T12:00:00.000Z', timezone: 'America/Denver', groups: [], keyDates: [] });
+    const response = await isolatedApp().request('/service');
+    expect(response.status).toBe(200);
+    expect(response.headers.get('cache-control')).toContain('private');
+    expect(response.headers.get('cache-control')).toContain('max-age=30');
+    expect(response.headers.get('etag')).toMatch(/^W\/"[A-Za-z0-9_-]+"$/);
+    expect(mocks.serviceOverview).toHaveBeenCalledWith(
+      '11111111-1111-4111-8111-111111111111',
+      expect.objectContaining({ timezone: 'America/Denver' }),
+    );
+  });
+
+  it('returns 304 when the private ETag is fresh', async () => {
+    mocks.serviceOverview.mockResolvedValue({ asOf: '2026-10-15T12:00:00.000Z', timezone: 'America/Denver', groups: [], keyDates: [] });
+    const first = await isolatedApp().request('/service');
+    const etag = first.headers.get('etag')!;
+    const second = await isolatedApp().request('/service', { headers: { 'If-None-Match': etag } });
+    expect(second.status).toBe(304);
+    expect(second.headers.get('etag')).toBe(etag);
+  });
+});
+
+describe('GET /service/:deliverableId/occurrences', () => {
+  it('404s a deliverable the read model refuses, with no body detail', async () => {
+    mocks.deliverableOccurrences.mockResolvedValue(null);
+    const response = await isolatedApp().request('/service/11111111-1111-4111-8111-111111111111/occurrences');
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: 'Not found' });
+  });
+
+  it('rejects a non-uuid deliverable id before touching the read model', async () => {
+    const response = await isolatedApp().request('/service/not-a-uuid/occurrences');
+    expect(response.status).toBe(400);
+    expect(mocks.deliverableOccurrences).not.toHaveBeenCalled();
+  });
+
+  it('passes the validated limit through', async () => {
+    mocks.deliverableOccurrences.mockResolvedValue({ asOf: '', timezone: 'America/Denver', deliverable: { id: 'd1', name: 'x', cadence: 'monthly' }, occurrences: [] });
+    await isolatedApp().request('/service/11111111-1111-4111-8111-111111111111/occurrences?limit=5');
+    expect(mocks.deliverableOccurrences).toHaveBeenCalledWith(
+      '11111111-1111-4111-8111-111111111111',
+      '11111111-1111-4111-8111-111111111111',
+      expect.objectContaining({ limit: 5 }),
+    );
+  });
+});
+
+describe('GET /service through the real portal router', () => {
+  it('returns 401 without an authenticated portal session', async () => {
+    routerState.authenticated = false;
+    const response = await portalRoutes.request('/service');
+    expect(response.status).toBe(401);
+    expect(mocks.serviceOverview).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when service visibility is disabled', async () => {
+    routerState.brandingRows = [{ enableService: false }];
+    const response = await portalRoutes.request('/service', { headers: { Authorization: 'Bearer token' } });
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({ code: 'PORTAL_SERVICE_DISABLED' });
+    expect(mocks.serviceOverview).not.toHaveBeenCalled();
+  });
+
+  it('gates the occurrences path on the same flag', async () => {
+    routerState.brandingRows = [{ enableService: false }];
+    const response = await portalRoutes.request(
+      '/service/11111111-1111-4111-8111-111111111111/occurrences',
+      { headers: { Authorization: 'Bearer token' } },
+    );
+    expect(response.status).toBe(403);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/api && npx vitest run src/routes/portal/service.test.ts`
+Expected: FAIL, `./service` not found.
+
+- [ ] **Step 3: Add the schemas**
+
+In `apps/api/src/routes/portal/schemas.ts`, next to `portalReportRunParamSchema` (line 186):
+
+```ts
+export const portalDeliverableParamSchema = z.object({ deliverableId: z.string().guid() });
+export const portalDocumentParamSchema = z.object({ id: z.string().guid() });
+// Spec §8 publishes the last 24 occurrences; the cap lives in the read model
+// too, so a crafted query string cannot widen the window.
+export const portalOccurrenceListSchema = z.object({
+  limit: z.coerce.number().int().min(1).max(24).default(24)
+});
+```
+
+- [ ] **Step 4: Write the router**
+
+```ts
+// apps/api/src/routes/portal/service.ts
+import { Hono } from 'hono';
+import { zValidator } from '../../lib/validation';
+import { deliverableOccurrences, serviceOverview } from '../../services/portal/serviceReadModel';
+import { applyPortalCacheHeaders, buildWeakEtag, isEtagFresh } from './helpers';
+import { portalDeliverableParamSchema, portalOccurrenceListSchema } from './schemas';
+
+// Route hub for the customer-portal Service scorecard, gated by the
+// `enableService` strict flag. Mounted at root in routes/portal/index.ts under
+// createPortalFeatureGateStrict('enableService'); handlers own the absolute path.
+//
+// Spec D10: nothing here returns a ticket. The read model is the only place
+// the publication rules live — these handlers add caching and nothing else.
+export const portalServiceRoutes = new Hono();
+
+function sendCached(c: Parameters<Parameters<Hono['get']>[1]>[0], payload: unknown) {
+  applyPortalCacheHeaders(c, {
+    scope: 'private',
+    browserMaxAgeSeconds: 30,
+    staleWhileRevalidateSeconds: 0,
+    vary: ['Authorization', 'Cookie'],
+  });
+  const etag = buildWeakEtag(payload);
+  c.header('ETag', etag);
+  if (isEtagFresh(c.req.header('if-none-match'), etag)) {
+    return new Response(null, { status: 304, headers: c.res.headers });
+  }
+  return c.json(payload);
+}
+
+portalServiceRoutes.get('/service', async (c) => {
+  const auth = c.get('portalAuth');
+  const payload = await serviceOverview(auth.user.orgId, {
+    timezone: auth.timezone,
+    now: new Date(),
+  });
+  return sendCached(c, payload);
+});
+
+portalServiceRoutes.get(
+  '/service/:deliverableId/occurrences',
+  zValidator('param', portalDeliverableParamSchema),
+  zValidator('query', portalOccurrenceListSchema),
+  async (c) => {
+    const auth = c.get('portalAuth');
+    const payload = await deliverableOccurrences(
+      auth.user.orgId,
+      c.req.valid('param').deliverableId,
+      { timezone: auth.timezone, now: new Date(), limit: c.req.valid('query').limit },
+    );
+    // Bare 404, never 403: a deliverable of another org and a deliverable that
+    // does not exist must be indistinguishable (spec §12).
+    if (!payload) return c.json({ error: 'Not found' }, 404);
+    return sendCached(c, payload);
+  },
+);
+```
+
+Note: the payload's `asOf` changes on every request, so unlike `dashboard.ts` there is no point stripping timestamps before hashing — the ETag here is a transport-level validator for a single client's repeat fetch. Keep it simple and do not copy `withoutCollectionTimestamps`.
+
+- [ ] **Step 5: Mount it**
+
+In `apps/api/src/routes/portal/index.ts`, after the `/reports/*` block (line 51):
+
+```ts
+portalRoutes.use('/service/*', portalAuthMiddleware);
+portalRoutes.use('/service/*', createPortalFeatureGateStrict('enableService'));
+```
+and after `portalRoutes.route('/', portalReportRoutes);` (line 87):
+
+```ts
+portalRoutes.route('/', portalServiceRoutes);
+```
+with `import { portalServiceRoutes } from './service';` beside the other hub imports. A `use('/x/*')` middleware also matches the exact path `/x` in Hono — proven by the existing `dashboard.test.ts:197-209`, which gets a 403 on `/dashboard` from the `/dashboard/*` gate.
+
+- [ ] **Step 6: Run to verify pass**
+
+Run: `cd apps/api && npx vitest run src/routes/portal/service.test.ts src/routes/portal/dashboard.test.ts && npx tsc --noEmit`
+Expected: PASS. Running the dashboard test too catches an index.ts mount that broke an existing prefix.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/routes/portal/service.ts apps/api/src/routes/portal/service.test.ts \
+  apps/api/src/routes/portal/schemas.ts apps/api/src/routes/portal/index.ts
+git commit -m "feat(portal): GET /portal/service and occurrence history routes (W04)"
+```
+
+---
+
+### Task 9: `routes/portal/documents.ts`, streaming and its mount
+
+**Files:**
+- Create: `apps/api/src/routes/portal/documents.ts`, `apps/api/src/routes/portal/documents.test.ts`
+- Modify: `apps/api/src/routes/portal/index.ts`
+
+**Interfaces:**
+- Consumes: `documentsForOrg`, `portalVisibleDocument` (Task 7); `contentDispositionFor` (`apps/api/src/routes/tickets/attachments.ts:262`, imported across routers exactly as `apps/api/src/routes/portal/tickets.ts:32` already does); `streamDocument` and `DeliverableServiceError` from W03; `createPortalFeatureGateAny` (Task 1).
+- Produces: `portalDocumentRoutes`; `GET /api/v1/portal/documents`; `GET /api/v1/portal/documents/:id/content`.
+
+**W03 interface this task calls** (verified against `docs/superpowers/plans/billing/2026-09-10-service-deliverables-w03-org-documents.md` Task 7):
+
+```ts
+export function streamDocument(orgId: string, id: string, actor: DeliverableActor): Promise<{
+  view: OrgDocumentView; contentType: string; originalFilename: string; sha256: string;
+  body: Readable | Buffer | null; contentLength: number | null;
+}>;
+```
+It performs its own org-scoped lookup and throws `DeliverableServiceError` (404 `NOT_FOUND`) for a row outside the org or soft-deleted; a storage fault surfaces as a `BlobStorageError`. **It does not consult `portal_visible`** — correct, because it also serves the MSP surface. That predicate is this route's job, via `portalVisibleDocument`, and it runs first.
+
+**Before writing code, run `grep -n 'export function streamDocument' apps/api/src/services/orgDocumentService.ts`** to confirm the merged signature. If it drifted, adapt this call site — never fork a second byte path, and never reach into `blobStorage.ts` from a route.
+
+**The portal actor.** `streamDocument` takes the `DeliverableActor` shape from W01 (`{ userId, partnerId, accessibleOrgIds }`) and only reads `accessibleOrgIds` in `requireOrgAccess`. A portal session has no staff user, so build it explicitly and locally:
+
+```ts
+/** A portal session acting on its own org: no staff user, no partner axis.
+ *  requireOrgAccess only reads accessibleOrgIds, and RLS is the real fence. */
+const portalActor = (orgId: string): DeliverableActor => ({
+  userId: null, partnerId: null, accessibleOrgIds: [orgId],
+});
+```
+
+- [ ] **Step 1: Write the failing route tests**
+
+Reuse the same harness as Task 8, with three additions at the top of the file:
+
+```ts
+import { readFileSync } from 'node:fs';
+// DeliverableServiceError is a real class (W01 Task 8), imported rather than
+// mocked so `instanceof` in the route's catch block is exercised for real.
+import { DeliverableServiceError } from '../../services/serviceDeliverableService';
+
+const mocks = vi.hoisted(() => ({
+  documentsForOrg: vi.fn(),
+  portalVisibleDocument: vi.fn(),
+  streamDocument: vi.fn(),
+}));
+vi.mock('../../services/portal/documentsReadModel', () => ({
+  documentsForOrg: mocks.documentsForOrg,
+  portalVisibleDocument: mocks.portalVisibleDocument,
+}));
+vi.mock('../../services/orgDocumentService', async () => {
+  const actual = await vi.importActual<typeof import('../../services/orgDocumentService')>(
+    '../../services/orgDocumentService');
+  return { ...actual, streamDocument: mocks.streamDocument };
+});
+```
+
+Then the cases:
+
+```ts
+describe('GET /documents', () => {
+  it('sends the org listing with private caching and a weak ETag', async () => {
+    mocks.documentsForOrg.mockResolvedValue({ asOf: '2026-10-15T12:00:00.000Z', timezone: 'America/Denver', groups: [] });
+    const response = await isolatedApp().request('/documents');
+    expect(response.status).toBe(200);
+    expect(response.headers.get('cache-control')).toContain('private, max-age=30');
+    expect(mocks.documentsForOrg).toHaveBeenCalledWith(
+      '11111111-1111-4111-8111-111111111111', expect.objectContaining({ timezone: 'America/Denver' }));
+  });
+  it('returns 304 on a matching ETag', async () => {
+    mocks.documentsForOrg.mockResolvedValue({ asOf: 'x', timezone: 'UTC', groups: [] });
+    const first = await isolatedApp().request('/documents');
+    const etag = first.headers.get('etag')!;
+    expect((await isolatedApp().request('/documents', { headers: { 'If-None-Match': etag } })).status).toBe(304);
+  });
+});
+
+describe('GET /documents/:id/content', () => {
+  const ID = '11111111-1111-4111-8111-111111111111';
+
+  const handle = (sha: string) => ({
+    id: ID, contentType: 'application/pdf', byteSize: 3,
+    sha256: sha.repeat(64), originalFilename: 'runbook.pdf',
+  });
+
+  it('404s a document that is not this org\'s portal-visible row', async () => {
+    mocks.portalVisibleDocument.mockResolvedValue(null);
+    const response = await isolatedApp().request(`/documents/${ID}/content`);
+    expect(response.status).toBe(404);
+    // The visibility predicate runs BEFORE W03's service, which does not know
+    // about portal_visible at all.
+    expect(mocks.streamDocument).not.toHaveBeenCalled();
+  });
+
+  it('streams bytes with a sha256 ETag, a safe disposition and nosniff', async () => {
+    mocks.portalVisibleDocument.mockResolvedValue(handle('a'));
+    mocks.streamDocument.mockResolvedValue({
+      view: {}, contentType: 'application/pdf', originalFilename: 'runbook.pdf',
+      sha256: 'a'.repeat(64), body: Buffer.from('abc'), contentLength: 3,
+    });
+    const response = await isolatedApp().request(`/documents/${ID}/content`);
+    expect(response.status).toBe(200);
+    expect(mocks.streamDocument).toHaveBeenCalledWith(
+      '11111111-1111-4111-8111-111111111111', ID,
+      { userId: null, partnerId: null, accessibleOrgIds: ['11111111-1111-4111-8111-111111111111'] },
+    );
+    expect(response.headers.get('etag')).toBe(`"${'a'.repeat(64)}"`);
+    expect(response.headers.get('content-disposition')).toContain('attachment');
+    expect(response.headers.get('content-disposition')).toContain('runbook.pdf');
+    expect(response.headers.get('x-content-type-options')).toBe('nosniff');
+    expect(response.headers.get('cache-control')).toBe('private, max-age=300');
+  });
+
+  it('304s a matching sha256 ETag without opening the bytes', async () => {
+    mocks.portalVisibleDocument.mockResolvedValue(handle('b'));
+    const response = await isolatedApp().request(`/documents/${ID}/content`,
+      { headers: { 'If-None-Match': `"${'b'.repeat(64)}"` } });
+    expect(response.status).toBe(304);
+    expect(mocks.streamDocument).not.toHaveBeenCalled();
+  });
+
+  it('answers a storage fault with a retryable 503, never a 500', async () => {
+    mocks.portalVisibleDocument.mockResolvedValue(handle('c'));
+    mocks.streamDocument.mockRejectedValue(new Error('s3 down'));
+    const response = await isolatedApp().request(`/documents/${ID}/content`);
+    expect(response.status).toBe(503);
+  });
+
+  it('turns a 404 from the W03 service into a bare 404, not a 500', async () => {
+    // A row deleted between the visibility check and the stream.
+    mocks.portalVisibleDocument.mockResolvedValue(handle('d'));
+    mocks.streamDocument.mockRejectedValue(
+      new DeliverableServiceError('Not found', 404, 'NOT_FOUND'));
+    const response = await isolatedApp().request(`/documents/${ID}/content`);
+    expect(response.status).toBe(404);
+  });
+
+  it('never hands back a presigned url', async () => {
+    // Spec §8/§11: bytes stream through the API under RLS.
+    const source = readFileSync(new URL('./documents.ts', import.meta.url), 'utf8');
+    expect(source).not.toMatch(/presign|getSignedUrl/i);
+  });
+});
+
+describe('GET /documents through the real portal router', () => {
+  it('403s the listing when enable_documents is off', async () => {
+    routerState.brandingRows = [{ enableDocuments: false, enableService: true }];
+    const response = await portalRoutes.request('/documents', { headers: { Authorization: 'Bearer token' } });
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({ code: 'PORTAL_DOCUMENTS_DISABLED' });
+  });
+
+  it('still serves evidence bytes when only enable_service is on', async () => {
+    // Spec §8: document evidence is published under enable_service regardless
+    // of enable_documents, so the link the Service page renders must resolve.
+    routerState.brandingRows = [{ enableDocuments: false, enableService: true }];
+    mocks.portalVisibleDocument.mockResolvedValue(null);   // 404, not 403
+    const response = await portalRoutes.request(
+      '/documents/11111111-1111-4111-8111-111111111111/content',
+      { headers: { Authorization: 'Bearer token' } });
+    expect(response.status).toBe(404);
+  });
+
+  it('403s the bytes when both flags are off', async () => {
+    routerState.brandingRows = [{ enableDocuments: false, enableService: false }];
+    const response = await portalRoutes.request(
+      '/documents/11111111-1111-4111-8111-111111111111/content',
+      { headers: { Authorization: 'Bearer token' } });
+    expect(response.status).toBe(403);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/api && npx vitest run src/routes/portal/documents.test.ts`
+Expected: FAIL, `./documents` not found.
+
+- [ ] **Step 3: Write the router**
+
+`GET /documents` mirrors `sendCached` from Task 8 (duplicate the six-line helper locally rather than exporting it across hubs — `routes/portal/reports.ts` already repeats the same block twice; a shared helper here would be the only cross-hub coupling in the directory).
+
+`GET /documents/:id/content` follows `apps/api/src/routes/portal/tickets.ts:655-690` exactly:
+
+```ts
+portalDocumentRoutes.get(
+  '/documents/:id/content',
+  zValidator('param', portalDocumentParamSchema),
+  async (c) => {
+    const auth = c.get('portalAuth');
+    const orgId = auth.user.orgId;
+    const id = c.req.valid('param').id;
+
+    // The portal's own predicate: this org, portal_visible, not soft-deleted.
+    // W03's streamDocument does not know about portal_visible (it also serves
+    // the MSP surface), so this must run first and answer a bare 404.
+    const doc = await portalVisibleDocument(orgId, id);
+    if (!doc) return c.json({ error: 'Document not found' }, 404);
+
+    const etag = `"${doc.sha256}"`;
+    const headers: Record<string, string> = {
+      ETag: etag,
+      // Bytes are immutable per row (sha256 IS the identity), so a longer
+      // browser cache than the 30s JSON validator is correct here.
+      'Cache-Control': 'private, max-age=300',
+      'X-Content-Type-Options': 'nosniff',
+      Vary: 'Authorization, Cookie',
+    };
+    if (c.req.header('If-None-Match') === etag) return c.body(null, 304, headers);
+
+    let opened: Awaited<ReturnType<typeof streamDocument>>;
+    try {
+      opened = await streamDocument(orgId, id, portalActor(orgId));
+    } catch (err) {
+      // A row that vanished between the two reads is a 404, not a fault.
+      if (err instanceof DeliverableServiceError && err.status === 404) {
+        return c.json({ error: 'Document not found' }, 404);
+      }
+      // A transport fault is RETRYABLE, not a bug (the ticket-attachment route
+      // learned this the hard way: an S3 blip surfaced as a generic 500).
+      captureException(err);
+      return c.json({ error: 'Document storage is unavailable — try again shortly' }, 503);
+    }
+    if (!opened.body) return c.json({ error: 'Document not found' }, 404);
+
+    headers['Content-Type'] = opened.contentType;
+    headers['Content-Disposition'] =
+      contentDispositionFor(opened.contentType, opened.originalFilename);
+    const length = opened.contentLength ?? doc.byteSize;
+    if (typeof length === 'number') headers['Content-Length'] = String(length);
+
+    if (Buffer.isBuffer(opened.body)) return c.body(new Uint8Array(opened.body), 200, headers);
+    return c.body(Readable.toWeb(opened.body) as ReadableStream, 200, headers);
+  },
+);
+```
+
+- [ ] **Step 4: Mount it with the split gate**
+
+In `apps/api/src/routes/portal/index.ts`, add module-level gate constants next to `isTicketsUsagePath` (line 22) and the mount after the `/service/*` block:
+
+```ts
+const isDocumentContentPath = (c: Context) => /\/documents\/[^/]+\/content$/.test(c.req.path);
+const documentsLibraryGate = createPortalFeatureGateStrict('enableDocuments');
+// Spec §8: a portal-visible document published as delivery evidence is
+// downloadable under enable_service even when the library page is off.
+const documentBytesGate = createPortalFeatureGateAny('enableDocuments', 'enableService');
+
+portalRoutes.use('/documents/*', portalAuthMiddleware);
+portalRoutes.use('/documents/*', async (c, next) =>
+  isDocumentContentPath(c) ? documentBytesGate(c, next) : documentsLibraryGate(c, next));
+```
+and `portalRoutes.route('/', portalDocumentRoutes);` beside the other hub mounts.
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `cd apps/api && npx vitest run src/routes/portal/documents.test.ts src/routes/portal/service.test.ts src/routes/portal/tickets.test.ts && npx tsc --noEmit`
+Expected: PASS. Running `tickets.test.ts` too proves the new `/documents/*` mounts did not disturb the existing exact-path `/tickets/usage` precedence.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/routes/portal/documents.ts apps/api/src/routes/portal/documents.test.ts \
+  apps/api/src/routes/portal/index.ts
+git commit -m "feat(portal): GET /portal/documents listing and byte streaming (W04)"
+```
+
+---
+
+### Task 10: Portal client, nav and gate wiring
+
+**Files:**
+- Modify: `apps/portal/src/lib/api.ts:697-721,1230-1241`
+- Modify: `apps/portal/src/lib/navItems.ts:30-70`
+- Modify: `apps/portal/src/lib/navItems.test.ts`
+- Modify: `apps/portal/src/lib/visibilityGate.ts:14-37`
+- Modify: `apps/portal/src/lib/visibilityGate.test.ts:17-26`
+- Modify: `apps/portal/src/lib/protectedPaths.ts:14-26`
+- Modify: `apps/portal/src/lib/disabledPageCoverage.test.ts:30-43`
+
+**Interfaces:**
+- Consumes: the API routes from Tasks 8–9; the DTOs from Task 4.
+- Produces: `portalApi.getService`, `portalApi.getServiceOccurrences`, `portalApi.getDocuments`, `portalApi.documentContentUrl`; nav entries `/service` ("Service") and `/documents` ("Documents"); gate codes `PORTAL_SERVICE_DISABLED`, `PORTAL_DOCUMENTS_DISABLED`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `apps/portal/src/lib/navItems.test.ts`, extend the full-flag-set case (line ~48) to pass `enableService: true, enableDocuments: true` and expect:
+
+```ts
+    ]).toEqual([
+      '/dashboard', '/quotes', '/invoices', '/tickets', '/devices',
+      '/security', '/backups', '/reports', '/service', '/documents',
+      '/assets', '/profile',
+    ]);
+```
+and add:
+
+```ts
+  it('fails CLOSED for the W04 surfaces — absent or false hides them', () => {
+    for (const branding of [{}, { enableService: false, enableDocuments: false }]) {
+      const hrefs = buildPortalNavItems(branding).map((i) => i.href);
+      expect(hrefs).not.toContain('/service');
+      expect(hrefs).not.toContain('/documents');
+    }
+  });
+```
+
+In `apps/portal/src/lib/visibilityGate.test.ts`, add `'PORTAL_SERVICE_DISABLED'` and `'PORTAL_DOCUMENTS_DISABLED'` to `GATE_CODES` (line 17) — the parity test at line 89 reads the API source and will fail until `PORTAL_DISABLED_CODES` carries them.
+
+In `apps/portal/src/lib/disabledPageCoverage.test.ts`, add to `GATED_API_METHODS` (line 30):
+
+```ts
+  getService: 'PORTAL_SERVICE_DISABLED',
+  getServiceOccurrences: 'PORTAL_SERVICE_DISABLED',
+  getDocuments: 'PORTAL_DOCUMENTS_DISABLED',
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/portal && npx vitest run src/lib/navItems.test.ts src/lib/visibilityGate.test.ts`
+Expected: FAIL on both.
+
+- [ ] **Step 3: Implement**
+
+`apps/portal/src/lib/visibilityGate.ts`: append both codes to `PORTAL_DISABLED_CODES` and `'/service'`, `'/documents'` to `PORTAL_GATED_PAGES`. `PORTAL_UNGATED_HOME` stays `/quotes`.
+
+`apps/portal/src/lib/protectedPaths.ts`: add `'/service'` and `'/documents'` to `PORTAL_PROTECTED_PREFIXES` (without this, `disabledPageCoverage.test.ts:193-204` fails for the two new pages).
+
+`apps/portal/src/lib/navItems.ts`: widen the `Pick<BrandingConfig, …>` parameter with `'enableService' | 'enableDocuments'` and insert two entries **after** the Reports entry and before Equipment:
+
+```ts
+    branding.enableService === true
+      ? { href: '/service', label: 'Service' }
+      : null,
+    branding.enableDocuments === true
+      ? { href: '/documents', label: 'Documents' }
+      : null,
+```
+(Placement rationale, worth a comment: both are new fail-closed surfaces with no legacy expectation, and appending after the existing visibility block leaves every org's current nav order untouched.)
+
+`apps/portal/src/lib/api.ts`: add `enableService?: boolean; enableDocuments?: boolean;` to `BrandingConfig` (after line 720), and four members to `portalApi` beside `reportArtifactUrl` (line 1235):
+
+```ts
+  // W04 — service deliverables
+  getService: (
+    config: ApiRequestConfig = {},
+  ): Promise<ApiResponse<PortalServiceOverviewDto>> =>
+    apiGet<PortalServiceOverviewDto>('/portal/service', config),
+
+  getServiceOccurrences: (
+    deliverableId: string,
+    config: ApiRequestConfig = {},
+  ): Promise<ApiResponse<PortalOccurrencesDto>> =>
+    apiGet<PortalOccurrencesDto>(
+      `/portal/service/${encodeURIComponent(deliverableId)}/occurrences`,
+      config,
+    ),
+
+  getDocuments: (
+    config: ApiRequestConfig = {},
+  ): Promise<ApiResponse<PortalDocumentsDto>> =>
+    apiGet<PortalDocumentsDto>('/portal/documents', config),
+
+  // A browser-navigable path, not a fetch: the session cookie authenticates the
+  // download and the API streams the bytes. Never a presigned URL (spec §8).
+  documentContentUrl: (documentId: string): PublicApiPath =>
+    publicApiPath(`/portal/documents/${documentId}/content`),
+```
+with the four DTO types added to the `@breeze/shared` type import at the top of the file.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd apps/portal && npx vitest run src/lib && npx tsc --noEmit`
+Expected: PASS. `disabledPageCoverage.test.ts` will still pass here because no page calls the new methods yet; Tasks 11–12 add the pages and the branch it demands.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/portal/src/lib
+git commit -m "feat(portal): service and documents client, nav and gate wiring (W04)"
+```
+
+---
+
+### Task 11: Service page and scorecard component
+
+**Files:**
+- Create: `apps/portal/src/pages/service/index.astro`, `apps/portal/src/pages/service/index.test.ts`
+- Create: `apps/portal/src/components/portal/ServiceScorecard.tsx`, `apps/portal/src/components/portal/ServiceScorecard.test.tsx`
+
+**Interfaces:**
+- Consumes: `portalApi.getService`, `portalApi.getServiceOccurrences`, `portalApi.documentContentUrl`, `portalApi.reportArtifactUrl` (Task 10); `PortalServiceOverviewDto` (Task 4); `PageHeader`, `ErrorNotice`, `EmptyState`, `StatusMark`, `ROW`, `CELL`, `TH`, `BTN_SECONDARY` (`apps/portal/src/components/portal/ui.tsx`).
+- Produces: `data-testid` `portal-service-groups`, `portal-service-group-<contractId|standalone>`, `portal-service-row-<deliverableId>`, `portal-service-status-<deliverableId>`, `portal-service-evidence-<evidenceIndex>-<deliverableId>`, `portal-service-key-dates`, `portal-service-key-date-<id>`, `portal-service-empty`, `portal-service-error`, `portal-service-occurrences-<deliverableId>`, `portal-service-occurrence-row-<occurrenceId>`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// apps/portal/src/pages/service/index.test.ts
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const pageSource = readFileSync(new URL('./index.astro', import.meta.url), 'utf8');
+const componentSource = readFileSync(
+  new URL('../../components/portal/ServiceScorecard.tsx', import.meta.url), 'utf8');
+
+describe('service page visibility gate', () => {
+  it('bounces a page the MSP switched off instead of reporting a load failure', () => {
+    expect(pageSource).toContain('redirectToPortalHomeAfterDisabled(Astro)');
+  });
+  it('redirects on 401 before rendering', () => {
+    expect(pageSource).toContain('redirectToLoginAfter401(Astro)');
+  });
+});
+
+describe('service page fetch states', () => {
+  it('never prints a raw transport error at the customer', () => {
+    expect(pageSource).not.toMatch(/\{response\.error\}/);
+  });
+  it('names the recovery in the failure copy and keeps the page title', () => {
+    expect(pageSource).toContain('data-testid="portal-service-error"');
+    expect(pageSource).toContain("We couldn't load your service summary just now. Your IT team can help.");
+    expect(pageSource).toMatch(/<PageHeader\s+title="Service"/);
+  });
+});
+
+describe('service scorecard publication rules', () => {
+  it('renders no ticket anywhere', () => {
+    // Spec D10 belongs to the read model, but a component that invented a
+    // "View ticket" link would defeat it — assert the component source too.
+    expect(componentSource).not.toMatch(/ticket/i);
+  });
+  it('states plainly when the MSP holds the artifact', () => {
+    expect(componentSource).toContain('held_by_msp');
+    expect(componentSource).toContain('Delivered (artifact held by your IT team)');
+  });
+  it('gives every list, row and download a testid', () => {
+    for (const id of [
+      'portal-service-groups', 'portal-service-key-dates', 'portal-service-empty',
+    ]) expect(componentSource).toContain(`data-testid="${id}"`);
+    expect(componentSource).toMatch(/data-testid=\{`portal-service-row-\$\{/);
+    expect(componentSource).toMatch(/data-testid=\{`portal-service-occurrence-row-\$\{/);
+  });
+});
+```
+
+```tsx
+// apps/portal/src/components/portal/ServiceScorecard.test.tsx
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ServiceScorecard } from './ServiceScorecard';
+import type { PortalServiceOverviewDto } from '@breeze/shared';
+
+vi.mock('@/lib/api', () => ({
+  portalApi: {
+    getServiceOccurrences: vi.fn(),
+    documentContentUrl: (id: string) => `/api/v1/portal/documents/${id}/content`,
+    reportArtifactUrl: (id: string) => `/api/v1/portal/reports/runs/${id}/pdf`,
+  },
+}));
+
+const overview: PortalServiceOverviewDto = {
+  asOf: '2026-10-15T12:00:00.000Z',
+  timezone: 'America/Denver',
+  groups: [{
+    source: 'contract',
+    contract: { id: 'c1', name: 'Best plan' },
+    deliverables: [{
+      id: 'd1', name: 'Monthly sign-in log review', description: 'We read every sign-in',
+      cadence: 'monthly', artifactRequired: true, nextDue: '2026-10-31', status: 'on_track',
+      lastDelivered: { at: '2026-09-30T17:00:00.000Z', late: false, note: 'Nothing unusual',
+                       artifactState: 'attached',
+                       evidence: [{ kind: 'document', documentId: 'doc1', reportRunId: null,
+                                    title: 'September findings', createdAt: '2026-09-30T17:00:00.000Z' }] },
+    }],
+  }],
+  keyDates: [{ source: 'contract_end', id: 'c1', label: 'Best plan', kind: 'contract_end',
+               date: '2027-03-31', notes: null }],
+};
+
+describe('ServiceScorecard', () => {
+  it('names the contract the deliverables belong to', () => {
+    render(<ServiceScorecard overview={overview} />);
+    expect(screen.getByTestId('portal-service-group-c1')).toHaveTextContent('Best plan');
+    expect(screen.getByTestId('portal-service-row-d1')).toHaveTextContent('Monthly sign-in log review');
+  });
+
+  it('links attached evidence at the portal download path', () => {
+    render(<ServiceScorecard overview={overview} />);
+    expect(screen.getByTestId('portal-service-evidence-0-d1'))
+      .toHaveAttribute('href', '/api/v1/portal/documents/doc1/content');
+  });
+
+  it('says the artifact is held by the MSP rather than pretending it exists', () => {
+    const held = structuredClone(overview);
+    held.groups[0]!.deliverables[0]!.lastDelivered!.artifactState = 'held_by_msp';
+    held.groups[0]!.deliverables[0]!.lastDelivered!.evidence = [];
+    render(<ServiceScorecard overview={held} />);
+    expect(screen.getByTestId('portal-service-row-d1'))
+      .toHaveTextContent('Delivered (artifact held by your IT team)');
+  });
+
+  it('shows an honest empty state, not a blank page', () => {
+    render(<ServiceScorecard overview={{ ...overview, groups: [], keyDates: [] }} />);
+    expect(screen.getByTestId('portal-service-empty')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/portal && npx vitest run src/pages/service src/components/portal/ServiceScorecard.test.tsx`
+Expected: FAIL, modules not found.
+
+- [ ] **Step 3: Write the page**
+
+```astro
+---
+import PortalLayout from '../../layouts/PortalLayout.astro';
+import { ServiceScorecard } from '../../components/portal/ServiceScorecard';
+import { ErrorNotice, PageHeader } from '../../components/portal/ui';
+import { portalApi } from '../../lib/api';
+import { buildServerApiConfig } from '../../lib/server';
+import { redirectToLoginAfter401 } from '../../lib/session';
+import { isPortalPageDisabled, redirectToPortalHomeAfterDisabled } from '../../lib/visibilityGate';
+
+const response = await portalApi.getService(buildServerApiConfig(Astro.request));
+if (response.statusCode === 401) {
+  return redirectToLoginAfter401(Astro);
+}
+
+// enable_service off 403s with PORTAL_SERVICE_DISABLED. A page the org never
+// turned on is a setting, not a fault, so it bounces to the one page no
+// visibility flag can switch off (#4932). Other 403s ("Account is not active")
+// still render inline through the notice below.
+if (isPortalPageDisabled(response)) {
+  return redirectToPortalHomeAfterDisabled(Astro);
+}
+---
+
+<PortalLayout title="Service">
+  {
+    response.data
+      ? <ServiceScorecard client:load overview={response.data} />
+      : (
+          <div data-testid="portal-service-error">
+            <PageHeader
+              title="Service"
+              lede="What we look after for you, and what we delivered."
+            />
+            <ErrorNotice>We couldn't load your service summary just now. Your IT team can help.</ErrorNotice>
+          </div>
+        )
+  }
+</PortalLayout>
+```
+
+- [ ] **Step 4: Write `ServiceScorecard.tsx`**
+
+Structure, all composed from `ui.tsx` primitives and Tailwind classes (no inline `style` — production CSP refuses it):
+
+- `PageHeader title="Service" lede="What we look after for you, and what we delivered."`.
+- Empty state (`groups.length === 0 && keyDates.length === 0`): `EmptyState` with `data-testid="portal-service-empty"`, title "Nothing scheduled yet", body "Your IT team has not published a service schedule for this account."
+- `<div data-testid="portal-service-groups">`, one `<section data-testid={\`portal-service-group-${group.contract?.id ?? 'standalone'}\`}>` per group. The heading is the contract name, or "Other services" for the standalone group.
+- Inside each group a ruled list (`ROW`/`CELL`/`TH`, `divide-y divide-border/70`) with one `<tr data-testid={\`portal-service-row-${d.id}\`}>` per deliverable carrying: name + description; cadence in words (`CADENCE_LABEL: Record<PortalDeliverableCadence, string> = { monthly: 'Monthly', quarterly: 'Quarterly', semiannual: 'Twice a year', annual: 'Yearly', one_time: 'One time' }`); a `StatusMark` in `data-testid={\`portal-service-status-${d.id}\`}` with tone `on_track → success`, `due_soon → primary`, `late → warning`, `missed → destructive`; "Next due" as `formatDate`d `nextDue` or "Not scheduled"; and the last-delivered block.
+- Last-delivered block, the whole point of the page:
+
+```tsx
+const ARTIFACT_COPY: Record<PortalArtifactState, string | null> = {
+  attached: null,
+  report: null,
+  none: null,
+  // Nothing pretends evidence exists (spec §8). "Your IT team" is how the rest
+  // of the portal refers to the MSP.
+  held_by_msp: 'Delivered (artifact held by your IT team)',
+};
+```
+Render `Delivered <date> (<timezone>)` plus `Late` as a `warning` StatusMark when `late`, the note when present, `ARTIFACT_COPY[artifactState]` when non-null, and each evidence ref as an anchor:
+
+```tsx
+{last.evidence.map((ev, i) => (
+  <a
+    key={`${ev.kind}-${ev.documentId ?? ev.reportRunId}`}
+    data-testid={`portal-service-evidence-${i}-${d.id}`}
+    href={ev.kind === 'document'
+      ? portalApi.documentContentUrl(ev.documentId!)
+      : portalApi.reportArtifactUrl(ev.reportRunId!, 'pdf')}
+    download
+    className={cn(BTN_SECONDARY, 'min-h-11 sm:min-h-0 sm:py-1.5')}
+  >
+    <Download className="h-4 w-4" aria-hidden="true" />
+    {ev.title}
+  </a>
+))}
+```
+- A "Show history" button per deliverable that calls `portalApi.getServiceOccurrences(d.id)` on first click, stores the result in local state, and renders `<ul data-testid={\`portal-service-occurrences-${d.id}\`}>` with one `<li data-testid={\`portal-service-occurrence-row-${o.id}\`}>` per occurrence: period, due date, `OCCURRENCE_LABEL` (`scheduled: 'Scheduled', in_progress: 'In progress', delivered: 'Delivered', missed: 'Missed', waived: 'Not required this period'`), "Rescheduled" when `o.rescheduled`, the note, the artifact copy and the same evidence anchors. A failed fetch sets a local message rendered through `ErrorNotice`; it never replaces the page.
+- Key dates: `<section data-testid="portal-service-key-dates">` listing each as `<li data-testid={\`portal-service-key-date-${kd.id}\`}>` with label, `formatDate(kd.date)` and, for `source === 'contract_end'`, the suffix "Agreement ends". Omitted entirely when `keyDates.length === 0`.
+- A dated foot line, `As of {formatDateTime(overview.asOf, overview.timezone)} ({overview.timezone}).`, matching `DashboardTiles.tsx:319-322`.
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `cd apps/portal && npx vitest run src/pages/service src/components/portal/ServiceScorecard.test.tsx src/lib/disabledPageCoverage.test.ts src/lib/noInlineStyles.test.ts src/lib/basePathCoverage.test.ts && npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/portal/src/pages/service apps/portal/src/components/portal/ServiceScorecard.tsx \
+  apps/portal/src/components/portal/ServiceScorecard.test.tsx
+git commit -m "feat(portal): customer Service scorecard page (W04)"
+```
+
+---
+
+### Task 12: Documents page and library component
+
+**Files:**
+- Create: `apps/portal/src/pages/documents/index.astro`, `apps/portal/src/pages/documents/index.test.ts`
+- Create: `apps/portal/src/components/portal/DocumentLibrary.tsx`, `apps/portal/src/components/portal/DocumentLibrary.test.tsx`
+
+**Interfaces:**
+- Consumes: `portalApi.getDocuments`, `portalApi.documentContentUrl` (Task 10); `PortalDocumentsDto` (Task 4).
+- Produces: `data-testid` `portal-documents-groups`, `portal-documents-group-<category>`, `portal-document-row-<id>`, `portal-document-download-<id>`, `portal-documents-empty`, `portal-documents-error`, `documents-ledger-foot`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// apps/portal/src/pages/documents/index.test.ts
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const pageSource = readFileSync(new URL('./index.astro', import.meta.url), 'utf8');
+const componentSource = readFileSync(
+  new URL('../../components/portal/DocumentLibrary.tsx', import.meta.url), 'utf8');
+
+describe('documents page', () => {
+  it('bounces a page the MSP switched off', () => {
+    expect(pageSource).toContain('redirectToPortalHomeAfterDisabled(Astro)');
+  });
+  it('redirects on 401 before rendering', () => {
+    expect(pageSource).toContain('redirectToLoginAfter401(Astro)');
+  });
+  it('never prints a raw transport error at the customer', () => {
+    expect(pageSource).not.toMatch(/\{response\.error\}/);
+    expect(pageSource).toContain('data-testid="portal-documents-error"');
+    expect(pageSource).toContain("We couldn't load your documents just now. Your IT team can help.");
+  });
+  it('downloads through the API path, never a presigned url', () => {
+    expect(componentSource).toContain('portalApi.documentContentUrl');
+    expect(componentSource).not.toMatch(/https?:\/\//);
+  });
+  it('gives every list, row and download a testid', () => {
+    expect(componentSource).toContain('data-testid="portal-documents-groups"');
+    expect(componentSource).toContain('data-testid="portal-documents-empty"');
+    expect(componentSource).toMatch(/data-testid=\{`portal-document-row-\$\{/);
+    expect(componentSource).toMatch(/data-testid=\{`portal-document-download-\$\{/);
+  });
+});
+```
+
+```tsx
+// apps/portal/src/components/portal/DocumentLibrary.test.tsx
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { DocumentLibrary } from './DocumentLibrary';
+
+vi.mock('@/lib/api', () => ({
+  portalApi: { documentContentUrl: (id: string) => `/api/v1/portal/documents/${id}/content` },
+}));
+
+const dto = {
+  asOf: '2026-10-15T12:00:00.000Z',
+  timezone: 'America/Denver',
+  groups: [{
+    category: 'runbook' as const,
+    documents: [{
+      id: 'doc1', title: 'Firewall runbook', description: 'How we manage the edge',
+      category: 'runbook' as const, contentType: 'application/pdf', byteSize: 204800,
+      originalFilename: 'firewall.pdf', createdAt: '2026-10-01T00:00:00.000Z',
+    }],
+  }],
+};
+
+describe('DocumentLibrary', () => {
+  it('groups by a human category name and links the download', () => {
+    render(<DocumentLibrary documents={dto} />);
+    expect(screen.getByTestId('portal-documents-group-runbook')).toHaveTextContent('Runbooks');
+    expect(screen.getByTestId('portal-document-download-doc1'))
+      .toHaveAttribute('href', '/api/v1/portal/documents/doc1/content');
+  });
+
+  it('shows a readable size rather than a byte count', () => {
+    render(<DocumentLibrary documents={dto} />);
+    expect(screen.getByTestId('portal-document-row-doc1')).toHaveTextContent('200 KB');
+  });
+
+  it('says so honestly when nothing has been shared', () => {
+    render(<DocumentLibrary documents={{ ...dto, groups: [] }} />);
+    expect(screen.getByTestId('portal-documents-empty')).toBeInTheDocument();
+    expect(screen.queryByTestId('portal-documents-groups')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/portal && npx vitest run src/pages/documents src/components/portal/DocumentLibrary.test.tsx`
+Expected: FAIL, modules not found.
+
+- [ ] **Step 3: Write the page**
+
+Identical shape to Task 11's page: `portalApi.getDocuments(buildServerApiConfig(Astro.request))`, 401 → `redirectToLoginAfter401(Astro)`, `isPortalPageDisabled(response)` → `redirectToPortalHomeAfterDisabled(Astro)`, then `<DocumentLibrary client:load documents={response.data} />` or a `data-testid="portal-documents-error"` block with `PageHeader title="Documents" lede="The documents your IT team has shared with you."` and the `ErrorNotice` copy asserted above.
+
+- [ ] **Step 4: Write `DocumentLibrary.tsx`**
+
+```tsx
+const CATEGORY_LABEL: Record<PortalDocumentCategory, string> = {
+  baseline: 'Baselines',
+  runbook: 'Runbooks',
+  policy: 'Policies',
+  evidence: 'Delivery evidence',
+  report: 'Reports',
+  export: 'Exports',
+  other: 'Other',
+};
+
+/** Bytes as the reader would say them. 1 KB = 1024 B; one decimal above MB. */
+export function formatByteSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${Math.round(kb)} KB`;
+  return `${(kb / 1024).toFixed(1)} MB`;
+}
+```
+`PageHeader`, then either `EmptyState` (`data-testid="portal-documents-empty"`, title "Nothing shared yet", body "Your IT team has not shared any documents with you.") or `<div data-testid="portal-documents-groups">` with one `<section data-testid={\`portal-documents-group-${g.category}\`}>` per group: an `<h2>` of `CATEGORY_LABEL[g.category]` and a ruled table whose rows are `<tr data-testid={\`portal-document-row-${doc.id}\`}>` carrying title, description, `formatByteSize(doc.byteSize)`, `formatDate(doc.createdAt)` and a download anchor exactly as in `ReportRunList.tsx:229-239`:
+
+```tsx
+<a
+  data-testid={`portal-document-download-${doc.id}`}
+  href={portalApi.documentContentUrl(doc.id)}
+  download
+  aria-label={`Download ${doc.title}`}
+  className={cn(BTN_SECONDARY, 'min-h-11 sm:min-h-0 sm:py-1.5')}
+>
+  <Download className="h-4 w-4" aria-hidden="true" />
+  Download
+</a>
+```
+Close with a `data-testid="documents-ledger-foot"` count line and the `As of …` line.
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `cd apps/portal && npx vitest run src && npx tsc --noEmit`
+Expected: PASS — the whole portal suite, so `disabledPageCoverage`, `noInlineStyles` and `basePathCoverage` all see both new pages.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/portal/src/pages/documents apps/portal/src/components/portal/DocumentLibrary.tsx \
+  apps/portal/src/components/portal/DocumentLibrary.test.tsx
+git commit -m "feat(portal): customer Documents library page (W04)"
+```
+
+---
+
+### Task 13: Dashboard Service ledger row
+
+**Files:**
+- Modify: `apps/portal/src/components/portal/DashboardTiles.tsx:241-322`
+- Modify: `apps/portal/src/components/portal/DashboardTiles.test.tsx`
+
+**Interfaces:**
+- Consumes: `DashboardDto['service']` (Task 6).
+- Produces: `data-testid="portal-dashboard-tile-service"`.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+  it('omits the service row entirely when the org has no service tile', () => {
+    render(<DashboardTiles dashboard={dashboardWithout('service')} />);
+    expect(screen.queryByTestId('portal-dashboard-tile-service')).toBeNull();
+  });
+
+  it('states the 90-day record and the next due item', () => {
+    render(<DashboardTiles dashboard={{
+      ...baseDashboard,
+      service: { status: 'ok', windowDays: 90, deliveredOnTime: 5, deliveredLate: 1,
+                 missed: 0, nextDue: { name: 'Monthly sign-in log review', dueAt: '2026-10-31' },
+                 asOf: '2026-10-15T12:00:00.000Z' },
+    }} />);
+    const row = screen.getByTestId('portal-dashboard-tile-service');
+    expect(row).toHaveTextContent('5 of 6 on time');
+    expect(row).toHaveTextContent('Monthly sign-in log review');
+  });
+
+  it('says not yet available rather than 0 of 0 when nothing is scheduled', () => {
+    render(<DashboardTiles dashboard={{
+      ...baseDashboard,
+      service: { status: 'no_data', windowDays: 90, deliveredOnTime: null, deliveredLate: null,
+                 missed: null, nextDue: null, asOf: '2026-10-15T12:00:00.000Z' },
+    }} />);
+    expect(screen.getByTestId('portal-dashboard-tile-service')).toHaveTextContent('Not yet available');
+  });
+```
+(`dashboardWithout` is a local helper that deletes the named key from a clone of `baseDashboard`.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/portal && npx vitest run src/components/portal/DashboardTiles.test.tsx`
+Expected: FAIL — the row does not exist.
+
+- [ ] **Step 3: Implement**
+
+Add a `ServiceValue` function beside `BackupValue` (line 229) and one `LedgerRow` after the backup row, rendered only when `dashboard.service` is present:
+
+```tsx
+function ServiceValue({ tile }: { tile: NonNullable<DashboardDto['service']> }) {
+  const { deliveredOnTime, deliveredLate, missed, nextDue } = tile;
+  if (deliveredOnTime == null || deliveredLate == null || missed == null) return null;
+  const total = deliveredOnTime + deliveredLate + missed;
+  return (
+    <>
+      {total > 0 && (
+        <span className={FIGURE}>{`${deliveredOnTime} of ${total} on time`}</span>
+      )}
+      {nextDue && (
+        <span className={QUIET}>{`Next: ${nextDue.name}`}</span>
+      )}
+    </>
+  );
+}
+…
+{service && (
+  <LedgerRow
+    testId="portal-dashboard-tile-service"
+    label="Service delivered (90 days)"
+    status={effectiveStatus(
+      service.status,
+      service.deliveredOnTime != null || service.nextDue != null,
+    )}
+  >
+    <ServiceValue tile={service} />
+  </LedgerRow>
+)}
+```
+with `service` added to the destructuring at line 241. Placement: directly after the backup row and before Support, so the page reads capability → protection → work delivered → requests.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd apps/portal && npx vitest run src/components/portal/DashboardTiles.test.tsx src/pages/dashboard && npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/portal/src/components/portal/DashboardTiles.tsx apps/portal/src/components/portal/DashboardTiles.test.tsx
+git commit -m "feat(portal): dashboard service delivery row (W04)"
+```
+
+---
+
+### Task 14: Portal RLS integration test
+
+**Files:**
+- Create: `apps/api/src/__tests__/integration/portalServiceRls.integration.test.ts`
+
+**Interfaces:**
+- Consumes: `serviceOverview`, `deliverableOccurrences`, `serviceTile`, `documentsForOrg`, `portalVisibleDocument`; `createPartner`, `createOrganization`, `createUser` from `./db-utils`; `getTestDb` from `./setup`.
+
+Model the file on `apps/api/src/__tests__/integration/portalVisibilityRls.integration.test.ts` — same imports (`import './setup';`), the same admin-seeded / forged-context split, and the same positive-control discipline: **every negative assertion is paired with a positive one**, so a query that returns nothing because it is broken cannot read as a passing isolation proof.
+
+- [ ] **Step 1: Write the test**
+
+```ts
+import './setup';
+import { randomUUID } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { withDbAccessContext, type DbAccessContext } from '../../db';
+import {
+  contracts, orgDocuments, organizationKeyDates, portalBranding, reports, reportRuns,
+  serviceDeliverableEvidence, serviceDeliverableOccurrences, serviceDeliverables,
+} from '../../db/schema';
+import {
+  deliverableOccurrences, serviceOverview, serviceTile,
+} from '../../services/portal/serviceReadModel';
+import {
+  documentsForOrg, portalVisibleDocument,
+} from '../../services/portal/documentsReadModel';
+import { createOrganization, createPartner, createUser } from './db-utils';
+import { getTestDb } from './setup';
+
+/** Everything one org needs to be visible on the portal Service page. */
+async function seedOrgService(admin: ReturnType<typeof getTestDb>, orgId: string, partnerId: string, label: string) {
+  await admin.insert(portalBranding).values({
+    orgId, enableService: true, enableDocuments: true, enableReports: true,
+  });
+  const [contract] = await admin.insert(contracts).values({
+    partnerId, orgId, name: `${label} plan`, status: 'active', intervalMonths: 12,
+    startDate: '2026-01-01', endDate: '2027-01-01', currencyCode: 'USD',
+  }).returning({ id: contracts.id });
+  const [deliverable] = await admin.insert(serviceDeliverables).values({
+    orgId, contractId: contract!.id, name: `${label} sign-in log review`,
+    cadence: 'monthly', anchorDueDate: '2026-09-30', effectiveFrom: '2026-01-01',
+    artifactRequired: true, portalVisible: true,
+  }).returning({ id: serviceDeliverables.id });
+  const [occurrence] = await admin.insert(serviceDeliverableOccurrences).values({
+    orgId, deliverableId: deliverable!.id, nameSnapshot: `${label} sign-in log review`,
+    periodStart: '2026-09-01', periodEnd: '2026-09-30', dueAt: '2026-09-30',
+    originalDueAt: '2026-09-30', status: 'delivered',
+    deliveredAt: new Date('2026-09-29T12:00:00Z'), deliveryNote: `${label} note`,
+  }).returning({ id: serviceDeliverableOccurrences.id });
+  const [doc] = await admin.insert(orgDocuments).values({
+    orgId, title: `${label} findings`, category: 'evidence', storageBackend: 'db',
+    data: Buffer.from(label), contentType: 'application/pdf', byteSize: label.length,
+    sha256: 'a'.repeat(64), originalFilename: `${label}.pdf`, portalVisible: true,
+  }).returning({ id: orgDocuments.id });
+  await admin.insert(serviceDeliverableEvidence).values({
+    orgId, occurrenceId: occurrence!.id, kind: 'document', documentId: doc!.id,
+  });
+  await admin.insert(organizationKeyDates).values({
+    orgId, label: `${label} insurance renewal`, kind: 'insurance_renewal',
+    date: '2027-06-01', portalVisible: true,
+  });
+  return { contractId: contract!.id, deliverableId: deliverable!.id, occurrenceId: occurrence!.id, documentId: doc!.id };
+}
+
+function portalContext(orgId: string): DbAccessContext {
+  return { scope: 'organization', orgId, accessibleOrgIds: [orgId], accessiblePartnerIds: [], userId: null, currentPartnerId: null };
+}
+
+describe('portal service RLS', () => {
+  it('shows organization A its own service record and none of organization B\'s', async () => {
+    const admin = getTestDb();
+    const partner = await createPartner();
+    const orgA = await createOrganization({ partnerId: partner.id });
+    const orgB = await createOrganization({ partnerId: partner.id });
+    const a = await seedOrgService(admin, orgA.id, partner.id, 'alpha');
+    const b = await seedOrgService(admin, orgB.id, partner.id, 'bravo');
+    const args = { timezone: 'UTC', now: new Date('2026-10-15T12:00:00Z') };
+
+    await withDbAccessContext(portalContext(orgA.id), async () => {
+      const overview = await serviceOverview(orgA.id, args);
+      const serialized = JSON.stringify(overview);
+
+      // Positive control FIRST: without it, a broken query passes every
+      // negative assertion below by returning nothing.
+      expect(serialized).toContain('alpha sign-in log review');
+      expect(serialized).toContain('alpha findings');
+      expect(serialized).toContain('alpha insurance renewal');
+      expect(overview.groups[0]!.deliverables[0]!.lastDelivered!.artifactState).toBe('attached');
+
+      expect(serialized).not.toContain('bravo');
+      expect(serialized).not.toMatch(/ticket/i);
+
+      // A forged read of B's own org id under A's context sees nothing: RLS,
+      // not an app-layer filter, is what stops it.
+      expect((await serviceOverview(orgB.id, args)).groups).toEqual([]);
+
+      // B's deliverable id is indistinguishable from a non-existent one.
+      await expect(deliverableOccurrences(orgA.id, b.deliverableId, args)).resolves.toBeNull();
+      const own = await deliverableOccurrences(orgA.id, a.deliverableId, args);
+      expect(own!.occurrences).toHaveLength(1);
+      expect(JSON.stringify(own)).not.toMatch(/ticket/i);
+
+      const docs = await documentsForOrg(orgA.id, args);
+      expect(JSON.stringify(docs)).toContain('alpha findings');
+      expect(JSON.stringify(docs)).not.toContain('bravo');
+      await expect(portalVisibleDocument(orgA.id, b.documentId)).resolves.toBeNull();
+      await expect(portalVisibleDocument(orgA.id, a.documentId)).resolves.toMatchObject({ id: a.documentId });
+
+      const tile = await serviceTile(orgA.id, args);
+      expect(tile).toMatchObject({ status: 'ok', deliveredOnTime: 1, deliveredLate: 0, missed: 0 });
+    });
+  });
+
+  it('withholds a report run whose definition is not portal self-service', async () => {
+    const admin = getTestDb();
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const staff = await createUser({ partnerId: partner.id, orgId: null });
+    const seeded = await seedOrgService(admin, org.id, partner.id, 'charlie');
+
+    const [internal] = await admin.insert(reports).values({
+      orgId: org.id, name: 'Internal posture', type: 'security_compliance_posture',
+      portalSelfService: false, createdBy: staff.id,
+    }).returning({ id: reports.id });
+    const [run] = await admin.insert(reportRuns).values({
+      reportId: internal!.id, status: 'completed', completedAt: new Date(),
+    }).returning({ id: reportRuns.id });
+    await admin.insert(serviceDeliverableEvidence).values({
+      orgId: org.id, occurrenceId: seeded.occurrenceId, kind: 'report_run',
+      reportId: internal!.id, reportRunId: run!.id,
+    });
+
+    await withDbAccessContext(portalContext(org.id), async () => {
+      const overview = await serviceOverview(org.id, { timezone: 'UTC', now: new Date('2026-10-15T12:00:00Z') });
+      const evidence = overview.groups[0]!.deliverables[0]!.lastDelivered!.evidence;
+      // The document evidence still publishes; the internal run does not.
+      expect(evidence.map((e) => e.kind)).toEqual(['document']);
+      expect(JSON.stringify(overview)).not.toContain(run!.id);
+    });
+  });
+
+  it('publishes evidence documents even with enable_documents off', async () => {
+    const admin = getTestDb();
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    await seedOrgService(admin, org.id, partner.id, 'delta');
+    await admin.update(portalBranding).set({ enableDocuments: false })
+      .where(eq(portalBranding.orgId, org.id));
+
+    await withDbAccessContext(portalContext(org.id), async () => {
+      const overview = await serviceOverview(org.id, { timezone: 'UTC', now: new Date('2026-10-15T12:00:00Z') });
+      expect(overview.groups[0]!.deliverables[0]!.lastDelivered!.artifactState).toBe('attached');
+    });
+  });
+});
+```
+
+Adjust the seed literals to whatever W01/W03 actually named the columns — the file will not compile otherwise, which is the intended feedback.
+
+- [ ] **Step 2: Run it**
+
+```bash
+pnpm test-stack up
+cd apps/api && npx vitest run --config vitest.integration.config.ts src/__tests__/integration/portalServiceRls.integration.test.ts
+```
+Expected: PASS. A failure on the "positive control FIRST" assertions means the read model's predicates are wrong, not that isolation works.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/__tests__/integration/portalServiceRls.integration.test.ts
+git commit -m "test(portal): cross-org RLS proof for the service and documents surfaces (W04)"
+```
+
+---
+
+### Task 15: Wave verification and PR
+
+**Files:** none new.
+
+- [ ] **Step 1: Rebase on `main` and re-check the migration name**
+
+```bash
+git fetch origin && git rebase origin/main
+ls apps/api/migrations | sort | tail -3
+```
+If anything now sorts after `2026-10-15-170600-…`, rename the file upward, `git add -A`, amend the Task-1 commit, and re-run `cd apps/api && npx vitest run src/db/autoMigrate.test.ts`. The pre-push hook re-checks against `origin/main` and will refuse the push otherwise.
+
+- [ ] **Step 2: Run every unit suite this wave touched**
+
+```bash
+cd packages/shared && npx vitest run src/types src/validators/portal.test.ts && npx tsc --noEmit
+cd ../../apps/api && npx vitest run src/services/portal src/routes/portal src/routes/orgPortalSettings.test.ts src/db/autoMigrate.test.ts src/db/migrationRlsScope.test.ts && npx tsc --noEmit
+cd ../portal && npx vitest run src && npx tsc --noEmit
+cd ../web && npx vitest run src/components/settings/OrgPortalSettingsEditor.test.tsx src/lib/i18n src/lib/__tests__/no-silent-mutations.test.ts
+```
+Expected: all PASS. `migrationRlsScope.test.ts` must stay green — the new migration writes no rows, so it needs no `breeze.scope` election and must not be added to that test's frozen baseline.
+
+- [ ] **Step 3: Run the contract suites against a live database**
+
+```bash
+pnpm test-stack up
+cd apps/api && npx vitest run --config vitest.integration.config.ts \
+  src/__tests__/integration/portalServiceRls.integration.test.ts \
+  src/__tests__/integration/portalVisibilityRls.integration.test.ts \
+  src/__tests__/integration/rls-coverage.integration.test.ts \
+  src/__tests__/integration/tenantCascade.integration.test.ts \
+  src/__tests__/integration/tenant-export-policy.integration.test.ts \
+  src/__tests__/integration/tenantExportErasureRoundtrip.integration.test.ts
+pnpm db:check-drift
+```
+Expected: all PASS and no drift. `tenant-export-policy` is the suite that fails if Task 1 Step 8 was skipped; it cannot fail in the unit **Test API** job, so a green local unit run is not evidence.
+
+- [ ] **Step 4: Prove the flags end to end by hand**
+
+With the test stack up and the API booted against it: as an MSP admin, `PATCH /api/v1/orgs/organizations/<orgId>/portal-settings` with `{"enableService":true,"enableDocuments":false}`; then as a portal session for that org, `GET /api/v1/portal/service` → 200, `GET /api/v1/portal/documents` → 403 `PORTAL_DOCUMENTS_DISABLED`, `GET /api/v1/portal/documents/<evidence doc id>/content` → 200 bytes. Flip `enableService` to false → `/portal/service` returns 403 `PORTAL_SERVICE_DISABLED` and the same content path returns 403. Record the four status codes in the PR body.
+
+- [ ] **Step 5: Tear down and open the PR**
+
+```bash
+pnpm test-stack down
+git push -u origin feature/<parent#>-service-deliverables/wave-<W04 sub-issue#>
+gh pr create --title "feat(portal): customer Service and Documents surfaces (service deliverables W04)" --body "…"
+```
+The PR body must contain `Closes #<W04 sub-issue>`, the spec path, the four status codes from Step 4, and a line naming the three resolved spec ambiguities (occurrence-status vocabulary, the split document gate, the optional `DashboardDto.service` key) so the reviewer sees them without reading the diff.
+
+- [ ] **Step 6: Merge through the queue**
+
+`gh pr merge <N>` once `CI Success` is green. Never `--admin`.
+
+---
+
+## Self-review
+
+**Spec coverage.** §4.7 (both `portal_branding` columns, `PORTAL_VISIBILITY_FLAG_KEYS`, strict gates, export policy) → Task 1; the MSP write surface implied by §4.7 → Tasks 2–3. §8 `GET /portal/service` → Tasks 5, 8. §8 `GET /portal/service/:deliverableId/occurrences` → Tasks 6, 8. §8 `GET /portal/documents` and `/documents/:id/content` with `contentDispositionFor` and no presigned URL → Tasks 7, 9, 12. §8 dashboard `serviceTile` in `dashboardForOrg`'s `Promise.all` → Tasks 6, 13. §8 publication rules D10 (no ticket; document evidence under `enable_service`; report evidence needs `enable_reports` + `portal_self_service`; `held_by_msp`) → Task 5 helpers, tested in Tasks 5, 11, 14. §8 pages + nav → Tasks 10–12. §11 (no system escalation, org from the session, shape-1 only) → Global Constraints + Task 14. §13 portal tests → Tasks 5–7 (read-model units), 8–9 (routes: 403 flag-off, 304 ETag), 11–12 (pages), 14 (`portalServiceRls.integration.test.ts`), 15 (`rls-coverage`, `tenant-export-policy`).
+
+**Placeholder scan.** No "TBD", no "add error handling", no "similar to Task N". Every test step carries the assertion text; every implementation step carries either the code or an exact, checkable rule (the query plan in Task 5 Step 3, the four mechanical edits in Task 2 Step 3). The one cross-wave dependency, W03's `streamDocument`, was read back from the W03 plan and is quoted at its real three-argument signature; Task 9 still carries the `grep` that re-confirms it against the merged code before any line is written, because W03 may yet change under review.
+
+**Cross-wave checks run while writing this plan** (each found a real defect, now fixed): W03's `streamDocument` takes `(orgId, id, actor)` and returns `{ view, contentType, originalFilename, sha256, body, contentLength }` — not a row — so Task 7 became a metadata-only visibility lookup and Task 9 delegates the bytes; `streamDocument` does **not** filter `portal_visible`, so the portal predicate must run first and does; and W03 already claims migration slots `-170300-` and `-170400-` while W05 claims `-170500-`, so this wave moved to `-170600-`.
+
+**Type consistency.** `artifactStateFor`, `portalOccurrenceStatus`, `publishableEvidence`, `serviceOverview`, `deliverableOccurrences`, `serviceTile`, `documentsForOrg`, `portalVisibleDocument`, `portalServiceRoutes`, `portalDocumentRoutes`, `createPortalFeatureGateAny`, `portalApi.getService` / `getServiceOccurrences` / `getDocuments` / `documentContentUrl` are spelled identically in every Interfaces block, code block and test that names them. DTO names match `packages/shared/src/types/portalService.ts` exactly. `summarizeStatus` and `OccurrenceStatus` match the W01 plan's Task 8 exports; `orgDocuments`, `OrgDocumentCategory`, `DeliverableActor` and `streamDocument(orgId, id, actor)` were read back from the W03 plan's Tasks 3 and 7 and match it verbatim.

--- a/docs/superpowers/plans/billing/2026-09-10-service-deliverables-w05-templates-and-backfill.md
+++ b/docs/superpowers/plans/billing/2026-09-10-service-deliverables-w05-templates-and-backfill.md
@@ -1,0 +1,1900 @@
+---
+tracking_issue: LanternOps/breeze#5573
+---
+# Service Deliverables W05: Template Sets, Apply-to-Org/Contract, Settings Page and First-Customer Backfill — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let an MSP define a service tier once as a partner-wide deliverable template set and apply it to any org (optionally pinned to a contract) in one all-or-nothing transaction, with a settings page to author sets, an approval-gated MCP action, and a re-runnable script that stands up the first paying customer's eight "Best plan" deliverables from ids supplied at run time.
+
+**Architecture:** Two new dual-axis tables (`deliverable_template_sets`, `deliverable_template_items`) follow CLAUDE.md "Partner-Wide First": `org_id` XOR `partner_id`, one `FOR ALL` dual-axis policy plus a separate SELECT-only partner-wide branch. An item can never belong to a differently-owned set because it carries the set's owner columns and two *branch* composite FKs — `(set_id, org_id)` and `(set_id, partner_id)` — exactly one of which is live per row (a single three-column FK would be MATCH SIMPLE and therefore vacuous; see Task 1). `services/deliverableTemplateService.ts` is the only writer; `applyTemplateSet` copies items into `service_deliverables` through W01's `createDeliverable` inside one `db.transaction`, computing each `anchor_due_date` with a new pure `firstAnchorAfter` in `services/recurrence.ts`. REST, MCP, a settings page and an apply-modal sit on top; the backfill script is a thin driver over the same service under `withSystemDbAccessContext`.
+
+**Tech Stack:** PostgreSQL + hand-written SQL migrations, Drizzle ORM, Hono + Zod (`@breeze/shared` validators), Vitest (API unit with Drizzle mocks; API integration on real Postgres), Astro + React islands, react-i18next, Testing Library, tsx for the operational script.
+
+**Spec:** `docs/superpowers/specs/billing/2026-09-10-service-deliverables-portal-design.md` (approved 2026-09-10). This wave is D7/D9, §4.6, §9 (settings page + apply button), §10 (`routes/deliverableTemplates.ts`, `apply-template` REST + `manage_deliverables.apply_template` MCP), §12 (409 on name collisions), §13 (template XOR 23514), §15 (first use). Depends on **W01 only** — `docs/superpowers/plans/billing/2026-09-10-service-deliverables-w01-schema-core.md`, whose names and signatures are the contract this plan builds on.
+
+## Global Constraints
+
+- **Partner-Wide First (CLAUDE.md).** Both new tables are `org_id` XOR `partner_id`, both nullable, with `<table>_one_owner_chk CHECK ((org_id IS NULL) <> (partner_id IS NULL))`, a partner index, ONE dual-axis `FOR ALL` policy (`system OR breeze_has_org_access(org_id) OR breeze_has_partner_access(partner_id)`) and a SEPARATE SELECT-only policy named `<table>_partner_wide_select` `USING (org_id IS NULL AND partner_id = public.breeze_current_partner_id())`. Never append the partner-wide branch to the `FOR ALL` policy — that widens UPDATE/DELETE row targeting.
+- **Partner-wide writes gate on `canManagePartnerWidePolicies(auth)`** (`apps/api/src/services/partnerWideAccess.ts:25`). Create schemas take `ownerScope: 'organization' | 'partner'`; update schemas derived via `.partial()` must `.omit({ ownerScope: true })`.
+- **Partner-wide reads are gated on `actor.scope === 'partner'`** in the app layer. An org token carries a `partnerId` but never passes `breeze_has_partner_access`, and the SELECT branch deliberately makes partner-wide rows *readable* from an org context — so the app-layer gate is the only authorization control on that axis, not a redundant second one (`partnerWideAccess.ts:73` `canReadPartnerWideRows`). Never claim RLS/app parity.
+- **Never use the #1105 escalation** (`runOutsideDbContext(() => withSystemDbAccessContext(...))`) on this table: it double-holds a pooled connection under the request's own transaction and bypasses RLS. The SELECT branch is the sanctioned mechanism.
+- Migrations are idempotent (`CREATE TABLE IF NOT EXISTS`, `DO $$ … EXCEPTION WHEN duplicate_object`, `DROP POLICY IF EXISTS` then `CREATE`), carry **no inner `BEGIN`/`COMMIT`**, and write no rows (DDL only ⇒ no `breeze.scope` election needed).
+- Migration filename must sort after the newest **committed** migration. As of 2026-09-10 that is `2026-10-15-160010-backup-snapshots-layout-manifest.sql`; W01–W04 claim `2026-10-15-170000` … `-170400`. This wave uses `2026-10-15-170500-deliverable-templates.sql`. Re-check with `ls apps/api/migrations | sort | tail -1` before every commit and rename upward if origin/main gained a later one. W05's migration has no dependency on W02/W03/W04's files, so a fresh-DB replay in filename order is safe whatever order the waves land in.
+- Every composite FK that references an `org_id` column is `DEFERRABLE INITIALLY IMMEDIATE` (org-merge contract). Both branch FKs on `deliverable_template_items` are declared deferrable for symmetry.
+- Table privileges for `breeze_app` are NOT per-migration: `apps/api/src/db/ensureAppRole.ts:85-88` runs a blanket `GRANT SELECT, INSERT, UPDATE, DELETE, REFERENCES ON ALL TABLES IN SCHEMA public` plus `ALTER DEFAULT PRIVILEGES … ON TABLES TO breeze_app` at startup, so new tables inherit access automatically. Explicit per-table `GRANT`/`REVOKE` lines exist only for append-only overrides (e.g. `2026-10-08-101200-billing-evidence.sql:92`). The two `GRANT` statements kept in Task 1 are therefore harmless redundancy, not a requirement, and W01 needs nothing.
+- Registrations in the same PR as the migration: `DUAL_AXIS_TENANT_TABLES` **and** `XOR_OWNERSHIP_DUAL_AXIS_TABLES` (`apps/api/src/__tests__/integration/rls-coverage.integration.test.ts:315` and `:587`), `CORE_ORG_CASCADE_DELETE_ORDER` (`services/tenantCascade.ts`), `CORE_TENANT_EXPORT_POLICY` (`services/tenantExportPolicyRegistry.ts`), `services/orgMergeRegistry.ts`. `PARTNER_WIDE_SELECT_BRANCH_EXEMPT` has a hard ceiling of 0 (`rls-coverage.integration.test.ts:654`) — a new table **cannot** take an exemption, the branch ships in the creating migration.
+- Org access in services: `actor.accessibleOrgIds !== null && !actor.accessibleOrgIds.includes(orgId)` ⇒ 404 `NOT_FOUND`, never 403, never an existence leak.
+- Dates are ISO `YYYY-MM-DD` strings; month arithmetic only through `addMonthsClamped` / `addDaysISO` (`apps/api/src/services/contractMath.ts:21,62`).
+- Web mutations go through `runAction` (`apps/web/src/lib/runAction.ts`). i18n keys land in the `deliverables.json` namespace W01 created, in **all 8 locales** (`en`, `de-DE`, `es-419`, `fr-CA`, `fr-FR`, `it-IT`, `pt-BR`, `tr-TR`) with real translations — `apps/web/src/lib/i18n/translationCoverage.test.ts` caps exact-English duplicates.
+- Run one API test file as `cd apps/api && npx vitest run <path>`. Never `pnpm --filter <pkg> test -- --run <path>` (the `--` is forwarded literally and vitest runs the whole suite in watch mode).
+- Branch: `feature/<parent#>-service-deliverables/wave-<W05 sub-issue#>`; PR body contains `Closes #<W05 sub-issue>`.
+
+---
+
+## File structure
+
+| Path | Responsibility |
+|---|---|
+| `apps/api/migrations/2026-10-15-170500-deliverable-templates.sql` | two tables, XOR checks, branch FKs, dual-axis RLS + partner-wide SELECT branch |
+| `apps/api/src/db/schema/deliverableTemplates.ts` | Drizzle tables + row types |
+| `apps/api/src/db/schema/index.ts` | export the new module |
+| `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts` | `DUAL_AXIS_TENANT_TABLES` + `XOR_OWNERSHIP_DUAL_AXIS_TABLES` entries |
+| `apps/api/src/services/tenantCascade.ts`, `tenantExportPolicyRegistry.ts`, `orgMergeRegistry.ts` | cascade / export / merge registrations |
+| `apps/api/src/services/recurrence.ts` (+ `.test.ts`) | new pure `firstAnchorAfter` |
+| `apps/api/src/services/serviceDeliverableService.ts` | `createDeliverable` gains an optional `tx` executor |
+| `apps/api/src/services/deliverableTemplateService.ts` (+ `.test.ts`) | set/item CRUD + `applyTemplateSet` |
+| `packages/shared/src/validators/deliverableTemplates.ts` (+ `.test.ts`) | Zod schemas shared by API, web and the script |
+| `apps/api/src/routes/deliverableTemplates.ts` (+ `.test.ts`) | `/deliverable-templates` sets + items CRUD |
+| `apps/api/src/routes/serviceDeliverables.ts` (+ `.test.ts`) | `POST /orgs/:orgId/deliverables/apply-template` |
+| `apps/api/src/index.ts` | mount `deliverableTemplateRoutes` |
+| `apps/api/src/services/aiToolsDeliverables.ts` (+ `.registryParity.contract.test.ts`) | `list_deliverable_templates`, `manage_deliverables.apply_template` |
+| `apps/api/src/services/aiTools.ts`, `aiToolSchemas.ts`, `aiGuardrails.ts`, `aiAgentSdkTools.ts` | the four MCP registration sites |
+| `apps/api/src/__tests__/integration/deliverableTemplatesPartnerRls.integration.test.ts` | cross-partner forge, XOR, org isolation, SELECT branch, apply fan-out |
+| `apps/api/scripts/backfill-first-customer-deliverables.ts` | one-off operational script |
+| `apps/api/package.json` | `deliverables:backfill-first-customer` script entry |
+| `apps/web/src/lib/api/deliverableTemplates.ts` | typed fetch wrappers |
+| `apps/web/src/components/settings/DeliverableTemplatesPage.tsx` (+ `.test.tsx`) | settings page with ownerScope selector + "All orgs" badge |
+| `apps/web/src/pages/settings/deliverable-templates.astro`, `apps/web/src/pages/settings/index.astro` | page + nav card |
+| `apps/web/src/components/deliverables/ApplyTemplateModal.tsx` (+ `.test.tsx`) | picker (set, optional contract, effective from) |
+| `apps/web/src/components/organizations/record/OrgServiceTab.tsx`, `apps/web/src/components/contracts/ContractDeliverablesSection.tsx` | "Apply template set" button |
+| `apps/web/src/locales/*/deliverables.json` | new `templates.*` keys in 8 locales |
+
+---
+
+### Task 1: Migration — `deliverable_template_sets` and `deliverable_template_items`
+
+**Files:**
+- Create: `apps/api/migrations/2026-10-15-170500-deliverable-templates.sql`
+
+**Interfaces:**
+- Produces: tables `deliverable_template_sets`, `deliverable_template_items`; policies `deliverable_template_sets_isolation`, `deliverable_template_sets_partner_wide_select`, `deliverable_template_items_isolation`, `deliverable_template_items_partner_wide_select`; unique indexes `deliverable_template_sets_id_org_uq`, `deliverable_template_sets_id_partner_uq`. Reuses W01's enums `deliverable_cadence` and `deliverable_completion_mode` (created by `2026-10-15-170000-service-deliverables.sql`).
+
+**Owner-integrity design decision (the "decide and justify" point).** A single three-column FK `(set_id, org_id, partner_id) → sets(id, org_id, partner_id)` is **vacuous here**. Postgres FKs default to `MATCH SIMPLE`: if *any* referencing column is NULL the constraint is satisfied without a lookup. The XOR check guarantees one of `org_id`/`partner_id` is always NULL, so such an FK would never once be evaluated. `MATCH FULL` is the mirror failure — it demands all-NULL or all-non-NULL, which the XOR shape can never satisfy. The working design is **two branch FKs**, `(set_id, org_id)` and `(set_id, partner_id)`: for an org-owned item the first has both columns non-NULL and is checked (the set must carry that exact `org_id`), while the second is skipped; for a partner-owned item it is the other way round. Exactly one is live per row, and an item pointing at a differently-owned set fails with 23503. `ON DELETE CASCADE` on both is correct for the same reason — the live branch cascades, the skipped one has nothing to match.
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- Deliverable template sets and items (spec §4.6, D9).
+-- Dual-ownership per CLAUDE.md "Partner-Wide First": org_id XOR partner_id.
+-- DDL only: no rows are written, so no breeze.scope election is required.
+-- Depends on 2026-10-15-170000-service-deliverables.sql for the two enums.
+
+-- ============================================
+-- 1. deliverable_template_sets
+-- ============================================
+CREATE TABLE IF NOT EXISTS deliverable_template_sets (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id UUID REFERENCES organizations(id),
+  partner_id UUID REFERENCES partners(id),
+  name VARCHAR(200) NOT NULL,
+  description TEXT,
+  created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+DO $$ BEGIN
+  ALTER TABLE deliverable_template_sets ADD CONSTRAINT deliverable_template_sets_one_owner_chk
+    CHECK ((org_id IS NULL) <> (partner_id IS NULL));
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+-- Partial so the NULL axis never participates: a partner-wide set and an
+-- org-owned set may legitimately share a name.
+CREATE UNIQUE INDEX IF NOT EXISTS deliverable_template_sets_partner_name_uq
+  ON deliverable_template_sets (partner_id, name) WHERE partner_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS deliverable_template_sets_org_name_uq
+  ON deliverable_template_sets (org_id, name) WHERE org_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS deliverable_template_sets_partner_idx ON deliverable_template_sets (partner_id);
+CREATE INDEX IF NOT EXISTS deliverable_template_sets_org_idx ON deliverable_template_sets (org_id);
+
+-- FK targets for the two BRANCH foreign keys on items (see section 2). These
+-- must be non-partial, non-expression unique indexes or Postgres refuses to
+-- reference them. `id` is the PK, so uniqueness is trivially satisfied; the
+-- extra column is what makes the FK carry the owner axis.
+CREATE UNIQUE INDEX IF NOT EXISTS deliverable_template_sets_id_org_uq
+  ON deliverable_template_sets (id, org_id);
+CREATE UNIQUE INDEX IF NOT EXISTS deliverable_template_sets_id_partner_uq
+  ON deliverable_template_sets (id, partner_id);
+
+ALTER TABLE deliverable_template_sets ENABLE ROW LEVEL SECURITY;
+ALTER TABLE deliverable_template_sets FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS deliverable_template_sets_isolation ON deliverable_template_sets;
+CREATE POLICY deliverable_template_sets_isolation
+  ON deliverable_template_sets
+  USING (
+    public.breeze_current_scope() = 'system'
+    OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+    OR (partner_id IS NOT NULL AND public.breeze_has_partner_access(partner_id))
+  )
+  WITH CHECK (
+    public.breeze_current_scope() = 'system'
+    OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+    OR (partner_id IS NOT NULL AND public.breeze_has_partner_access(partner_id))
+  );
+
+-- Separate, additive, SELECT-ONLY partner-wide read branch (#4673; template
+-- 2026-10-05-110000-config-policy-partner-wide-select.sql). Appending it to the
+-- FOR ALL policy would also widen UPDATE/DELETE row targeting; Postgres never
+-- consults FOR SELECT policies when computing those targets.
+DROP POLICY IF EXISTS deliverable_template_sets_partner_wide_select ON deliverable_template_sets;
+CREATE POLICY deliverable_template_sets_partner_wide_select
+  ON deliverable_template_sets
+  FOR SELECT
+  USING (org_id IS NULL AND partner_id = public.breeze_current_partner_id());
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON deliverable_template_sets TO breeze_app;
+
+-- ============================================
+-- 2. deliverable_template_items
+-- ============================================
+-- The item copies the set's owner columns, carries the SAME XOR check, and pins
+-- itself to the set through TWO branch FKs (rationale above the task).
+CREATE TABLE IF NOT EXISTS deliverable_template_items (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  set_id UUID NOT NULL,
+  org_id UUID REFERENCES organizations(id),
+  partner_id UUID REFERENCES partners(id),
+  name VARCHAR(200) NOT NULL,
+  description TEXT,
+  cadence deliverable_cadence NOT NULL,
+  lead_days INTEGER NOT NULL DEFAULT 7,
+  grace_days INTEGER NOT NULL DEFAULT 14,
+  artifact_required BOOLEAN NOT NULL DEFAULT TRUE,
+  completion_mode deliverable_completion_mode NOT NULL DEFAULT 'on_ticket_resolve',
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+DO $$ BEGIN
+  ALTER TABLE deliverable_template_items ADD CONSTRAINT deliverable_template_items_one_owner_chk
+    CHECK ((org_id IS NULL) <> (partner_id IS NULL));
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE deliverable_template_items ADD CONSTRAINT deliverable_template_items_days_chk
+    CHECK (lead_days >= 0 AND grace_days >= 0);
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE deliverable_template_items ADD CONSTRAINT deliverable_template_items_set_org_fk
+    FOREIGN KEY (set_id, org_id) REFERENCES deliverable_template_sets(id, org_id)
+    ON DELETE CASCADE DEFERRABLE INITIALLY IMMEDIATE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  ALTER TABLE deliverable_template_items ADD CONSTRAINT deliverable_template_items_set_partner_fk
+    FOREIGN KEY (set_id, partner_id) REFERENCES deliverable_template_sets(id, partner_id)
+    ON DELETE CASCADE DEFERRABLE INITIALLY IMMEDIATE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+-- One name per set: applying a set must not try to create two deliverables with
+-- the same name, which service_deliverables_org_contract_name_uq would reject
+-- halfway through the transaction.
+CREATE UNIQUE INDEX IF NOT EXISTS deliverable_template_items_set_name_uq
+  ON deliverable_template_items (set_id, name);
+CREATE INDEX IF NOT EXISTS deliverable_template_items_set_sort_idx
+  ON deliverable_template_items (set_id, sort_order);
+CREATE INDEX IF NOT EXISTS deliverable_template_items_partner_idx ON deliverable_template_items (partner_id);
+CREATE INDEX IF NOT EXISTS deliverable_template_items_org_idx ON deliverable_template_items (org_id);
+
+ALTER TABLE deliverable_template_items ENABLE ROW LEVEL SECURITY;
+ALTER TABLE deliverable_template_items FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS deliverable_template_items_isolation ON deliverable_template_items;
+CREATE POLICY deliverable_template_items_isolation
+  ON deliverable_template_items
+  USING (
+    public.breeze_current_scope() = 'system'
+    OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+    OR (partner_id IS NOT NULL AND public.breeze_has_partner_access(partner_id))
+  )
+  WITH CHECK (
+    public.breeze_current_scope() = 'system'
+    OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+    OR (partner_id IS NOT NULL AND public.breeze_has_partner_access(partner_id))
+  );
+
+DROP POLICY IF EXISTS deliverable_template_items_partner_wide_select ON deliverable_template_items;
+CREATE POLICY deliverable_template_items_partner_wide_select
+  ON deliverable_template_items
+  FOR SELECT
+  USING (org_id IS NULL AND partner_id = public.breeze_current_partner_id());
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON deliverable_template_items TO breeze_app;
+```
+
+- [ ] **Step 2: Verify the filename still sorts last, then run the naming and scope guards**
+
+Run: `ls apps/api/migrations | sort | tail -3 && scripts/check-migration-naming.sh --against-ref origin/main && cd apps/api && npx vitest run src/db/autoMigrate.test.ts src/db/migrationRlsScope.test.ts`
+Expected: the new file is within the `2026-10-15-1705xx` band, both guards PASS. `migrationRlsScope` passes because the file writes no rows — never add this file to that suite's frozen baseline.
+
+- [ ] **Step 3: Apply twice against the worktree test stack**
+
+Run: `pnpm test-stack up` (once for the wave), then twice:
+`cd apps/api && DATABASE_URL=$(grep DATABASE_URL .env.test | cut -d= -f2-) pnpm db:migrate`
+Expected: the second run is a clean no-op (idempotency).
+
+- [ ] **Step 4: Forge the cross-owner item by hand as `breeze_app`**
+
+Run `psql` against the test stack as `breeze_app` and, under a system context, insert a partner-owned set `S` then an item with `org_id = <some org>, partner_id = NULL, set_id = S`.
+Expected: `ERROR: insert or update on table "deliverable_template_items" violates foreign key constraint "deliverable_template_items_set_org_fk"` (SQLSTATE 23503). If it succeeds, the branch-FK pair is wrong — stop and fix before writing any TypeScript.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/migrations/2026-10-15-170500-deliverable-templates.sql
+git commit -m "feat(deliverables): partner-wide deliverable template set and item tables (W05)"
+```
+
+---
+
+### Task 2: Drizzle schema module
+
+**Files:**
+- Create: `apps/api/src/db/schema/deliverableTemplates.ts`
+- Modify: `apps/api/src/db/schema/index.ts` (next to the `serviceDeliverables` export W01 added)
+
+**Interfaces:**
+- Consumes: `deliverableCadenceEnum`, `deliverableCompletionModeEnum` from `./serviceDeliverables` (W01 Task 3).
+- Produces: `deliverableTemplateSets`, `deliverableTemplateItems`, `type DeliverableTemplateSetRow`, `type DeliverableTemplateItemRow`.
+
+- [ ] **Step 1: Write the module**
+
+```ts
+import { pgTable, uuid, varchar, text, integer, boolean, timestamp, index, uniqueIndex } from 'drizzle-orm/pg-core';
+import { organizations } from './orgs';
+import { partners } from './partners';
+import { users } from './users';
+import { deliverableCadenceEnum, deliverableCompletionModeEnum } from './serviceDeliverables';
+
+/**
+ * Spec §4.6 / D9. Dual ownership: org_id XOR partner_id (CLAUDE.md
+ * "Partner-Wide First"). The XOR CHECK, the two branch FKs on items and the
+ * partner-wide SELECT policy live in SQL only — Drizzle cannot express any of
+ * them. The single-column `references()` below exist for typing.
+ */
+export const deliverableTemplateSets = pgTable('deliverable_template_sets', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id').references(() => organizations.id),
+  partnerId: uuid('partner_id').references(() => partners.id),
+  name: varchar('name', { length: 200 }).notNull(),
+  description: text('description'),
+  createdBy: uuid('created_by').references(() => users.id, { onDelete: 'set null' }),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+}, (t) => [
+  uniqueIndex('deliverable_template_sets_id_org_uq').on(t.id, t.orgId),
+  uniqueIndex('deliverable_template_sets_id_partner_uq').on(t.id, t.partnerId),
+  index('deliverable_template_sets_partner_idx').on(t.partnerId),
+  index('deliverable_template_sets_org_idx').on(t.orgId),
+]);
+
+/** Spec §4.6. Owner columns are copied from the set and pinned by two branch FKs. */
+export const deliverableTemplateItems = pgTable('deliverable_template_items', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  setId: uuid('set_id').notNull().references(() => deliverableTemplateSets.id, { onDelete: 'cascade' }),
+  orgId: uuid('org_id').references(() => organizations.id),
+  partnerId: uuid('partner_id').references(() => partners.id),
+  name: varchar('name', { length: 200 }).notNull(),
+  description: text('description'),
+  cadence: deliverableCadenceEnum('cadence').notNull(),
+  leadDays: integer('lead_days').notNull().default(7),
+  graceDays: integer('grace_days').notNull().default(14),
+  artifactRequired: boolean('artifact_required').notNull().default(true),
+  completionMode: deliverableCompletionModeEnum('completion_mode').notNull().default('on_ticket_resolve'),
+  sortOrder: integer('sort_order').notNull().default(0),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+}, (t) => [
+  uniqueIndex('deliverable_template_items_set_name_uq').on(t.setId, t.name),
+  index('deliverable_template_items_set_sort_idx').on(t.setId, t.sortOrder),
+  index('deliverable_template_items_partner_idx').on(t.partnerId),
+  index('deliverable_template_items_org_idx').on(t.orgId),
+]);
+
+export type DeliverableTemplateSetRow = typeof deliverableTemplateSets.$inferSelect;
+export type DeliverableTemplateItemRow = typeof deliverableTemplateItems.$inferSelect;
+```
+
+Confirm the real export name of the partners table (`grep -n "pgTable('partners'" apps/api/src/db/schema/*.ts`) and adjust the import.
+
+- [ ] **Step 2: Export from the schema barrel**
+
+Add `export * from './deliverableTemplates';` immediately after the `export * from './serviceDeliverables';` line W01 added to `apps/api/src/db/schema/index.ts`.
+
+- [ ] **Step 3: Typecheck and drift check**
+
+Run: `cd apps/api && npx tsc --noEmit -p tsconfig.json && DATABASE_URL=$(grep DATABASE_URL .env.test | cut -d= -f2-) pnpm db:check-drift`
+Expected: no type errors; no drift reported for the two tables. The partial unique name indexes are deliberately absent from the Drizzle definition (Drizzle emits no partial uniques here and `db:check-drift` does not diff the live DB against the schema — see the memory note); do not chase them.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/db/schema/deliverableTemplates.ts apps/api/src/db/schema/index.ts
+git commit -m "feat(deliverables): drizzle schema for deliverable template sets and items (W05)"
+```
+
+---
+
+### Task 3: Tenancy registrations
+
+**Files:**
+- Modify: `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts:315` (`DUAL_AXIS_TENANT_TABLES`) and `:587` (`XOR_OWNERSHIP_DUAL_AXIS_TABLES`)
+- Modify: `apps/api/src/services/tenantCascade.ts` (`CORE_ORG_CASCADE_DELETE_ORDER`, between `'delegant_m365_connections'` and `'deployment_invites'`, around line 389)
+- Modify: `apps/api/src/services/tenantExportPolicyRegistry.ts` (`CORE_TENANT_EXPORT_POLICY`)
+- Modify: `apps/api/src/services/orgMergeRegistry.ts` (SPECIAL map)
+
+- [ ] **Step 1: RLS coverage lists**
+
+In `DUAL_AXIS_TENANT_TABLES` (the set starting at line 315) add, with a comment in the house style:
+
+```ts
+  // deliverable_template_sets / deliverable_template_items (spec §4.6, D9): a
+  // template set is org-scoped (org_id set) OR partner-wide (partner_id set,
+  // org_id NULL — one service tier applied across every org the MSP manages).
+  // Created dual-axis from day one in 2026-10-15-170500-deliverable-templates.
+  // The org_id column means org-tenant auto-discovery already asserts the
+  // breeze_has_org_access branch, so these entries are what assert the
+  // breeze_has_partner_access (partner-wide) branch. CHECKs
+  // <table>_one_owner_chk enforce exactly one axis. Functional cross-partner
+  // forge proof: deliverableTemplatesPartnerRls.integration.test.ts.
+  'deliverable_template_sets',
+  'deliverable_template_items',
+```
+
+Add the same two names to `XOR_OWNERSHIP_DUAL_AXIS_TABLES` (line 587 set). Do **not** touch `PARTNER_WIDE_SELECT_BRANCH_EXEMPT`: its ceiling is 0 and the branch ships in Task 1's migration.
+
+- [ ] **Step 2: Cascade order**
+
+Insert into `CORE_ORG_CASCADE_DELETE_ORDER` between `'delegant_m365_connections'` and `'deployment_invites'`:
+
+```ts
+  // Items before sets — children before parents. localeCompare already orders
+  // them that way ('i' < 's' at the diverging character); verified with
+  // `node --eval "console.log('deliverable_template_items'.localeCompare('deliverable_template_sets'))"` => -1.
+  // Both sort after 'delegant_m365_connections' ('e' < 'i') and before
+  // 'deployment_invites' ('l' < 'p').
+  'deliverable_template_items',
+  'deliverable_template_sets',
+```
+
+Partner-wide rows carry `org_id NULL`, so an org erasure never touches them — the cascade only removes org-owned sets and their items, which is correct.
+
+- [ ] **Step 3: Export policy**
+
+Add to `CORE_TENANT_EXPORT_POLICY` (alphabetical, near the `custom_field_definitions` entry at line 180). Every column is classified; there is no `json`/`jsonb`/`bytea` column on either table, so nothing goes to `excludedOpen`:
+
+```ts
+  "deliverable_template_items": tablePolicy("org_id", {"included":["id","set_id","org_id","partner_id","name","description","cadence","lead_days","grace_days","artifact_required","completion_mode","sort_order","created_at","updated_at"],"reviewedIncluded":[],"excludedSensitive":[],"excludedOpen":[]}),
+  "deliverable_template_sets": tablePolicy("org_id", {"included":["id","org_id","partner_id","name","description","created_by","created_at","updated_at"],"reviewedIncluded":[],"excludedSensitive":[],"excludedOpen":[]}),
+```
+
+- [ ] **Step 4: Merge registry**
+
+`deliverable_template_sets` carries `UNIQUE (org_id, name) WHERE org_id IS NOT NULL`, so a plain repoint raises 23505 when both orgs own a set with the same name. Items ride the parent. Add to the SPECIAL map next to the `custom_field_definitions` entry (`orgMergeRegistry.ts:451`):
+
+```ts
+  deliverable_template_sets: { kind: 'repoint-dedupe', key: ['name'], keyWhere: 'org_id IS NOT NULL' }, // verified: deliverable_template_sets_org_name_uq (org_id, name) WHERE org_id IS NOT NULL — partner-wide sets (org_id NULL) are never touched by an org merge
+  deliverable_template_items: { kind: 'repoint', }, // rides the parent: both branch FKs are ON DELETE CASCADE, and a loser set dropped by the dedupe above takes its items with it
+```
+
+If the engine's `repoint-dedupe` does not accept `keyWhere`, read how `tenant_variables` (line 397) expresses its partial predicate and copy that form exactly; if it cannot express the predicate at all, fall back to `{ kind: 'custom', note: '…' }` and implement it in `orgMergeCustomExecutors.ts` by deleting the loser's colliding org-owned sets (their items cascade) before the repoint. Write the `repoint` entry in whatever form the plain repoint list uses in this file (a bare string in the array, or a SPECIAL-map entry) — check an adjacent leaf table such as `contract_documents` and match it.
+
+- [ ] **Step 5: Run the five standing contract suites**
+
+Run (test stack up):
+```bash
+cd apps/api && npx vitest run --config vitest.integration.config.ts \
+  src/__tests__/integration/rls-coverage.integration.test.ts \
+  src/__tests__/integration/tenantCascade.integration.test.ts \
+  src/__tests__/integration/tenant-export-policy.integration.test.ts \
+  src/__tests__/integration/tenantExportErasureRoundtrip.integration.test.ts \
+  src/__tests__/integration/orgLifecycleFoundations.integration.test.ts
+```
+Expected: all PASS. A failure names the missing table or column — fix the registration, never the test. In particular `rls-coverage`'s "every org_id-XOR-partner_id dual-axis table has a `breeze_current_partner_id()` partner-wide SELECT branch" (line 1617) must be green; if it names either new table, the Task 1 migration did not apply.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/__tests__/integration/rls-coverage.integration.test.ts apps/api/src/services/tenantCascade.ts apps/api/src/services/tenantExportPolicyRegistry.ts apps/api/src/services/orgMergeRegistry.ts
+git commit -m "chore(tenancy): register deliverable template tables in RLS, cascade, export and merge (W05)"
+```
+
+---
+
+### Task 4: Shared validators
+
+**Files:**
+- Create: `packages/shared/src/validators/deliverableTemplates.ts`
+- Test: `packages/shared/src/validators/deliverableTemplates.test.ts`
+- Modify: `packages/shared/src/validators/index.ts` (export the new module)
+
+**Interfaces:**
+- Produces: `templateOwnerScopeSchema`, `createTemplateItemSchema`, `updateTemplateItemSchema`, `createTemplateSetSchema`, `updateTemplateSetSchema`, `applyTemplateSetSchema`, `listTemplateSetsQuerySchema` and the inferred types `CreateTemplateItemInput`, `UpdateTemplateItemInput`, `CreateTemplateSetInput`, `UpdateTemplateSetInput`, `ApplyTemplateSetInput`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+import { describe, expect, it } from 'vitest';
+import {
+  createTemplateSetSchema,
+  updateTemplateSetSchema,
+  createTemplateItemSchema,
+  applyTemplateSetSchema,
+} from './deliverableTemplates';
+
+const item = { name: 'Sign-in log review', cadence: 'monthly' as const };
+
+describe('deliverableTemplates validators', () => {
+  it('defaults ownerScope to organization and item knobs to the deliverable defaults', () => {
+    const parsed = createTemplateSetSchema.parse({ name: 'Best plan', items: [item] });
+    expect(parsed.ownerScope).toBe('organization');
+    expect(parsed.items[0]!.leadDays).toBe(7);
+    expect(parsed.items[0]!.graceDays).toBe(14);
+    expect(parsed.items[0]!.artifactRequired).toBe(true);
+    expect(parsed.items[0]!.completionMode).toBe('on_ticket_resolve');
+    expect(parsed.items[0]!.sortOrder).toBe(0);
+  });
+
+  it('accepts a partner-wide set with no items', () => {
+    expect(createTemplateSetSchema.parse({ name: 'Best plan', ownerScope: 'partner' }).items).toEqual([]);
+  });
+
+  it('rejects an unknown cadence and negative day counts', () => {
+    expect(createTemplateItemSchema.safeParse({ ...item, cadence: 'continuous' }).success).toBe(false);
+    expect(createTemplateItemSchema.safeParse({ ...item, leadDays: -1 }).success).toBe(false);
+  });
+
+  it('the update schema cannot change ownership or items (CLAUDE.md step 2)', () => {
+    expect(updateTemplateSetSchema.safeParse({ ownerScope: 'partner' }).success).toBe(false);
+    expect(updateTemplateSetSchema.safeParse({ orgId: '11111111-1111-4111-8111-111111111111' }).success).toBe(false);
+    expect(updateTemplateSetSchema.safeParse({ items: [] }).success).toBe(false);
+    expect(updateTemplateSetSchema.parse({ name: 'Best plan v2' })).toEqual({ name: 'Best plan v2' });
+  });
+
+  it('apply requires a setId and an ISO effectiveFrom when present', () => {
+    expect(applyTemplateSetSchema.safeParse({ setId: 'nope' }).success).toBe(false);
+    expect(applyTemplateSetSchema.safeParse({ setId: '11111111-1111-4111-8111-111111111111', effectiveFrom: '31/10/2026' }).success).toBe(false);
+    const ok = applyTemplateSetSchema.parse({ setId: '11111111-1111-4111-8111-111111111111', effectiveFrom: '2026-10-01' });
+    expect(ok.contractId).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd packages/shared && npx vitest run src/validators/deliverableTemplates.test.ts`
+Expected: FAIL, module not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+import { z } from 'zod';
+
+const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'YYYY-MM-DD');
+
+export const templateOwnerScopeSchema = z.enum(['organization', 'partner']);
+
+const templateItemFields = {
+  name: z.string().min(1).max(200),
+  description: z.string().max(2000).nullable().optional(),
+  // Mirrors deliverableCadenceSchema in serviceDeliverables.ts (W01); kept as a
+  // literal enum rather than an import so a cadence added to one file cannot
+  // silently widen the other without a test noticing.
+  cadence: z.enum(['monthly', 'quarterly', 'semiannual', 'annual', 'one_time']),
+  leadDays: z.number().int().min(0).max(365).default(7),
+  graceDays: z.number().int().min(0).max(365).default(14),
+  artifactRequired: z.boolean().default(true),
+  completionMode: z.enum(['explicit', 'on_ticket_resolve']).default('on_ticket_resolve'),
+  sortOrder: z.number().int().min(0).default(0),
+};
+
+export const createTemplateItemSchema = z.object(templateItemFields);
+export const updateTemplateItemSchema = z.object(templateItemFields).partial().strict();
+
+export const createTemplateSetSchema = z.object({
+  // Create-only. The server derives the partner from the caller's own token and
+  // gates partner-wide creation on canManagePartnerWidePolicies.
+  ownerScope: templateOwnerScopeSchema.default('organization'),
+  orgId: z.string().guid().optional(),
+  name: z.string().min(1).max(200),
+  description: z.string().max(2000).nullable().optional(),
+  items: z.array(createTemplateItemSchema).max(50).default([]),
+});
+
+// CLAUDE.md "Partner-Wide First" step 2: an update schema derived via .partial()
+// MUST omit ownerScope, or a PATCH could re-home a set onto the other axis.
+// orgId and items are omitted for the same reason — items are managed through
+// the item routes so ownership stays derivable from the parent.
+export const updateTemplateSetSchema = createTemplateSetSchema
+  .omit({ ownerScope: true, orgId: true, items: true })
+  .partial()
+  .strict();
+
+export const listTemplateSetsQuerySchema = z.object({
+  orgId: z.string().guid().optional(),
+});
+
+export const applyTemplateSetSchema = z.object({
+  setId: z.string().guid(),
+  contractId: z.string().guid().optional(),
+  effectiveFrom: isoDate.optional(),
+  ownerUserId: z.string().guid().optional(),
+});
+
+export type CreateTemplateItemInput = z.infer<typeof createTemplateItemSchema>;
+export type UpdateTemplateItemInput = z.infer<typeof updateTemplateItemSchema>;
+export type CreateTemplateSetInput = z.infer<typeof createTemplateSetSchema>;
+export type UpdateTemplateSetInput = z.infer<typeof updateTemplateSetSchema>;
+export type ApplyTemplateSetInput = z.infer<typeof applyTemplateSetSchema>;
+```
+
+Add `export * from './deliverableTemplates';` to `packages/shared/src/validators/index.ts` next to the `serviceDeliverables` export W01 added.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd packages/shared && npx vitest run src/validators/deliverableTemplates.test.ts && npx tsc --noEmit`
+Expected: PASS (5 tests); no type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/shared/src/validators
+git commit -m "feat(shared): deliverable template validators (W05)"
+```
+
+---
+
+### Task 5: `firstAnchorAfter` and the transaction-capable `createDeliverable`
+
+**Files:**
+- Modify: `apps/api/src/services/recurrence.ts` (append one exported function)
+- Modify: `apps/api/src/services/recurrence.test.ts` (append one describe block)
+- Modify: `apps/api/src/services/serviceDeliverableService.ts` (`createDeliverable` signature)
+
+**Interfaces:**
+- Consumes: `cadenceMonths`, `coveredPeriod`, `addMonthsClamped`, `addDaysISO` (W01 Task 5; `contractMath.ts:21,62`).
+- Produces:
+
+```ts
+export function firstAnchorAfter(effectiveFrom: string, cadence: Cadence): string;
+// serviceDeliverableService.ts
+export type DbExecutor = typeof db | Parameters<Parameters<typeof db.transaction>[0]>[0];
+export function createDeliverable(orgId: string, input: CreateDeliverableInput, actor: DeliverableActor, tx?: DbExecutor): Promise<ServiceDeliverableRow>;
+```
+
+**Anchor rule (spec §4.6 says only "end of the first full period after `effective_from`" — this pins it).** `anchor = effective_from + <cadence months> − 1 day`, so the covered period `(anchor − m months, anchor]` begins on `effective_from`. `one_time` has no period, so its anchor is `effective_from` itself. Worked: monthly from `2026-10-01` → `2026-10-31`; quarterly → `2026-12-31`; semiannual → `2027-03-31`; annual → `2027-09-30`; monthly from `2026-10-15` → `2026-11-14`. **Month-end caveat, deliberate:** `addMonthsClamped` is not invertible around short months, so for `effective_from = 2026-02-01` the anchor is `2026-02-28` and `coveredPeriod` reports a period start of `2026-01-29` — three days before `effective_from`. The rejected alternative was to advance a whole cadence step whenever the period start lands early, which for that same input skips February entirely and delays the customer's first deliverable by a month. The anchor names the period *end*, which is what the customer and the sweep key on, so a few days of nominal overlap is the cheaper error.
+
+- [ ] **Step 1: Write the failing test (append to `recurrence.test.ts`)**
+
+```ts
+import { firstAnchorAfter } from './recurrence';
+
+describe('firstAnchorAfter (template apply, spec §4.6)', () => {
+  const cases: Array<[string, Parameters<typeof firstAnchorAfter>[1], string]> = [
+    ['2026-10-01', 'monthly', '2026-10-31'],
+    ['2026-10-01', 'quarterly', '2026-12-31'],
+    ['2026-10-01', 'semiannual', '2027-03-31'],
+    ['2026-10-01', 'annual', '2027-09-30'],
+    ['2026-10-01', 'one_time', '2026-10-01'],
+    ['2026-10-15', 'monthly', '2026-11-14'],
+    ['2026-01-31', 'monthly', '2026-02-27'],
+    ['2026-02-01', 'monthly', '2026-02-28'],
+  ];
+  it.each(cases)('%s / %s -> %s', (from, cadence, expected) => {
+    expect(firstAnchorAfter(from, cadence)).toBe(expected);
+  });
+
+  it('the anchor covers a period that ends on the anchor itself', () => {
+    const anchor = firstAnchorAfter('2026-10-01', 'quarterly');
+    expect(coveredPeriod(anchor, 'quarterly')).toEqual({ periodStart: '2026-10-01', periodEnd: '2026-12-31' });
+  });
+
+  it('the first planned occurrence is the anchor, not a date before effective_from', () => {
+    const anchor = firstAnchorAfter('2026-10-01', 'monthly');
+    const plan = planOccurrences({
+      anchorDueDate: anchor, cadence: 'monthly', effectiveFrom: '2026-10-01', effectiveUntil: null,
+      leadDays: 7, graceDays: 14, today: '2026-10-25', existingDueDates: [],
+    });
+    expect(plan.map((p) => p.dueAt)).toEqual(['2026-10-31']);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/api && npx vitest run src/services/recurrence.test.ts`
+Expected: FAIL — `firstAnchorAfter` is not exported.
+
+- [ ] **Step 3: Implement**
+
+Append to `apps/api/src/services/recurrence.ts`:
+
+```ts
+/**
+ * The `anchor_due_date` a deliverable gets when a template item is applied from
+ * `effectiveFrom` (spec §4.6: "end of the first full period after
+ * effective_from").
+ *
+ * anchor = effectiveFrom + cadence months − 1 day, so coveredPeriod(anchor)
+ * begins exactly on effectiveFrom. `one_time` has no period, so its single
+ * obligation is due on the day the schedule starts.
+ *
+ * Month-end caveat (deliberate): addMonthsClamped is not invertible around
+ * short months, so an effectiveFrom of 2026-02-01 yields 2026-02-28 whose
+ * coveredPeriod starts 2026-01-29 — three days early. Advancing a whole cadence
+ * step to avoid that would skip February and delay the first deliverable by a
+ * month, which is the worse error. The anchor names the period END, which is
+ * what the sweep and the customer key on.
+ */
+export function firstAnchorAfter(effectiveFrom: string, cadence: Cadence): string {
+  const months = cadenceMonths(cadence);
+  if (months === null) return effectiveFrom;
+  return addDaysISO(addMonthsClamped(effectiveFrom, months), -1);
+}
+```
+
+- [ ] **Step 4: Make `createDeliverable` transaction-capable**
+
+In `apps/api/src/services/serviceDeliverableService.ts`, add near the imports:
+
+```ts
+// A live db handle or an open transaction handle. Same shape catalogService.ts:73
+// uses. applyTemplateSet (W05) needs every createDeliverable in ONE transaction:
+// calling the module-level `db` from inside db.transaction() would acquire a
+// SECOND pooled connection and silently run outside the transaction.
+export type DbExecutor = typeof db | Parameters<Parameters<typeof db.transaction>[0]>[0];
+```
+
+Change the signature to `export async function createDeliverable(orgId: string, input: CreateDeliverableInput, actor: DeliverableActor, tx: DbExecutor = db): Promise<ServiceDeliverableRow>` and replace every `db.` inside that function body (validation selects and the insert) with `tx.`. Leave every other exported function untouched — no other W05 path needs it.
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `cd apps/api && npx vitest run src/services/recurrence.test.ts src/services/serviceDeliverableService.test.ts && npx tsc --noEmit`
+Expected: PASS. W01's `createDeliverable` tests must still pass unchanged — the new parameter is optional and defaults to `db`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/services/recurrence.ts apps/api/src/services/recurrence.test.ts apps/api/src/services/serviceDeliverableService.ts
+git commit -m "feat(deliverables): firstAnchorAfter and transaction-capable createDeliverable (W05)"
+```
+
+---
+
+### Task 6: `deliverableTemplateService.ts` — set and item CRUD
+
+**Files:**
+- Create: `apps/api/src/services/deliverableTemplateService.ts`
+- Test: `apps/api/src/services/deliverableTemplateService.test.ts`
+
+**Interfaces:**
+- Consumes: schema from Task 2, validators from Task 4, `canManagePartnerWidePolicies` / `PartnerWideWriteDeniedError` / `PARTNER_WIDE_WRITE_DENIED_MESSAGE` (`services/partnerWideAccess.ts:25,31,35`).
+- Produces (Task 7 adds `applyTemplateSet` to the same module):
+
+```ts
+import type { AuthContext } from '../middleware/auth';
+
+export interface TemplateActor {
+  userId: string | null;
+  scope: AuthContext['scope'];                       // 'system' | 'partner' | 'organization'
+  partnerId: string | null;
+  partnerOrgAccess: AuthContext['partnerOrgAccess']; // 'all' | 'selected' | 'none' | null | undefined
+  accessibleOrgIds: string[] | null;                 // null = system, unrestricted
+}
+export class TemplateServiceError extends Error {
+  constructor(message: string, readonly status: number, readonly code: string, readonly details?: unknown);
+}
+export interface TemplateItemView extends DeliverableTemplateItemRow {}
+export interface TemplateSetView extends DeliverableTemplateSetRow { items: TemplateItemView[]; ownerScope: 'organization' | 'partner' }
+
+export function listTemplateSets(actor: TemplateActor, q: { orgId?: string }): Promise<TemplateSetView[]>;
+export function getTemplateSet(setId: string, actor: TemplateActor): Promise<TemplateSetView>;
+export function createTemplateSet(input: CreateTemplateSetInput, actor: TemplateActor): Promise<TemplateSetView>;
+export function updateTemplateSet(setId: string, patch: UpdateTemplateSetInput, actor: TemplateActor): Promise<TemplateSetView>;
+export function deleteTemplateSet(setId: string, actor: TemplateActor): Promise<void>;
+export function addTemplateItem(setId: string, input: CreateTemplateItemInput, actor: TemplateActor): Promise<TemplateItemView>;
+export function updateTemplateItem(setId: string, itemId: string, patch: UpdateTemplateItemInput, actor: TemplateActor): Promise<TemplateItemView>;
+export function removeTemplateItem(setId: string, itemId: string, actor: TemplateActor): Promise<void>;
+```
+
+Rules the service enforces (each has a test):
+
+- **Read visibility** (`visibilityCondition`): system (`accessibleOrgIds === null`) sees everything. Otherwise the org arm is `inArray(sets.orgId, actor.accessibleOrgIds)`; the partner-wide arm `and(isNull(sets.orgId), eq(sets.partnerId, actor.partnerId))` is added **only when `actor.scope === 'partner' && actor.partnerId`**. With neither arm, return `[]` — never an unfiltered query. An org token therefore sees only org-owned sets even though the RLS SELECT branch would let it read partner-wide rows; that branch is for the agent/worker path, and this gate is the authorization control (`partnerWideAccess.ts:52-84`).
+- **Create with `ownerScope: 'partner'`**: `canManagePartnerWidePolicies(actor)` must be true, else throw `PartnerWideWriteDeniedError` (routes map to 403). `partnerId = actor.partnerId` (400 `PARTNER_CONTEXT_REQUIRED` when null); `orgId = null`.
+- **Create with `ownerScope: 'organization'`**: `orgId = input.orgId ?? actor's single accessible org`; 400 `ORG_REQUIRED` when unresolvable; 404 `NOT_FOUND` when the actor cannot access it. `partnerId = null`.
+- **Mutating a partner-wide set or any of its items** re-checks `canManagePartnerWidePolicies(actor)` on the loaded row — visibility is not permission.
+- **Name collisions**: `23505` on `deliverable_template_sets_{partner,org}_name_uq` → 409 `DUPLICATE_TEMPLATE_SET_NAME`; on `deliverable_template_items_set_name_uq` → 409 `DUPLICATE_TEMPLATE_ITEM_NAME`. Use `isPgUniqueViolation` / `pgErrorConstraint` (`apps/api/src/utils/pgErrors.ts:3`).
+- **Items inherit the set's owner columns**, always copied from the loaded set row and never from input — that is what keeps the branch FKs satisfiable.
+- A set or item id the actor cannot see → 404 `NOT_FOUND`, never 403.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const dbMocks = vi.hoisted(() => ({ rows: [] as unknown[] }));
+vi.mock('../db', () => {
+  const chain = () => {
+    const c: any = {};
+    for (const m of ['select', 'from', 'where', 'limit', 'orderBy', 'innerJoin', 'leftJoin', 'insert', 'values', 'update', 'set', 'delete', 'returning']) {
+      c[m] = vi.fn(() => c);
+    }
+    c.then = (res: (v: unknown) => void) => res(dbMocks.rows.shift() ?? []);
+    c.transaction = async (fn: (tx: unknown) => unknown) => fn(c);
+    return c;
+  };
+  return { db: chain() };
+});
+
+import {
+  createTemplateSet,
+  listTemplateSets,
+  addTemplateItem,
+  TemplateServiceError,
+} from './deliverableTemplateService';
+import { PartnerWideWriteDeniedError } from './partnerWideAccess';
+
+const partnerAdmin = { userId: 'u1', scope: 'partner' as const, partnerId: 'p1', partnerOrgAccess: 'all' as const, accessibleOrgIds: ['org1'] };
+const partnerTech = { ...partnerAdmin, partnerOrgAccess: 'selected' as const };
+const orgUser = { userId: 'u2', scope: 'organization' as const, partnerId: 'p1', partnerOrgAccess: null, accessibleOrgIds: ['org1'] };
+
+describe('deliverableTemplateService', () => {
+  beforeEach(() => { dbMocks.rows.length = 0; });
+
+  it('a partner tech without full org access cannot create a partner-wide set', async () => {
+    await expect(createTemplateSet({ name: 'Best plan', ownerScope: 'partner', items: [] }, partnerTech))
+      .rejects.toBeInstanceOf(PartnerWideWriteDeniedError);
+  });
+
+  it('an org-scope user cannot create a partner-wide set either', async () => {
+    await expect(createTemplateSet({ name: 'Best plan', ownerScope: 'partner', items: [] }, orgUser))
+      .rejects.toBeInstanceOf(PartnerWideWriteDeniedError);
+  });
+
+  it('404s an org the actor cannot access, without touching the db', async () => {
+    await expect(createTemplateSet({ name: 'Best plan', ownerScope: 'organization', orgId: 'org2', items: [] }, partnerAdmin))
+      .rejects.toMatchObject({ status: 404, code: 'NOT_FOUND' });
+  });
+
+  it('maps a set name unique violation to 409 DUPLICATE_TEMPLATE_SET_NAME', async () => {
+    const { db } = await import('../db');
+    (db as any).returning = vi.fn(() => { throw Object.assign(new Error('dup'), { code: '23505', constraint_name: 'deliverable_template_sets_partner_name_uq' }); });
+    await expect(createTemplateSet({ name: 'Best plan', ownerScope: 'partner', items: [] }, partnerAdmin))
+      .rejects.toMatchObject({ status: 409, code: 'DUPLICATE_TEMPLATE_SET_NAME' });
+  });
+
+  it('an org-scope reader never gets the partner-wide arm in its query', async () => {
+    dbMocks.rows.push([]);
+    await listTemplateSets(orgUser, {});
+    const { db } = await import('../db');
+    const whereArg = (db as any).where.mock.calls.at(-1)?.[0];
+    expect(JSON.stringify(whereArg ?? {})).not.toContain('p1');
+  });
+
+  it('an item copies the set owner columns and never trusts input', async () => {
+    dbMocks.rows.push([{ id: 's1', orgId: null, partnerId: 'p1', name: 'Best plan' }]); // loaded set
+    dbMocks.rows.push([{ id: 'i1', setId: 's1', orgId: null, partnerId: 'p1', name: 'Sign-in log review' }]);
+    await addTemplateItem('s1', { name: 'Sign-in log review', cadence: 'monthly', leadDays: 7, graceDays: 14, artifactRequired: true, completionMode: 'on_ticket_resolve', sortOrder: 0 }, partnerAdmin);
+    const { db } = await import('../db');
+    const values = (db as any).values.mock.calls.at(-1)?.[0];
+    expect(values).toMatchObject({ setId: 's1', orgId: null, partnerId: 'p1' });
+  });
+
+  it('a partner tech cannot add an item to a partner-wide set', async () => {
+    dbMocks.rows.push([{ id: 's1', orgId: null, partnerId: 'p1', name: 'Best plan' }]);
+    await expect(addTemplateItem('s1', { name: 'x', cadence: 'monthly', leadDays: 7, graceDays: 14, artifactRequired: true, completionMode: 'on_ticket_resolve', sortOrder: 0 }, partnerTech))
+      .rejects.toBeInstanceOf(PartnerWideWriteDeniedError);
+  });
+
+  it('a set the actor cannot see is 404, not 403', async () => {
+    dbMocks.rows.push([]);
+    await expect(addTemplateItem('s9', { name: 'x', cadence: 'monthly', leadDays: 7, graceDays: 14, artifactRequired: true, completionMode: 'on_ticket_resolve', sortOrder: 0 }, partnerAdmin))
+      .rejects.toMatchObject({ status: 404, code: 'NOT_FOUND' });
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/api && npx vitest run src/services/deliverableTemplateService.test.ts`
+Expected: FAIL, module not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+import { and, asc, eq, inArray, isNull, or, sql, type SQL } from 'drizzle-orm';
+import { db } from '../db';
+import {
+  deliverableTemplateSets,
+  deliverableTemplateItems,
+  type DeliverableTemplateSetRow,
+  type DeliverableTemplateItemRow,
+} from '../db/schema/deliverableTemplates';
+import type { AuthContext } from '../middleware/auth';
+import type {
+  CreateTemplateSetInput, UpdateTemplateSetInput, CreateTemplateItemInput, UpdateTemplateItemInput,
+} from '@breeze/shared';
+import { canManagePartnerWidePolicies, PartnerWideWriteDeniedError } from './partnerWideAccess';
+import { isPgUniqueViolation, pgErrorConstraint } from '../utils/pgErrors';
+
+export interface TemplateActor {
+  userId: string | null;
+  scope: AuthContext['scope'];
+  partnerId: string | null;
+  partnerOrgAccess: AuthContext['partnerOrgAccess'];
+  accessibleOrgIds: string[] | null;
+}
+
+export class TemplateServiceError extends Error {
+  constructor(message: string, readonly status: number, readonly code: string, readonly details?: unknown) {
+    super(message);
+    this.name = 'TemplateServiceError';
+  }
+}
+
+const notFound = () => new TemplateServiceError('Not found', 404, 'NOT_FOUND');
+
+function requireOrgAccess(actor: TemplateActor, orgId: string): void {
+  if (actor.accessibleOrgIds !== null && !actor.accessibleOrgIds.includes(orgId)) throw notFound();
+}
+
+/**
+ * Rows this actor may READ. The partner-wide arm is gated on partner scope
+ * (CLAUDE.md "Partner-Wide First" step 3): the table's partner-wide SELECT
+ * policy deliberately makes those rows readable from an org context, so this
+ * gate is the ONLY authorization control on that axis, not a redundant second
+ * one (partnerWideAccess.ts canReadPartnerWideRows).
+ */
+function visibilityCondition(actor: TemplateActor): SQL | undefined {
+  if (actor.accessibleOrgIds === null) return undefined; // system
+  const arms: SQL[] = [];
+  if (actor.accessibleOrgIds.length > 0) arms.push(inArray(deliverableTemplateSets.orgId, actor.accessibleOrgIds));
+  if (actor.scope === 'partner' && actor.partnerId) {
+    arms.push(and(isNull(deliverableTemplateSets.orgId), eq(deliverableTemplateSets.partnerId, actor.partnerId))!);
+  }
+  if (arms.length === 0) return sql`false`;
+  return arms.length === 1 ? arms[0]! : or(...arms)!;
+}
+
+const ownerScopeOf = (row: Pick<DeliverableTemplateSetRow, 'orgId'>) => (row.orgId === null ? 'partner' as const : 'organization' as const);
+
+/** Visibility is not permission: a partner-wide row is administrable only by a full-partner admin. */
+function requireWritable(row: Pick<DeliverableTemplateSetRow, 'orgId'>, actor: TemplateActor): void {
+  if (row.orgId === null && !canManagePartnerWidePolicies(actor)) throw new PartnerWideWriteDeniedError();
+}
+
+function mapUniqueViolation(err: unknown): never {
+  if (isPgUniqueViolation(err)) {
+    const constraint = pgErrorConstraint(err) ?? '';
+    if (constraint.startsWith('deliverable_template_items_set_name')) {
+      throw new TemplateServiceError('An item with this name already exists in the set', 409, 'DUPLICATE_TEMPLATE_ITEM_NAME');
+    }
+    throw new TemplateServiceError('A template set with this name already exists', 409, 'DUPLICATE_TEMPLATE_SET_NAME');
+  }
+  throw err;
+}
+```
+
+Then write, with no TODOs:
+
+- `loadSetOr404(setId, actor)` — one select with `and(eq(sets.id, setId), visibilityCondition(actor))`, throwing `notFound()` on empty.
+- `hydrate(setRow)` — selects its items ordered by `asc(items.sortOrder), asc(items.name)` and returns `{ ...setRow, items, ownerScope: ownerScopeOf(setRow) }`.
+- `listTemplateSets` — `visibilityCondition` plus an optional `eq(sets.orgId, q.orgId)` after `requireOrgAccess`; one follow-up `inArray(items.setId, ids)` select, grouped in memory (no N+1).
+- `getTemplateSet` — `hydrate(await loadSetOr404(...))`.
+- `createTemplateSet` — resolves `{ orgId, partnerId }` per the rules above, then one `db.transaction` inserting the set and any `input.items` (owner columns copied from the resolved pair), wrapped in `try/catch` → `mapUniqueViolation`.
+- `updateTemplateSet` / `deleteTemplateSet` — `loadSetOr404` then `requireWritable`, then update (`updatedAt: new Date()`) or delete (items cascade).
+- `addTemplateItem` / `updateTemplateItem` / `removeTemplateItem` — `loadSetOr404` + `requireWritable`, then write with `orgId`/`partnerId` copied from the loaded set and `setId` from the path, never from input. `updateTemplateItem` and `removeTemplateItem` scope on `and(eq(items.id, itemId), eq(items.setId, setId))` and 404 on zero rows.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd apps/api && npx vitest run src/services/deliverableTemplateService.test.ts && npx tsc --noEmit`
+Expected: PASS (8 tests); no type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/deliverableTemplateService.ts apps/api/src/services/deliverableTemplateService.test.ts
+git commit -m "feat(deliverables): deliverable template set and item service (W05)"
+```
+
+---
+
+### Task 7: `applyTemplateSet`
+
+**Files:**
+- Modify: `apps/api/src/services/deliverableTemplateService.ts`
+- Modify: `apps/api/src/services/deliverableTemplateService.test.ts`
+
+**Interfaces:**
+- Consumes: `createDeliverable(orgId, input, actor, tx)` and `DbExecutor` (Task 5), `firstAnchorAfter` (Task 5), `contracts` schema.
+- Produces:
+
+```ts
+export interface AppliedTemplateResult {
+  setId: string; setName: string; orgId: string; contractId: string | null; effectiveFrom: string;
+  created: Array<{ id: string; name: string; cadence: Cadence; anchorDueDate: string }>;
+  skipped: string[];
+}
+export function applyTemplateSet(
+  orgId: string,
+  setId: string,
+  opts: { contractId?: string; effectiveFrom?: string; ownerUserId?: string; onCollision?: 'reject' | 'skip' },
+  actor: TemplateActor,
+): Promise<AppliedTemplateResult>;
+```
+
+Rules:
+
+- `requireOrgAccess(actor, orgId)` first; `loadSetOr404(setId, actor)` second (an unreadable set is 404, not 403). Applying does **not** require `canManagePartnerWidePolicies` — reading a partner-wide set and copying it into your own org is a read of the template and a write to the org, not an edit of partner-wide state.
+- `effectiveFrom` = `opts.effectiveFrom` ?? the contract's `start_date` when `contractId` is given ?? today (spec D1 default). Today is `new Date().toISOString().slice(0, 10)`.
+- `contractId`, when given, must belong to `orgId` → else 400 `CONTRACT_NOT_IN_ORG` (same code W01's `createDeliverable` uses).
+- `anchorDueDate = firstAnchorAfter(effectiveFrom, item.cadence)` per item.
+- **Collision check before any write**: select `service_deliverables.name` where `orgId` matches, the contract matches (`eq` when given, `isNull` otherwise — mirroring the `COALESCE(contract_id, nil)` unique index), and `inArray(name, itemNames)`. With `onCollision: 'reject'` (the default, used by REST and MCP) throw 409 `TEMPLATE_NAME_COLLISION` with `details: { collisions: string[] }` and write nothing. With `onCollision: 'skip'` (used by the backfill script) drop those items and record them in `result.skipped`.
+- All remaining items are created in **one** `db.transaction`, each through `createDeliverable(orgId, {...}, actor, tx)`. A 23505 raised inside the transaction (a concurrent apply) is re-mapped to the same 409 so the caller sees one error shape.
+- The set may be applied to an org under a **different** partner than a partner-wide set's owner only if the actor can see both — `visibilityCondition` already guarantees that.
+
+- [ ] **Step 1: Write the failing tests (append)**
+
+```ts
+import { applyTemplateSet } from './deliverableTemplateService';
+import { firstAnchorAfter } from './recurrence';
+
+describe('applyTemplateSet', () => {
+  const set = { id: 's1', orgId: null, partnerId: 'p1', name: 'Best plan' };
+  const items = [
+    { id: 'i1', setId: 's1', name: 'Sign-in log review', cadence: 'monthly', leadDays: 7, graceDays: 14, artifactRequired: true, completionMode: 'on_ticket_resolve', sortOrder: 0, description: null },
+    { id: 'i2', setId: 's1', name: 'Firewall rule review', cadence: 'quarterly', leadDays: 14, graceDays: 21, artifactRequired: true, completionMode: 'on_ticket_resolve', sortOrder: 1, description: null },
+  ];
+
+  it('409s with every colliding name and writes nothing', async () => {
+    dbMocks.rows.push([set]);                                   // loadSetOr404
+    dbMocks.rows.push(items);                                   // items
+    dbMocks.rows.push([{ name: 'Sign-in log review' }]);        // existing deliverables
+    await expect(applyTemplateSet('org1', 's1', { effectiveFrom: '2026-10-01' }, partnerAdmin))
+      .rejects.toMatchObject({ status: 409, code: 'TEMPLATE_NAME_COLLISION', details: { collisions: ['Sign-in log review'] } });
+    const { db } = await import('../db');
+    expect((db as any).insert).not.toHaveBeenCalled();
+  });
+
+  it('onCollision skip reports the skipped names and still creates the rest', async () => {
+    dbMocks.rows.push([set], items, [{ name: 'Sign-in log review' }]);
+    const result = await applyTemplateSet('org1', 's1', { effectiveFrom: '2026-10-01', onCollision: 'skip' }, partnerAdmin);
+    expect(result.skipped).toEqual(['Sign-in log review']);
+    expect(result.created.map((c) => c.name)).toEqual(['Firewall rule review']);
+  });
+
+  it('computes each anchor from the item cadence (spec §4.6)', async () => {
+    dbMocks.rows.push([set], items, []);
+    const result = await applyTemplateSet('org1', 's1', { effectiveFrom: '2026-10-01' }, partnerAdmin);
+    expect(result.created.map((c) => c.anchorDueDate)).toEqual(['2026-10-31', '2026-12-31']);
+    expect(result.created[0]!.anchorDueDate).toBe(firstAnchorAfter('2026-10-01', 'monthly'));
+  });
+
+  it('404s an org the actor cannot access before reading the set', async () => {
+    await expect(applyTemplateSet('org2', 's1', {}, partnerAdmin)).rejects.toMatchObject({ status: 404, code: 'NOT_FOUND' });
+    const { db } = await import('../db');
+    expect((db as any).select).not.toHaveBeenCalled();
+  });
+
+  it('rejects a contract belonging to another org', async () => {
+    dbMocks.rows.push([set], items, []);                        // set, items, contract lookup empty
+    await expect(applyTemplateSet('org1', 's1', { contractId: '11111111-1111-4111-8111-111111111111' }, partnerAdmin))
+      .rejects.toMatchObject({ status: 400, code: 'CONTRACT_NOT_IN_ORG' });
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/api && npx vitest run src/services/deliverableTemplateService.test.ts -t applyTemplateSet`
+Expected: FAIL — `applyTemplateSet` is not exported.
+
+- [ ] **Step 3: Implement**
+
+```ts
+import { createDeliverable } from './serviceDeliverableService';
+import { firstAnchorAfter, type Cadence } from './recurrence';
+import { contracts } from '../db/schema/contracts';
+import { serviceDeliverables } from '../db/schema/serviceDeliverables';
+
+export interface AppliedTemplateResult {
+  setId: string; setName: string; orgId: string; contractId: string | null; effectiveFrom: string;
+  created: Array<{ id: string; name: string; cadence: Cadence; anchorDueDate: string }>;
+  skipped: string[];
+}
+
+export async function applyTemplateSet(
+  orgId: string,
+  setId: string,
+  opts: { contractId?: string; effectiveFrom?: string; ownerUserId?: string; onCollision?: 'reject' | 'skip' },
+  actor: TemplateActor,
+): Promise<AppliedTemplateResult> {
+  requireOrgAccess(actor, orgId);
+  const set = await loadSetOr404(setId, actor);
+  const items = await db.select().from(deliverableTemplateItems)
+    .where(eq(deliverableTemplateItems.setId, set.id))
+    .orderBy(asc(deliverableTemplateItems.sortOrder), asc(deliverableTemplateItems.name));
+
+  const contractId = opts.contractId ?? null;
+  let contractStart: string | null = null;
+  if (contractId) {
+    const [row] = await db.select({ startDate: contracts.startDate }).from(contracts)
+      .where(and(eq(contracts.id, contractId), eq(contracts.orgId, orgId))).limit(1);
+    if (!row) throw new TemplateServiceError('Contract does not belong to this organization', 400, 'CONTRACT_NOT_IN_ORG');
+    contractStart = row.startDate;
+  }
+  // Spec D1: effective_from defaults to the contract start when attached, else today.
+  const effectiveFrom = opts.effectiveFrom ?? contractStart ?? new Date().toISOString().slice(0, 10);
+
+  const names = items.map((i) => i.name);
+  const collisions = names.length === 0 ? [] : (await db
+    .select({ name: serviceDeliverables.name }).from(serviceDeliverables)
+    .where(and(
+      eq(serviceDeliverables.orgId, orgId),
+      contractId ? eq(serviceDeliverables.contractId, contractId) : isNull(serviceDeliverables.contractId),
+      inArray(serviceDeliverables.name, names),
+    ))).map((r) => r.name);
+
+  if (collisions.length > 0 && (opts.onCollision ?? 'reject') === 'reject') {
+    throw new TemplateServiceError(
+      `These deliverables already exist on the target: ${collisions.join(', ')}`,
+      409, 'TEMPLATE_NAME_COLLISION', { collisions },
+    );
+  }
+  const skipped = new Set(collisions);
+  const toCreate = items.filter((i) => !skipped.has(i.name));
+
+  // All-or-nothing: every createDeliverable runs on the SAME tx handle, so a
+  // failure on item 7 of 8 leaves no partial schedule behind.
+  const created = await db.transaction(async (tx) => {
+    const out: AppliedTemplateResult['created'] = [];
+    for (const item of toCreate) {
+      const anchorDueDate = firstAnchorAfter(effectiveFrom, item.cadence as Cadence);
+      const row = await createDeliverable(orgId, {
+        contractId: contractId ?? undefined,
+        name: item.name,
+        description: item.description ?? undefined,
+        cadence: item.cadence as Cadence,
+        anchorDueDate,
+        effectiveFrom,
+        leadDays: item.leadDays,
+        graceDays: item.graceDays,
+        artifactRequired: item.artifactRequired,
+        completionMode: item.completionMode,
+        ownerUserId: opts.ownerUserId ?? undefined,
+        portalVisible: true,
+        sortOrder: item.sortOrder,
+      }, actor as never, tx);
+      out.push({ id: row.id, name: row.name, cadence: row.cadence as Cadence, anchorDueDate });
+    }
+    return out;
+  }).catch(mapApplyError);
+
+  return { setId: set.id, setName: set.name, orgId, contractId, effectiveFrom, created, skipped: [...skipped] };
+}
+
+/** A concurrent apply races past the pre-check and hits the unique index; give the caller one error shape. */
+function mapApplyError(err: unknown): never {
+  if (isPgUniqueViolation(err)) {
+    throw new TemplateServiceError('A deliverable with one of these names already exists on the target', 409, 'TEMPLATE_NAME_COLLISION', { collisions: [] });
+  }
+  throw err;
+}
+```
+
+`createDeliverable` takes a `DeliverableActor` (`{ userId, partnerId, accessibleOrgIds }`), which `TemplateActor` structurally satisfies; replace the `as never` with a small explicit adapter `{ userId: actor.userId, partnerId: actor.partnerId, accessibleOrgIds: actor.accessibleOrgIds }` once you have the real type in front of you.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd apps/api && npx vitest run src/services/deliverableTemplateService.test.ts && npx tsc --noEmit`
+Expected: PASS (13 tests total); no type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/deliverableTemplateService.ts apps/api/src/services/deliverableTemplateService.test.ts
+git commit -m "feat(deliverables): applyTemplateSet with 409 collision contract and one transaction (W05)"
+```
+
+---
+
+### Task 8: REST routes
+
+**Files:**
+- Create: `apps/api/src/routes/deliverableTemplates.ts`, `apps/api/src/routes/deliverableTemplates.test.ts`
+- Modify: `apps/api/src/routes/serviceDeliverables.ts` (+ its `.test.ts`) — add `POST /orgs/:orgId/deliverables/apply-template`
+- Modify: `apps/api/src/index.ts` (near line 834, beside the other `api.route(...)` calls)
+
+**Interfaces:**
+- Produces (all `requireScope('partner','system')`, permission `contracts:read` on GET and `contracts:write` on mutations, every response `{ data }`):
+
+```
+GET    /deliverable-templates?orgId
+POST   /deliverable-templates
+GET    /deliverable-templates/:setId
+PATCH  /deliverable-templates/:setId
+DELETE /deliverable-templates/:setId                       200 { data: { ok: true } }
+POST   /deliverable-templates/:setId/items
+PATCH  /deliverable-templates/:setId/items/:itemId
+DELETE /deliverable-templates/:setId/items/:itemId         200 { data: { ok: true } }
+POST   /orgs/:orgId/deliverables/apply-template            { setId, contractId?, effectiveFrom?, ownerUserId? }
+```
+
+- [ ] **Step 1: Write the failing route tests**
+
+Follow `apps/api/src/routes/contracts/periods.test.ts` for the harness (mock `../middleware/auth`, hoist service mocks, build the Hono app). Cover, at minimum:
+
+```ts
+it('401 without auth', …);
+it('403 when the role lacks contracts:write on POST /deliverable-templates', …);
+it('400 when the body fails createTemplateSetSchema (unknown cadence)', …);
+it('403 with PARTNER_WIDE_WRITE_DENIED_MESSAGE when the service throws PartnerWideWriteDeniedError', …);
+it('409 DUPLICATE_TEMPLATE_SET_NAME passes the service code through', …);
+it('200 { data } listing sets for the caller', …);
+it('404 (not 403) for a set id the service cannot see', …);
+it('POST /orgs/:orgId/deliverables/apply-template returns { data } with created and skipped', …);
+it('POST apply-template surfaces 409 TEMPLATE_NAME_COLLISION with details.collisions', …);
+it('POST apply-template 400s a non-ISO effectiveFrom before reaching the service', …);
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/api && npx vitest run src/routes/deliverableTemplates.test.ts src/routes/serviceDeliverables.test.ts`
+Expected: FAIL — `routes/deliverableTemplates.ts` does not exist.
+
+- [ ] **Step 3: Implement**
+
+Build `deliverableTemplateRoutes` as a `new Hono<{ Variables: { auth: AuthContext } }>()` with `authMiddleware`, `requireScope('partner','system')` and `requirePermission('contracts', 'read'|'write')` per route — copy the exact middleware names and order from `apps/api/src/routes/contracts/contracts.ts`. Every handler is:
+
+```ts
+try {
+  return c.json({ data: await svc(...) });
+} catch (err) {
+  return handleTemplateError(c, err);
+}
+```
+
+with
+
+```ts
+function templateActorFrom(c: Context): TemplateActor {
+  const auth = c.get('auth');
+  return {
+    userId: auth.user?.id ?? null,
+    scope: auth.scope,
+    partnerId: auth.partnerId ?? null,
+    partnerOrgAccess: auth.partnerOrgAccess ?? null,
+    accessibleOrgIds: auth.accessibleOrgIds,
+  };
+}
+
+function handleTemplateError(c: Context, err: unknown) {
+  if (err instanceof PartnerWideWriteDeniedError) return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE, code: 'PARTNER_WIDE_WRITE_DENIED' }, 403);
+  if (err instanceof TemplateServiceError) {
+    return c.json({ error: err.message, code: err.code, ...(err.details ? { details: err.details } : {}) }, err.status as ContentfulStatusCode);
+  }
+  throw err;
+}
+```
+
+Add to `routes/serviceDeliverables.ts` (reusing its existing `deliverableActorFrom` for the org check and this file's `templateActorFrom` shape for the service call):
+
+```ts
+deliverableRoutes.post('/:orgId/deliverables/apply-template',
+  requirePermission('contracts', 'write'),
+  zValidator('json', applyTemplateSetSchema),
+  async (c) => {
+    const { setId, contractId, effectiveFrom, ownerUserId } = c.req.valid('json');
+    try {
+      return c.json({ data: await applyTemplateSet(c.req.param('orgId'), setId, { contractId, effectiveFrom, ownerUserId }, templateActorFrom(c)) });
+    } catch (err) {
+      return handleTemplateError(c, err);
+    }
+  });
+```
+
+Register the route **before** any `/:orgId/deliverables/:id` pattern in that file so `apply-template` is not swallowed as an id. Mount the new router in `apps/api/src/index.ts` beside the other billing routers:
+
+```ts
+api.route('/deliverable-templates', deliverableTemplateRoutes);
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd apps/api && npx vitest run src/routes/deliverableTemplates.test.ts src/routes/serviceDeliverables.test.ts && npx tsc --noEmit`
+Expected: PASS; no type errors.
+
+- [ ] **Step 5: Smoke against a live API**
+
+Boot the API on the test stack and, with a partner-admin token:
+`curl -sf -H "Authorization: Bearer <token>" localhost:3001/api/v1/deliverable-templates` → `{"data":[]}`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/routes/deliverableTemplates.ts apps/api/src/routes/deliverableTemplates.test.ts apps/api/src/routes/serviceDeliverables.ts apps/api/src/routes/serviceDeliverables.test.ts apps/api/src/index.ts
+git commit -m "feat(deliverables): template REST routes and apply-template endpoint (W05)"
+```
+
+---
+
+### Task 9: MCP tools — `list_deliverable_templates` and `manage_deliverables.apply_template`
+
+**Files:**
+- Create or modify: `apps/api/src/services/aiToolsDeliverables.ts` (W02 also owns this file; if W02 landed first, extend it in place)
+- Create: `apps/api/src/services/aiToolsDeliverables.registryParity.contract.test.ts`
+- Modify: `apps/api/src/services/aiTools.ts` (import + `registerDeliverableTools(aiTools)` beside `registerContractTools(aiTools)` at line 294)
+- Modify: `apps/api/src/services/aiToolSchemas.ts` (`toolInputSchemas`)
+- Modify: `apps/api/src/services/aiGuardrails.ts` (`TIER2_READONLY_TOOLS` line 164, `TIER3_ACTIONS` line 185, `TOOL_PERMISSIONS` line 602)
+- Modify: `apps/api/src/services/aiAgentSdkTools.ts` (`TOOL_TIERS` around line 285, plus two `tool(...)` registrations)
+
+**A `manage_*` tool has FOUR registration sites** (`aiToolsContracts.registryParity.contract.test.ts:1-20`): the tool definition's action enum, `aiToolSchemas.toolInputSchemas`, the `aiAgentSdkTools.ts` `tool()` action enum, and `aiGuardrails.TOOL_PERMISSIONS`. A missing site-4 entry fails **closed** with `Unknown action "apply_template" for tool "manage_deliverables"`, which reads like a permissions bug rather than a registration bug.
+
+**Wave-order note.** W02 creates `manage_deliverables` with create/update/deactivate/deliver/waive/reopen/reschedule/link_evidence. If W05 lands first, create the tool here with `apply_template` as its only action and W02 adds the rest to all four sites; if W02 landed first, add `apply_template` to all four sites. Either way `apply_template` is approval-gated: it arms unattended ticket creation across a whole schedule.
+
+- [ ] **Step 1: Write the failing parity test**
+
+```ts
+/** Four registration sites; site 4 fails CLOSED. No vi.mock — needs the REAL registries. */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { registerDeliverableTools } from './aiToolsDeliverables';
+import { toolInputSchemas } from './aiToolSchemas';
+import { TOOL_PERMISSIONS, TIER3_ACTIONS } from './aiGuardrails';
+import type { AiTool } from './aiTools';
+
+function definitionActions(): string[] {
+  const map = new Map<string, AiTool>();
+  registerDeliverableTools(map);
+  const tool = map.get('manage_deliverables');
+  if (!tool) throw new Error('manage_deliverables is not registered');
+  const props = tool.definition.input_schema.properties as Record<string, { enum?: string[] }>;
+  if (!props.action?.enum) throw new Error('manage_deliverables definition has no action enum');
+  return props.action.enum;
+}
+
+describe('manage_deliverables registration parity', () => {
+  it('registers both deliverable-template tools', () => {
+    const map = new Map<string, AiTool>();
+    registerDeliverableTools(map);
+    expect(map.has('list_deliverable_templates')).toBe(true);
+    expect(map.has('manage_deliverables')).toBe(true);
+  });
+
+  it('every definition action is in the central Zod schema', () => {
+    const schema = toolInputSchemas.manage_deliverables as unknown as { shape: { action: { options: readonly string[] } } };
+    expect([...schema.shape.action.options].sort()).toEqual([...definitionActions()].sort());
+  });
+
+  it('every definition action has a TOOL_PERMISSIONS entry', () => {
+    const perms = TOOL_PERMISSIONS.manage_deliverables as Record<string, unknown>;
+    expect(definitionActions().filter((a) => !(a in perms))).toEqual([]);
+  });
+
+  it('apply_template is approval-gated (Tier 3)', () => {
+    expect(TIER3_ACTIONS.manage_deliverables ?? []).toContain('apply_template');
+  });
+
+  it('the SDK tool registration carries apply_template', () => {
+    const src = readFileSync(new URL('./aiAgentSdkTools.ts', import.meta.url), 'utf8');
+    const start = src.indexOf("      'manage_deliverables',");
+    expect(start, 'manage_deliverables is not registered in aiAgentSdkTools.ts').toBeGreaterThan(-1);
+    expect(src.slice(start, start + 2000)).toContain("'apply_template'");
+  });
+
+  it('list_deliverable_templates is a read tool with a schema and a permission', () => {
+    expect('list_deliverable_templates' in toolInputSchemas).toBe(true);
+    expect(TOOL_PERMISSIONS.list_deliverable_templates).toEqual({ resource: 'contracts', action: 'read' });
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/api && npx vitest run src/services/aiToolsDeliverables.registryParity.contract.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement site 1 (the tool definitions)**
+
+In `apps/api/src/services/aiToolsDeliverables.ts`, follow the `aiToolsContracts.ts` shape exactly: a `MANAGE_DELIVERABLES_REQUIRED: Record<string, readonly string[]>` presence map, an `actorFromAuth(auth): TemplateActor`, a `serviceErrorToJson(err)` that emits `{ error, code, details? }`, and `export function registerDeliverableTools(aiTools: Map<string, AiTool>): void`.
+
+```ts
+const MANAGE_DELIVERABLES_REQUIRED: Record<string, readonly string[]> = {
+  apply_template: ['orgId', 'setId'],
+};
+
+aiTools.set('list_deliverable_templates', {
+  tier: 2 as AiToolTier,
+  deviceArgs: [],
+  definition: {
+    name: 'list_deliverable_templates',
+    description:
+      'List deliverable template sets the caller can use: sets owned by an accessible organization, plus the partner-wide sets ("all organizations") when the caller holds a partner token. Each set lists its items with cadence, lead and grace days and whether an artifact is required. Read-only.',
+    input_schema: { type: 'object' as const, properties: { orgId: { type: 'string', description: 'Filter to sets owned by one organization (UUID)' } }, required: [] },
+  },
+  handler: async (input, auth) => {
+    try {
+      const sets = await listTemplateSets(actorFromAuth(auth), { orgId: input.orgId ? String(input.orgId) : undefined });
+      return JSON.stringify({ sets });
+    } catch (err) {
+      return serviceErrorToJson(err) ?? JSON.stringify({ error: 'Failed to list deliverable templates' });
+    }
+  },
+});
+
+aiTools.set('manage_deliverables', {
+  tier: 2 as AiToolTier,
+  deviceArgs: [],
+  definition: {
+    name: 'manage_deliverables',
+    description:
+      'Manage an organization\'s service deliverables. `apply_template` copies every item of a deliverable template set into the organization (optionally pinned to a contract) as scheduled deliverables; it arms unattended ticket creation for every future period and therefore requires approval. It is all-or-nothing: if any item name already exists on the target nothing is written and the colliding names are returned.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        action: { type: 'string', enum: ['apply_template'], description: 'Action to perform' },
+        orgId: { type: 'string', description: 'Target organization (UUID)' },
+        setId: { type: 'string', description: 'Deliverable template set to apply (UUID)' },
+        contractId: { type: 'string', description: 'Optional contract to attach the created deliverables to (UUID)' },
+        effectiveFrom: { type: 'string', description: 'ISO date YYYY-MM-DD; defaults to the contract start date, else today' },
+        ownerUserId: { type: 'string', description: 'Optional owner/assignee for every created deliverable (UUID)' },
+      },
+      required: ['action'],
+    },
+  },
+  handler: async (input, auth) => {
+    const action = String(input.action ?? '');
+    const missing = missingParamsJson(MANAGE_DELIVERABLES_REQUIRED[action] ?? [], input, 'manage_deliverables', action);
+    if (missing) return missing;
+    try {
+      const parsed = applyTemplateSetSchema.parse({
+        setId: String(input.setId), contractId: input.contractId ? String(input.contractId) : undefined,
+        effectiveFrom: input.effectiveFrom ? String(input.effectiveFrom) : undefined,
+        ownerUserId: input.ownerUserId ? String(input.ownerUserId) : undefined,
+      });
+      const result = await applyTemplateSet(String(input.orgId), parsed.setId, parsed, actorFromAuth(auth));
+      return JSON.stringify(result);
+    } catch (err) {
+      return zodErrorToJson(err) ?? serviceErrorToJson(err) ?? JSON.stringify({ error: 'Failed to apply the template set' });
+    }
+  },
+});
+```
+
+Import `missingParamsJson` and `zodErrorToJson` from `./aiToolValidation` (same as `aiToolsContracts.ts`). Register the hub call in `aiTools.ts`.
+
+- [ ] **Step 4: Implement sites 2–4**
+
+`aiToolSchemas.ts` (beside the `manage_contracts` entry at line 452):
+
+```ts
+  list_deliverable_templates: z.object({ orgId: uuid.optional() }),
+  manage_deliverables: z.object({
+    action: z.enum(['apply_template']),
+    orgId: uuid.optional(),
+    setId: uuid.optional(),
+    contractId: uuid.optional(),
+    effectiveFrom: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+    ownerUserId: uuid.optional(),
+  }),
+```
+
+`aiGuardrails.ts`:
+- `TIER2_READONLY_TOOLS` (line 164): add `'list_deliverable_templates'`.
+- `TIER3_ACTIONS` (line 185): add `manage_deliverables: ['apply_template'], // arms unattended ticket creation for every future period of every applied item — same class as manage_software_policies create/update (#3552)`.
+- `TOOL_PERMISSIONS` (line 602, beside `manage_contracts` at line 692):
+  ```ts
+  list_deliverable_templates: { resource: 'contracts', action: 'read' },
+  manage_deliverables: { apply_template: { resource: 'contracts', action: 'manage' } },
+  ```
+
+`aiAgentSdkTools.ts`: add `list_deliverable_templates: 2,` and `manage_deliverables: 2,   // apply_template escalates to 3 in guardrails` to `TOOL_TIERS` (around line 285), and two `tool(...)` registrations beside the `manage_contracts` one (line 2546) using the same field shapes as the Zod schema above and `makeHandler('<name>', getAuth, onPreToolUse, onPostToolUse)`.
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `cd apps/api && npx vitest run src/services/aiToolsDeliverables.registryParity.contract.test.ts src/services/aiToolsRegistryParity.test.ts && npx tsc --noEmit`
+Expected: PASS. `aiToolsRegistryParity.test.ts` proves both new tools have a Zod schema and a `TOOL_PERMISSIONS` entry — its two exemption lists are empty by design, never add a name to them.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/services/aiToolsDeliverables.ts apps/api/src/services/aiToolsDeliverables.registryParity.contract.test.ts apps/api/src/services/aiTools.ts apps/api/src/services/aiToolSchemas.ts apps/api/src/services/aiGuardrails.ts apps/api/src/services/aiAgentSdkTools.ts
+git commit -m "feat(deliverables): approval-gated apply_template and list_deliverable_templates MCP tools (W05)"
+```
+
+---
+
+### Task 10: Web API client and i18n
+
+**Files:**
+- Create: `apps/web/src/lib/api/deliverableTemplates.ts`
+- Modify: `apps/web/src/locales/{en,de-DE,es-419,fr-CA,fr-FR,it-IT,pt-BR,tr-TR}/deliverables.json`
+
+**Interfaces:**
+- Consumes: `Fetcher`, `ActionError` and the `Deliverable` type from W01's `apps/web/src/lib/api/serviceDeliverables.ts`.
+- Produces:
+
+```ts
+export interface TemplateItem { id: string; setId: string; name: string; description: string | null; cadence: Cadence; leadDays: number; graceDays: number; artifactRequired: boolean; completionMode: 'explicit' | 'on_ticket_resolve'; sortOrder: number }
+export interface TemplateSet { id: string; orgId: string | null; partnerId: string | null; ownerScope: 'organization' | 'partner'; name: string; description: string | null; items: TemplateItem[]; createdAt: string; updatedAt: string }
+export interface ApplyTemplateResult { setId: string; setName: string; orgId: string; contractId: string | null; effectiveFrom: string; created: Array<{ id: string; name: string; cadence: Cadence; anchorDueDate: string }>; skipped: string[] }
+
+export function listTemplateSets(f: Fetcher, q?: { orgId?: string }): Promise<TemplateSet[]>;
+export function createTemplateSet(f: Fetcher, body: CreateTemplateSetInput): Promise<TemplateSet>;
+export function updateTemplateSet(f: Fetcher, setId: string, body: UpdateTemplateSetInput): Promise<TemplateSet>;
+export function deleteTemplateSet(f: Fetcher, setId: string): Promise<void>;
+export function addTemplateItem(f: Fetcher, setId: string, body: CreateTemplateItemInput): Promise<TemplateItem>;
+export function updateTemplateItem(f: Fetcher, setId: string, itemId: string, body: UpdateTemplateItemInput): Promise<TemplateItem>;
+export function removeTemplateItem(f: Fetcher, setId: string, itemId: string): Promise<void>;
+export function applyTemplateSet(f: Fetcher, orgId: string, body: ApplyTemplateSetInput): Promise<ApplyTemplateResult>;
+```
+
+- [ ] **Step 1: Write the client**
+
+Each function does `const res = await f(path, { method, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) })`, then on `!res.ok` parses the JSON body and throws `new ActionError(parsed.error ?? res.statusText, res.status, parsed.code, parsed.details)` — mirror the exact `ActionError` constructor used by `apps/web/src/lib/api/contractDocuments.ts`. On success return `(await res.json()).data`. Thin wrappers, no test file of their own: the component tests in Tasks 11 and 12 exercise them.
+
+- [ ] **Step 2: Add the English keys**
+
+Add a `templates` subtree to `apps/web/src/locales/en/deliverables.json`:
+
+```json
+{
+  "templates": {
+    "pageTitle": "Deliverable templates",
+    "pageDescription": "Define a service tier once and apply it to any customer. Partner-wide sets are available to every organization you manage.",
+    "empty": "No template sets yet.",
+    "allOrganizations": "All orgs",
+    "actions": { "newSet": "New template set", "addItem": "Add deliverable", "apply": "Apply template set", "edit": "Edit", "delete": "Delete", "save": "Save", "cancel": "Cancel" },
+    "form": { "name": "Set name", "description": "Description", "itemName": "Deliverable name", "cadence": "Cadence", "leadDays": "Open this many days before due", "graceDays": "Mark missed this many days after due", "artifactRequired": "Artifact required", "completionMode": "Completion" },
+    "ownerScope": { "legend": "Who is this set for?", "allOrganizations": "All organizations (partner-wide)", "thisOrganizationOnly": "This organization only" },
+    "apply": { "title": "Apply template set", "set": "Template set", "contract": "Contract (optional)", "noContract": "No contract", "effectiveFrom": "Effective from", "owner": "Owner (optional)", "submit": "Apply", "created_one": "Created {{count}} deliverable", "created_other": "Created {{count}} deliverables", "skipped": "Skipped (already present): {{names}}" },
+    "errors": { "collision": "These deliverables already exist on the target: {{names}}", "duplicateSetName": "A template set with this name already exists.", "duplicateItemName": "An item with this name already exists in the set.", "partnerWideDenied": "Managing partner-wide templates requires full partner organization access." },
+    "toast": { "setSaved": "Template set saved", "setDeleted": "Template set deleted", "itemSaved": "Deliverable saved", "itemDeleted": "Deliverable removed", "applied": "Template set applied" }
+  }
+}
+```
+
+- [ ] **Step 3: Translate into the seven other locales**
+
+Write real translations into `de-DE`, `es-419`, `fr-CA`, `fr-FR`, `it-IT`, `pt-BR`, `tr-TR` — not English copies. Consult `apps/web/src/locales/TERMINOLOGY.md` for fixed terms; keep `Breeze` untranslated. `translationCoverage.test.ts` caps exact-English duplicates per namespace, so a lazy copy reddens the suite.
+
+- [ ] **Step 4: Run the locale suites**
+
+Run: `cd apps/web && npx vitest run src/lib/i18n`
+Expected: PASS (parity + coverage).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/lib/api/deliverableTemplates.ts apps/web/src/locales
+git commit -m "feat(web): deliverable template API client and i18n keys (W05)"
+```
+
+---
+
+### Task 11: Settings page
+
+**Files:**
+- Create: `apps/web/src/components/settings/DeliverableTemplatesPage.tsx`, `DeliverableTemplatesPage.test.tsx`
+- Create: `apps/web/src/pages/settings/deliverable-templates.astro`
+- Modify: `apps/web/src/pages/settings/index.astro` (a card beside the Billing card at line 49)
+
+**Interfaces:**
+- Consumes: `useDefaultOwnerScope()` (`apps/web/src/hooks/useDefaultOwnerScope.ts`), `useAuthStore(s => s.user?.canManagePartnerWide)`, `fetchWithAuth`, `runAction`, the Task 10 client.
+- Produces: default-exported `DeliverableTemplatesPage` React island.
+
+UI contract, copied from `apps/web/src/components/settings/CustomFieldsPage.tsx` (the closest precedent — same ownership shape, same selector, same badge):
+
+- `const { isPartnerScope, defaultOwnerScope } = useDefaultOwnerScope();` and `const canManagePartnerWide = useAuthStore((s) => s.user?.canManagePartnerWide) !== false;` (absent means a session persisted before the field existed — treat as capable, matching the server, which gates every write regardless). `showOwnerScope = isPartnerScope && canManagePartnerWide` (`CustomFieldsPage.tsx:69-71`).
+- The ownerScope fieldset renders **only on create** (`modalMode === 'create' && showOwnerScope`), with `data-testid="deliverable-template-owner"`, `-owner-partner`, `-owner-org` (`CustomFieldsPage.tsx:607-636`).
+- A set with `orgId === null` renders an "All orgs" badge, `data-testid="deliverable-template-all-orgs-badge"`, classes `ml-2 rounded-full bg-primary/10 px-2 py-0.5 text-xs text-primary` (`CustomFieldsPage.tsx:469-477`).
+- Edit/delete controls are hidden for a partner-wide set when `!canManagePartnerWide` — an unconditional button just trades a create 403 for a delete 403 (`CustomFieldsPage.tsx:77-78`).
+- Every mutation goes through `runAction`; catch per CLAUDE.md: `if (err instanceof ActionError && err.status === 401) return;` then toast only non-`ActionError`s.
+
+- [ ] **Step 1: Write the failing component tests**
+
+```tsx
+it('renders the All orgs badge for a partner-wide set and not for an org-owned one', …);
+it('shows the ownerScope selector only on create, and only for a partner admin', …);
+it('hides the selector for a partner tech whose canManagePartnerWide is false', …);
+it('POSTs ownerScope partner when All organizations is selected', …);   // assert the request body
+it('POSTs ownerScope organization by default with a concrete org selected', …);
+it('hides edit and delete on a partner-wide set when canManagePartnerWide is false', …);
+it('surfaces the 409 DUPLICATE_TEMPLATE_SET_NAME message from the response, not a generic error', …);
+it('adds and removes an item through runAction and shows the toast', …);
+```
+
+Mock `fetchWithAuth` and the auth/org stores exactly as `CustomFieldsPage.ownerScope.test.tsx` does (`vi.hoisted` + `vi.mock('../../lib/authScope')`).
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/web && npx vitest run src/components/settings/DeliverableTemplatesPage.test.tsx`
+Expected: FAIL — component not found.
+
+- [ ] **Step 3: Implement the page, the Astro route and the nav card**
+
+`apps/web/src/pages/settings/deliverable-templates.astro`:
+
+```astro
+---
+import DashboardLayout from '../../layouts/DashboardLayout.astro';
+import DeliverableTemplatesPage from '../../components/settings/DeliverableTemplatesPage';
+---
+
+<DashboardLayout title="Deliverable Templates">
+  <DeliverableTemplatesPage client:load />
+</DashboardLayout>
+```
+
+`apps/web/src/pages/settings/index.astro`, beside the Billing card (the card is unconditional — org-scope users can still author org-owned sets, and the page hides the ownerScope selector for them):
+
+```astro
+      <a
+        href="/settings/deliverable-templates"
+        class="rounded-lg border bg-card p-6 shadow-xs transition hover:border-primary hover:shadow-md"
+        data-deliverable-templates-settings-card
+      >
+        <div class="space-y-2">
+          <h2 class="text-lg font-semibold">Deliverable Templates</h2>
+          <p class="text-sm text-muted-foreground">
+            Define a service tier once and apply its deliverables to any customer.
+          </p>
+        </div>
+      </a>
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd apps/web && npx vitest run src/components/settings/DeliverableTemplatesPage.test.tsx src/lib/__tests__/no-silent-mutations.test.ts src/lib/i18n && pnpm --filter @breeze/web typecheck`
+Expected: PASS. If `no-silent-mutations` flags the page, wrap the offending handler in `runAction` — do not add it to `runActionAllowlist.ts`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/settings/DeliverableTemplatesPage.tsx apps/web/src/components/settings/DeliverableTemplatesPage.test.tsx apps/web/src/pages/settings/deliverable-templates.astro apps/web/src/pages/settings/index.astro
+git commit -m "feat(web): deliverable templates settings page (W05)"
+```
+
+---
+
+### Task 12: "Apply template set" in the org record and the contract section
+
+**Files:**
+- Create: `apps/web/src/components/deliverables/ApplyTemplateModal.tsx`, `ApplyTemplateModal.test.tsx`
+- Modify: `apps/web/src/components/organizations/record/OrgServiceTab.tsx` (W01 Task 14)
+- Modify: `apps/web/src/components/contracts/ContractDeliverablesSection.tsx` (W01 Task 13)
+
+**Interfaces:**
+- Produces:
+
+```tsx
+export function ApplyTemplateModal(props: {
+  fetcher: Fetcher;
+  orgId: string;
+  contractId?: string;        // preselects and locks the contract when opened from the contract section
+  onApplied: (result: ApplyTemplateResult) => void;
+  onClose: () => void;
+}): JSX.Element;
+```
+
+Behaviour:
+
+- On open, `listTemplateSets(fetcher)`. Each option shows the set name plus the "All orgs" badge when `ownerScope === 'partner'`.
+- Fields: set (required), contract (a `<select>` from `GET /contracts?orgId=`; hidden and fixed when `contractId` is given), effective from (a date input defaulting to today), owner (optional, from the org's technicians if that list is already available on the page; otherwise omit the field entirely rather than shipping a guid box).
+- Submit goes through `runAction(() => applyTemplateSet(fetcher, orgId, { setId, contractId, effectiveFrom, ownerUserId }))`.
+- A 409 `TEMPLATE_NAME_COLLISION` renders `templates.errors.collision` with `details.collisions` joined — inline in the modal, and the modal stays open so the tech can pick a different contract. Any other `ActionError` is already toasted by `runAction`; a 401 returns silently.
+- On success, call `onApplied(result)` so the parent refetches, and toast `templates.toast.applied` plus `templates.apply.created` / `templates.apply.skipped` when `skipped.length > 0`.
+- `data-testid`: `apply-template-modal`, `apply-template-set`, `apply-template-contract`, `apply-template-effective-from`, `apply-template-submit`, `apply-template-collision`.
+
+Wiring: add an "Apply template set" button next to W01's "Add deliverable" button in `OrgServiceTab` (no `contractId`, uses `orgFetch`) and in `ContractDeliverablesSection` (passes `contractId`, uses `fetchWithAuth`), each opening the modal and refetching its deliverable list from `onApplied`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```tsx
+it('lists template sets and badges the partner-wide ones', …);
+it('locks the contract field when opened from the contract section', …);
+it('POSTs apply-template with the chosen set, contract and effective date', …);
+it('renders the colliding names inline on 409 and keeps the modal open', …);
+it('reports skipped names on success and calls onApplied', …);
+it('OrgServiceTab refetches its deliverables after a successful apply', …);
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/web && npx vitest run src/components/deliverables/ApplyTemplateModal.test.tsx src/components/organizations/record/OrgServiceTab.test.tsx`
+Expected: FAIL — component not found.
+
+- [ ] **Step 3: Implement**
+
+Use the repo's Tailwind conventions (`rounded-lg border bg-card`, `fixed inset-0 z-50 …` for the overlay) and copy the modal skeleton from an existing deliverables drawer (`OccurrenceDrawer.tsx`, W01) so focus handling and the close affordance match.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd apps/web && npx vitest run src/components/deliverables src/components/organizations/record src/components/contracts src/lib/__tests__/no-silent-mutations.test.ts && pnpm --filter @breeze/web typecheck`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/deliverables/ApplyTemplateModal.tsx apps/web/src/components/deliverables/ApplyTemplateModal.test.tsx apps/web/src/components/organizations/record/OrgServiceTab.tsx apps/web/src/components/contracts/ContractDeliverablesSection.tsx
+git commit -m "feat(web): apply template set from the org record and contract deliverables (W05)"
+```
+
+---
+
+### Task 13: Integration test — partner RLS, XOR, owner integrity and apply fan-out
+
+**Files:**
+- Create: `apps/api/src/__tests__/integration/deliverableTemplatesPartnerRls.integration.test.ts`
+
+This is CLAUDE.md "Partner-Wide First" step 6. Model the file on `apps/api/src/__tests__/integration/customFieldDefinitionsPartnerRls.integration.test.ts` — it already has the exact helper set this table needs: `SYSTEM_CTX`, `partnerContext(partnerId, orgIds)`, `orgContext(orgId, currentPartnerId)`, `agentContext(orgId, devicePartnerId)`, `expectSqlState(fn, code)` and the `afterEach` cleanup.
+
+- [ ] **Step 1: Write the tests**
+
+1. **Partner insert** — a partner context inserts `{ orgId: null, partnerId: own }`; 1 row returned, `orgId` null.
+2. **Cross-partner forge 42501** — attacker partner context inserts `{ orgId: null, partnerId: victim }` → SQLSTATE `42501`.
+3. **XOR 23514** — a partner context inserts `{ orgId: <own org>, partnerId: own }` (both axes). The RLS `WITH CHECK` passes on the org branch, so the statement reaches the CHECK — this is what proves the XOR does work RLS does not. Expect `23514`. Repeat for `deliverable_template_items`.
+4. **Ownerless 42501** — both columns NULL: RLS rejects before the CHECK is evaluated, so expect `42501`, not `23514`.
+5. **Org isolation** — org A's context cannot read a set owned by org B (seeded under system scope): `count` is 0. Positive control: org A reads back its own set (1 row), so case 5 cannot pass vacuously.
+6. **Partner-wide SELECT branch** — an `orgContext(orgA, partnerP)` reads a partner-wide set owned by `partnerP`: 1 row. A partner-wide set owned by a *different* partner: 0 rows. With `currentPartnerId: null` (the degenerate no-GUC caller): 0 rows — this pins the `=` vs `IS NOT DISTINCT FROM` choice in the policy.
+7. **Agent path** — `agentContext(orgA, partnerP)` reads the same partner-wide set: 1 row (`middleware/agentAuth.ts` sets `currentPartnerId: device.partnerId`; the branch is load-bearing there).
+8. **Branch-FK owner integrity 23503** — under system scope, insert an item with `{ setId: <partner-wide set>, orgId: <some org>, partnerId: null }` → `23503` on `deliverable_template_items_set_org_fk`. Mirror it: an item with `{ setId: <org-owned set>, orgId: null, partnerId: P }` → `23503` on `deliverable_template_items_set_partner_fk`.
+9. **Write is still refused from an org context** — an org context `UPDATE` and `DELETE` against a visible partner-wide set affect **zero rows** (the SELECT branch grants no write), and an org context `INSERT` of a partner-wide row raises `42501`.
+10. **Cascade** — deleting a set removes its items (both branches).
+11. **Apply fan-out** — seed a partner-wide set with two items, then call `applyTemplateSet(orgA.id, set.id, { effectiveFrom: '2026-10-01' }, partnerAdminActor)` inside `withDbAccessContext(partnerContext(...))`. Assert: two `service_deliverables` rows exist **in orgA only** (`count` in orgB is 0), their `anchor_due_date` values are `2026-10-31` and `2026-12-31`, and re-running it raises `TEMPLATE_NAME_COLLISION` with both names and creates nothing further (`count` still 2).
+
+- [ ] **Step 2: Run to verify**
+
+Run: `cd apps/api && npx vitest run --config vitest.integration.config.ts src/__tests__/integration/deliverableTemplatesPartnerRls.integration.test.ts`
+Expected: PASS. **Confirm in the output that the expected number of tests actually ran** — a `0 tests` line is a stall, not green.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/__tests__/integration/deliverableTemplatesPartnerRls.integration.test.ts
+git commit -m "test(deliverables): template partner RLS, XOR, owner integrity and apply fan-out (W05)"
+```
+
+---
+
+### Task 14: First-customer backfill script
+
+**Files:**
+- Create: `apps/api/scripts/backfill-first-customer-deliverables.ts`
+- Modify: `apps/api/package.json` (scripts block, beside `partner-trust:backfill-cards` at line 21)
+
+**Interfaces:**
+- Consumes: `withSystemDbAccessContext`, `closeDb` from `../src/db`; `createTemplateSet`, `applyTemplateSet`, `listTemplateSets` from `../src/services/deliverableTemplateService`; `updateDeliverable` from `../src/services/serviceDeliverableService`.
+- Produces: no exports; a CLI.
+
+**Hard rules.** No customer id, org name, partner id or contract id is ever written into this file — the spec's "Northwind Law P.C." is a fictional stand-in and does not appear either. Every id arrives as a flag at run time. The script is re-runnable: it reuses an existing set with the same `(partner_id, name)` and applies with `onCollision: 'skip'`, so a half-finished run finishes cleanly.
+
+The eight items are spec §15, cadence and `artifactRequired` verbatim:
+
+| # | name | cadence | artifactRequired |
+|---|---|---|---|
+| 1 | Sign-in log review | monthly | true |
+| 2 | Threat detection review | monthly | true |
+| 3 | Intune management | monthly | false (checkpoint) |
+| 4 | Vulnerability management | monthly | true |
+| 5 | Documentation and configuration audit | quarterly | true |
+| 6 | Firewall rule review | quarterly | true |
+| 7 | VPN and access policy management | monthly | false (checkpoint) |
+| 8 | IR runbooks and tabletop | annual | true |
+
+`auto_evidence_report_id` is a **deliverable** column, not a template-item column (spec §4.6), so the script sets it after the apply, on the "Vulnerability management" deliverable only, via `updateDeliverable` — and only when `--vuln-report-id` is supplied.
+
+- [ ] **Step 1: Write the script**
+
+```ts
+#!/usr/bin/env tsx
+// First-customer deliverable backfill (spec §15). Creates a partner-wide
+// template set, applies it to one org (and optionally one contract), then
+// attaches the vulnerability report as auto-evidence.
+//
+// Every id is supplied at run time; NOTHING customer-specific is committed.
+//
+//   pnpm --filter @breeze/api deliverables:backfill-first-customer -- \
+//     --org-id <uuid> --contract-id <uuid> --owner-user-id <uuid> \
+//     --effective-from 2026-10-01 [--vuln-report-id <uuid>] \
+//     [--set-name "Best plan"] [--dry-run]
+//
+// Re-runnable: an existing set with the same (partner_id, name) is reused and
+// deliverables that already exist on the target are skipped, not duplicated.
+
+import { and, eq } from 'drizzle-orm';
+import { closeDb, db, withSystemDbAccessContext } from '../src/db';
+import { organizations } from '../src/db/schema/orgs';
+import {
+  applyTemplateSet, createTemplateSet, listTemplateSets, type TemplateActor,
+} from '../src/services/deliverableTemplateService';
+import { updateDeliverable } from '../src/services/serviceDeliverableService';
+import type { CreateTemplateItemInput } from '@breeze/shared';
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+const LOG = '[backfill-first-customer-deliverables]';
+
+const VULNERABILITY_ITEM_NAME = 'Vulnerability management';
+
+/** Spec §15. `description` stays null: it is customer-facing copy the MSP writes per client. */
+const BEST_PLAN_ITEMS: CreateTemplateItemInput[] = [
+  { name: 'Sign-in log review',                     cadence: 'monthly',   artifactRequired: true,  leadDays: 7,  graceDays: 14, completionMode: 'on_ticket_resolve', sortOrder: 0 },
+  { name: 'Threat detection review',                cadence: 'monthly',   artifactRequired: true,  leadDays: 7,  graceDays: 14, completionMode: 'on_ticket_resolve', sortOrder: 1 },
+  { name: 'Intune management',                      cadence: 'monthly',   artifactRequired: false, leadDays: 7,  graceDays: 14, completionMode: 'on_ticket_resolve', sortOrder: 2 },
+  { name: VULNERABILITY_ITEM_NAME,                  cadence: 'monthly',   artifactRequired: true,  leadDays: 7,  graceDays: 14, completionMode: 'on_ticket_resolve', sortOrder: 3 },
+  { name: 'Documentation and configuration audit',  cadence: 'quarterly', artifactRequired: true,  leadDays: 14, graceDays: 21, completionMode: 'on_ticket_resolve', sortOrder: 4 },
+  { name: 'Firewall rule review',                   cadence: 'quarterly', artifactRequired: true,  leadDays: 14, graceDays: 21, completionMode: 'on_ticket_resolve', sortOrder: 5 },
+  { name: 'VPN and access policy management',       cadence: 'monthly',   artifactRequired: false, leadDays: 7,  graceDays: 14, completionMode: 'on_ticket_resolve', sortOrder: 6 },
+  { name: 'IR runbooks and tabletop',               cadence: 'annual',    artifactRequired: true,  leadDays: 30, graceDays: 30, completionMode: 'on_ticket_resolve', sortOrder: 7 },
+];
+
+function flag(name: string): string | undefined {
+  const i = process.argv.indexOf(`--${name}`);
+  return i === -1 ? undefined : process.argv[i + 1];
+}
+
+function requireUuid(name: string): string {
+  const value = flag(name);
+  if (!value || !UUID.test(value)) throw new Error(`--${name} is required and must be a UUID`);
+  return value;
+}
+
+async function main(): Promise<void> {
+  const orgId = requireUuid('org-id');
+  const ownerUserId = requireUuid('owner-user-id');
+  const contractId = flag('contract-id');
+  const vulnReportId = flag('vuln-report-id');
+  const effectiveFrom = flag('effective-from');
+  const setName = flag('set-name') ?? 'Best plan';
+  const dryRun = process.argv.includes('--dry-run');
+
+  if (contractId && !UUID.test(contractId)) throw new Error('--contract-id must be a UUID');
+  if (vulnReportId && !UUID.test(vulnReportId)) throw new Error('--vuln-report-id must be a UUID');
+  if (effectiveFrom && !ISO_DATE.test(effectiveFrom)) throw new Error('--effective-from must be YYYY-MM-DD');
+
+  await withSystemDbAccessContext(async () => {
+    const [org] = await db.select({ partnerId: organizations.partnerId })
+      .from(organizations).where(eq(organizations.id, orgId)).limit(1);
+    if (!org) throw new Error(`Organization ${orgId} does not exist`);
+
+    // System scope: unrestricted, and canManagePartnerWidePolicies is true for it.
+    const actor: TemplateActor = {
+      userId: ownerUserId, scope: 'system', partnerId: org.partnerId,
+      partnerOrgAccess: 'all', accessibleOrgIds: null,
+    };
+
+    if (dryRun) {
+      console.log(`${LOG} DRY RUN — would create partner-wide set "${setName}" for partner ${org.partnerId} with ${BEST_PLAN_ITEMS.length} items and apply it to org ${orgId}${contractId ? ` / contract ${contractId}` : ''}.`);
+      return;
+    }
+
+    const existing = (await listTemplateSets(actor, {}))
+      .find((s) => s.ownerScope === 'partner' && s.partnerId === org.partnerId && s.name === setName);
+    const set = existing ?? await createTemplateSet(
+      { ownerScope: 'partner', name: setName, description: null, items: BEST_PLAN_ITEMS }, actor,
+    );
+    console.log(`${LOG} ${existing ? 'Reusing' : 'Created'} partner-wide set ${set.id} ("${set.name}") with ${set.items.length} items`);
+
+    const result = await applyTemplateSet(orgId, set.id, {
+      contractId, effectiveFrom, ownerUserId, onCollision: 'skip',
+    }, actor);
+
+    for (const created of result.created) {
+      console.log(`${LOG} created deliverable ${created.id}  ${created.cadence.padEnd(10)} anchor ${created.anchorDueDate}  ${created.name}`);
+    }
+    for (const name of result.skipped) console.log(`${LOG} skipped (already present): ${name}`);
+    console.log(`${LOG} effective_from = ${result.effectiveFrom}; ${result.created.length} created, ${result.skipped.length} skipped`);
+
+    if (vulnReportId) {
+      const target = result.created.find((c) => c.name === VULNERABILITY_ITEM_NAME);
+      if (!target) {
+        console.warn(`${LOG} "${VULNERABILITY_ITEM_NAME}" was skipped or absent — --vuln-report-id not applied`);
+      } else {
+        await updateDeliverable(orgId, target.id, { autoEvidenceReportId: vulnReportId }, {
+          userId: ownerUserId, partnerId: org.partnerId, accessibleOrgIds: null,
+        });
+        console.log(`${LOG} attached auto-evidence report ${vulnReportId} to deliverable ${target.id}`);
+      }
+    }
+  }, 'backfillFirstCustomerDeliverables');
+}
+
+main()
+  .catch((error) => {
+    console.error(`${LOG} Failed:`, error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await closeDb();
+  });
+```
+
+Add to `apps/api/package.json`:
+
+```json
+    "deliverables:backfill-first-customer": "tsx scripts/backfill-first-customer-deliverables.ts",
+```
+
+- [ ] **Step 2: Prove it refuses bad input**
+
+Run: `cd apps/api && npx tsx scripts/backfill-first-customer-deliverables.ts --org-id nope --owner-user-id nope`
+Expected: exits non-zero with `--org-id is required and must be a UUID`, no database connection attempted beyond `closeDb`.
+
+- [ ] **Step 3: Dry-run then real-run against the test stack**
+
+Seed a partner, org, user and contract on the test stack (`pnpm test-stack up`), then:
+```bash
+cd apps/api && DATABASE_URL=$(grep DATABASE_URL .env.test | cut -d= -f2-) \
+  npx tsx scripts/backfill-first-customer-deliverables.ts \
+  --org-id <org> --contract-id <contract> --owner-user-id <user> --effective-from 2026-10-01 --dry-run
+```
+Expected: the dry-run line, no rows written. Drop `--dry-run` and re-run: eight `created deliverable` lines with anchors `2026-10-31` (×5 monthly), `2026-12-31` (×2 quarterly) and `2027-09-30` (annual). Run it a **third** time: eight `skipped (already present)` lines, `0 created`, exit 0.
+
+- [ ] **Step 4: Verify the rows**
+
+`psql` as `breeze_app`: `SELECT name, cadence, anchor_due_date, artifact_required, owner_user_id, contract_id FROM service_deliverables WHERE org_id = '<org>' ORDER BY sort_order;` → eight rows matching the §15 table, every `owner_user_id` set, every `contract_id` set.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/scripts/backfill-first-customer-deliverables.ts apps/api/package.json
+git commit -m "feat(deliverables): re-runnable first-customer deliverable backfill script (W05)"
+```
+
+---
+
+### Task 15: Wave verification and PR
+
+- [ ] **Step 1: Full API unit run** — `cd apps/api && npx vitest run` → green.
+- [ ] **Step 2: Integration contract suites** (test stack up):
+```bash
+cd apps/api && npx vitest run --config vitest.integration.config.ts \
+  src/__tests__/integration/rls-coverage.integration.test.ts \
+  src/__tests__/integration/tenantCascade.integration.test.ts \
+  src/__tests__/integration/tenant-export-policy.integration.test.ts \
+  src/__tests__/integration/tenantExportErasureRoundtrip.integration.test.ts \
+  src/__tests__/integration/orgLifecycleFoundations.integration.test.ts \
+  src/__tests__/integration/deliverableTemplatesPartnerRls.integration.test.ts
+```
+→ green, and each suite reports a non-zero test count.
+- [ ] **Step 3: Shared + web** — `cd packages/shared && npx vitest run` ; `cd apps/web && npx vitest run` and `pnpm --filter @breeze/web typecheck` ; `pnpm lint` at the root → all clean.
+- [ ] **Step 4: Manual smoke** on a worktree stack (`pnpm wt-stack up`): as a partner admin, create a partner-wide set with three items on `/settings/deliverable-templates` (confirm the "All orgs" badge), apply it to an org from the org record Service tab, apply it again and confirm the inline collision message names all three, then apply it to a *different* org pinned to a contract and confirm the deliverables appear on the contract's Deliverables tab. As a partner tech with `orgAccess='selected'`, confirm the ownerScope selector is hidden and the partner-wide set has no edit/delete controls.
+- [ ] **Step 5: Tear down** — `pnpm test-stack down` and `pnpm wt-stack down`. Confirm with `docker compose ls -a --format json | jq -r '.[] | select(.ConfigFiles|test("breeze")) | "\(.Name)\t\(.Status)"'` that nothing of yours is left running.
+- [ ] **Step 6: PR** with `Closes #<W05 sub-issue>`, a link to the spec, and a **Tenancy** section listing: the XOR check, the dual-axis `FOR ALL` policy, the partner-wide SELECT branch, the branch-FK owner-integrity design, and the five registration lists touched. Run `/pr-review-toolkit:review-pr`; act only on confirmed findings. Enqueue with `gh pr merge <N>` on green — **never** `--admin`. If the PR is stacked on a sibling branch rather than `main`, `ci.yml` does not run at all: dispatch it with `gh workflow run CI --ref <branch>` before merging.
+
+---
+
+## Self-review
+
+**Spec coverage.** §4.6 both tables with the XOR check, partner index, one dual-axis `FOR ALL` policy and the separate SELECT-only branch → Task 1; the item columns `cadence`, `lead_days`, `grace_days`, `artifact_required`, `completion_mode`, `sort_order`, `description` → Tasks 1, 2, 4; unique `(partner_id, name)` and `(org_id, name)` → Task 1; items carrying the set's owner columns so an item can never belong to a differently-owned set → Task 1 (branch-FK pair, justified) and Task 13 case 8. D7 is W01's `organization_key_dates`, untouched here. D9 copy-on-apply → Task 7. §4.9 registration checklist → Task 3. §9 settings page with create-only ownerScope selector and "All orgs" badge → Task 11; "Apply template set" on the contract and org-record surfaces → Task 12. §10 `routes/deliverableTemplates.ts` sets and items CRUD + `POST /orgs/:orgId/deliverables/apply-template` → Task 8; `manage_deliverables.apply_template` approval-gated plus `list_deliverable_templates` → Task 9; the `contracts` permission resource → Tasks 8, 9. §12 409 on apply-template name collisions, nothing written → Task 7 (service), Task 8 (route), Task 12 (UI). §13 template XOR 23514 → Task 13 case 3, alongside the four standing contract suites in Tasks 3 and 15. §15 first use → Task 14. CLAUDE.md "Partner-Wide First" steps 1, 2, 3, 6 and 7 → Tasks 1, 4, 6, 13 and the Task 15 sweep; step 4 (config-policy linkage) and step 5 (worker fan-out) do not apply — a template set is not a `PARTNER_LINKABLE_FEATURE_TYPES` feature and nothing evaluates it against devices; the apply fan-out is an explicit user action and is proved against real Postgres in Task 13 case 11.
+
+**Placeholders.** None. Every code step carries the real code. Three places deliberately instruct a lookup rather than guessing: the `partners` table export name (Task 2 Step 1), the `repoint-dedupe` partial-predicate form in `orgMergeRegistry.ts` (Task 3 Step 4), and the `ActionError` constructor arity (Task 10 Step 1) — each names the file to read and the fallback to take.
+
+**Type consistency.** `TemplateActor`, `TemplateServiceError`, `TemplateSetView`, `TemplateItemView`, `AppliedTemplateResult`, `ApplyTemplateResult` (the web mirror), `visibilityCondition`, `requireWritable`, `loadSetOr404`, `firstAnchorAfter`, `DbExecutor` and `applyTemplateSet` are spelled identically in Tasks 5–14. `ownerScope` is `'organization' | 'partner'` everywhere (validator, service view, web client, UI). The MCP action string is `apply_template` at all four registration sites and in the parity test. The error codes `TEMPLATE_NAME_COLLISION`, `DUPLICATE_TEMPLATE_SET_NAME`, `DUPLICATE_TEMPLATE_ITEM_NAME`, `CONTRACT_NOT_IN_ORG`, `NOT_FOUND` and `PARTNER_WIDE_WRITE_DENIED` appear with the same spelling in the service, the routes, the tests and the i18n keys.
+
+**Cross-wave contracts touched.** Task 5 adds an optional fourth parameter to W01's `createDeliverable` and one exported function to W01's `recurrence.ts` — both additive, both leaving W01's tests green. Task 9 shares `aiToolsDeliverables.ts` with W02; the wave-order note in that task says which direction to merge. Nothing in this wave depends on W02, W03 or W04.

--- a/docs/superpowers/plans/billing/2026-09-10-service-deliverables.md
+++ b/docs/superpowers/plans/billing/2026-09-10-service-deliverables.md
@@ -1,0 +1,50 @@
+---
+tracking_issue: LanternOps/breeze#5573
+---
+# Service Deliverables, Org Documents and Key Dates — Plan Index
+
+**Spec:** `docs/superpowers/specs/billing/2026-09-10-service-deliverables-portal-design.md` (approved 2026-09-10).
+
+One plan document per wave. Each wave is one PR on its own branch
+`feature/<parent#>-service-deliverables/wave-<sub-issue#>` with `Closes #<sub-issue#>`
+in the PR body. State lives on GitHub (feature-lifecycle); the wave issue is the
+source of truth for status, never this index.
+
+| Wave | Plan | Depends on |
+|---|---|---|
+| W01 | [Schema, core services, contract and org record surfaces](2026-09-10-service-deliverables-w01-schema-core.md) | — |
+| W02 | [Sweep worker, ticket integration, key-date reminders, auto-evidence, MCP tools](2026-09-10-service-deliverables-w02-sweep-and-tickets.md) | W01 |
+| W03 | [Org documents library, blob storage extraction, document evidence, Documents tab](2026-09-10-service-deliverables-w03-org-documents.md) | W01 |
+| W04 | [Customer portal Service and Documents surfaces](2026-09-10-service-deliverables-w04-portal.md) | W02, W03 |
+| W05 | [Deliverable template sets, apply-to-org/contract, settings page, first-customer backfill](2026-09-10-service-deliverables-w05-templates-and-backfill.md) | W01 |
+
+W03 and W05 run in parallel with W02. W04 starts once both W02 and W03 have merged.
+
+## Migration slots reserved
+
+| File | Wave |
+|---|---|
+| `2026-10-15-170000-service-deliverables.sql` | W01 |
+| `2026-10-15-170100-tickets-work-kind.sql` | W01 |
+| `2026-10-15-170200-organization-key-dates.sql` | W01 |
+| `2026-10-15-170300-org-documents.sql` | W03 |
+| `2026-10-15-170400-documents-permissions.sql` (DML: seeds `documents:*` permission rows; elects `breeze.scope=system` first) | W03 |
+| `2026-10-15-170500-deliverable-templates.sql` | W05 |
+| `2026-10-15-170600-portal-branding-service-documents-flags.sql` | W04 |
+
+Every executor re-checks `ls apps/api/migrations | sort | tail -1` before committing
+and renames upward if main has moved past these names. Slots are independent
+(no wave's migration depends on a later slot), so waves may land in any order
+that respects the dependency column above.
+
+## Cross-wave names that must not drift
+
+Defined in W01 and consumed verbatim by W02–W05: `serviceDeliverables`,
+`serviceDeliverableOccurrences`, `serviceDeliverableEvidence`,
+`organizationKeyDates`, `ticketWorkKindEnum`; `DeliverableActor`,
+`DeliverableServiceError`, `DeliverableSummary`, `OccurrenceView`, `KeyDateView`,
+`EvidenceRef`; `transition` (`serviceDeliverableState.ts`); `planOccurrences`,
+`coveredPeriod`, `nthDueDate`, `isInLeadWindow`, `isPastGrace` (`recurrence.ts`);
+the four W02 stubs `materializeOccurrences`, `openOccurrence`,
+`markOccurrenceMissed`, `applyTicketStatusChange`; routes under
+`/orgs/:orgId/deliverables…` and `/orgs/:orgId/key-dates…`.

--- a/docs/superpowers/specs/billing/2026-09-10-service-deliverables-portal-design.md
+++ b/docs/superpowers/specs/billing/2026-09-10-service-deliverables-portal-design.md
@@ -1,0 +1,588 @@
+# Service deliverables, org documents and key dates — design
+
+Status: **approved by Todd 2026-09-10** (after the D12–D14 additions).
+Advisor quorum: Fable position formed, codex gpt-6-astra xhigh read-only review
+received; two disagreements resolved in codex's favour on the evidence, one split
+resolved by tie-break. See "Quorum record" (§17).
+Tracking: to be registered via feature-lifecycle after approval.
+Plan: to be written with `writing-plans` after approval.
+
+## 1. Problem and goal
+
+MSPs sell service tiers whose value is scheduled human work, not tooling: "monthly
+sign-in log review", "quarterly configuration audit against the baseline", "annual
+tabletop". Breeze contracts (`apps/api/src/db/schema/contracts.ts`) bill money and
+count devices, but cannot record those obligations, open the work when it falls
+due, capture the artifact that proves it was done, or show the customer what they
+received. Today that lives in a spreadsheet, a calendar and a Drive folder per
+client, so it does not scale past one client and the customer sees nothing.
+
+Three adjacent gaps surface with it:
+
+- No org-level document library. Bytes exist only as `contract_documents`,
+  `invoice_documents` and `ticket_attachments`; a runbook, a firewall rule export
+  or an onboarding baseline has nowhere to live and no portal exposure.
+- No org-level key dates. Custom fields are device-only
+  (`customFields.ts`, `deviceCustomFieldValues.ts`); an insurance renewal date or a
+  vendor contract end date cannot be recorded, let alone drive a reminder.
+- No recurring or scheduled ticket creation of any kind (grep for "recurring" in
+  the ticket routes, services and schema is empty).
+
+Goal: an organization carries a **service deliverables schedule**, normally attached
+to a contract; a daily job **opens the work as tickets** when due; delivery is
+**recorded explicitly with evidence**; the customer portal shows a **service
+scorecard** (what was delivered, when, with what evidence, what is next) and a
+**documents** page; the MSP sees the same on the contract and the org record. The
+first paying use is a law firm on a "Best" tier with eight deliverables
+(a fictional "Northwind Law P.C." stands in for the real firm throughout this document).
+
+## 2. Decisions
+
+| # | Decision | Chosen | Rejected | Why |
+|---|---|---|---|---|
+| D1 | Owner of a deliverable | **Organization**, with optional `contract_id` and its own `effective_from` / `effective_until` | Contract-owned, `contract_id NOT NULL` (Fable's first position) | Codex showed the contract status is a *billing* state machine: `generateDueInvoice` sets `status='expired'` as soon as the next billing period is past `end_date` (`contractService.ts` ~line 2013), so an annual-advance contract is `expired` the day after its one invoice while service runs 12 more months. Service life must not be read off billing state. `contract_documents.contract_id` is already nullable for the same reason. |
+| D2 | Occurrences | **Materialized rows**, one per period, with a name snapshot | Compute due dates from cadence + anchor on read | Each occurrence carries state (ticket, evidence, delivered/missed/waived, lateness). Mirrors `contract_billing_periods`: `UNIQUE (parent, period_start)` plus an explicit transaction around claim + ticket creation. |
+| D3 | Work item | **Reuse tickets**, discriminated by a new typed `tickets.work_kind` | New task table; a `deliverable` tag | Tickets already have `due_date`, assignee, comments, public attachments, portal visibility, notification and time entries. Deliverable tickets are created with **no SLA** (planned work; the SLA worker clocks from `created_at`, so a 7-day lead ticket would breach before the work is due). A typed column, not a tag string, so a future Projects module reuses the same discriminator (`project_task`) for SLA suppression, list filters and portal rules. |
+| D4 | What records delivery | **Explicit delivery with a completion policy**; ticket resolution alone never marks delivered when an artifact is required | "Ticket resolved ⇒ delivered" (Fable's first position) | Closing a ticket requires neither an artifact nor a note (`changeTicketStatus`, `ticketService.ts` ~line 942), which contradicts `artifact_required`. Resolution moves the occurrence to `awaiting_evidence` when evidence is missing, to `delivered` when it is present or not required. |
+| D5 | Document bytes | `s3 \| db` dual backend via a generic blob helper extracted from `ticketAttachmentStorage.ts`; keys carry no tenant id | Inline `bytea` like `contract_documents` | Runbooks and exports are larger and more numerous than signed PDFs; the ticket-attachment shape already solves backend selection, upload compensation, 503 on storage fault and no presigned URLs. The erasure S3 pre-clear (`tenantCascade.ts` ~line 1111) is extended to `org_documents`. |
+| D6 | Evidence | **Join table** `service_deliverable_evidence`, many per occurrence, DB-enforced ownership | Two nullable FK columns on the occurrence | A monthly review commonly produces a findings document and an export. `report_runs` has no `org_id`, so ownership is enforced through `reports(id, org_id)`. |
+| D7 | Key dates | **Typed table** `organization_key_dates` | Extend `custom_field_definitions` with an org entity type | Dates drive scheduler behaviour (reminders, annual roll-over) and need typing; custom field values are structurally device-bound. Contract end dates stay on `contracts` and are unioned into the view. |
+| D8 | Recurrence model | **Cadence enum + anchor date**; no `continuous` | `recurrence_rule` jsonb like `maintenance_windows`; a `continuous` cadence | Sold cadences are monthly, quarterly, semiannual, annual, one-time. `maintenance_windows.custom` is not reusable RRULE code (it advances weekly). "Continuous" work has no due date and therefore no delivery record; it is modelled as a monthly checkpoint with `artifact_required=false`. |
+| D9 | Templates | **Partner-wide sets** (`org_id XOR partner_id`), applied by copying rows; last wave | Contract-only authoring; or defer out of v1 (codex) | CLAUDE.md "Partner-Wide First": a tier is defined once and applied to every customer, which is the reason this feature exists. Copy-on-apply keeps a customer's schedule stable when the template later changes. Kept in v1 as W05 because W01–W04 do not depend on it. |
+| D10 | Portal exposure | Two new **strict** flags `enable_service`, `enable_documents` on `portal_branding`, fail closed; curated delivery records only, never internal tickets | Reuse `enable_reports`; link tickets | Same shape as the five Wave-1 flags. Sweep-created tickets have no portal requester and are internal; the portal shows the delivery record and portal-visible evidence, not the ticket. |
+| D11 | ICS feed | **Out of v1** | In W02 (Fable's first position) | The portal replaces the customer calendar; the MSP gets an upcoming view in the web app. No ICS code exists in the repo; a feed is a follow-up issue. |
+| D12 | System-produced evidence | Optional `auto_evidence_report_id` on a deliverable; the sweep generates a report run on the due date and attaches it as evidence | Human-only evidence | Backup verification, patch compliance and vulnerability review are things Breeze can prove itself. The technician reviews a report Breeze already made instead of assembling one; the portal gets a real artifact every period. |
+| D13 | Recurrence code placement | Pure module `services/recurrence.ts` (period math, materialization plan) consumed by the worker | Inline in `deliverableWorker.ts` | Recurring project tasks and other future schedules reuse it without importing the worker. |
+| D14 | Projects-forward boundaries | Occurrences stay flat: no dependencies, phases or estimates; `one_time` means a contractual one-off; evidence join tables are per subject type; template sets are deliverable-specific | Generic polymorphic work/evidence/template tables now | Keeps composite-FK tenancy enforcement and stops deliverables becoming a half-project system. Projects adds its own tables against the same document library, ticket `work_kind` and portal grouping. |
+
+## 3. Scope
+
+In:
+
+- Tables: `service_deliverables`, `service_deliverable_occurrences`,
+  `service_deliverable_evidence`, `org_documents`, `organization_key_dates`,
+  `deliverable_template_sets`, `deliverable_template_items`, plus two
+  `portal_branding` columns and one `tickets.work_kind` column.
+- Daily sweep: materialize occurrences, open tickets, mark missed, key-date
+  reminders and annual roll-over. Event subscriber: ticket status changes move the
+  occurrence per the completion policy.
+- Explicit deliver / waive / reopen actions with evidence upload or linking.
+- Web (MSP): contract detail "Deliverables" tab; org record "Service" tab (all
+  deliverables incl. those with no contract, upcoming view) and "Documents" tab; key
+  dates card on the org overview; template sets under settings; portal flags.
+- Portal: `/service`, `/documents`, a dashboard tile, downloads.
+- REST + MCP tools.
+- Backfill of the first customer's deliverables from its existing tracking tickets (W05).
+
+Out (v1):
+
+- ICS / calendar feed (follow-up issue).
+- Deliverable SLAs, penalties or credits.
+- Customer sign-off on a delivered occurrence; portal is read-only.
+- Byte upload over MCP (metadata and evidence linking only).
+- Full-text search or preview over documents.
+- Moving a deliverable ticket to another org (blocked, see §6).
+
+## 4. Data model
+
+Every composite FK that references an `org_id` column is `DEFERRABLE INITIALLY
+IMMEDIATE` (org merge contract, CLAUDE.md). Dates are calendar dates; "today" in
+the sweep is computed in the partner's configured timezone, falling back to UTC,
+exactly as the billing sweep does (the plan pins the helper).
+
+### 4.1 `service_deliverables` — shape 1 (direct `org_id`)
+
+| column | type | notes |
+|---|---|---|
+| id | uuid pk | |
+| org_id | uuid not null | FK organizations |
+| contract_id | uuid null | composite FK `(contract_id, org_id) → contracts(id, org_id)` deferrable, `ON DELETE SET NULL (contract_id)` |
+| name | varchar(200) not null | |
+| description | text | customer-facing sentence |
+| cadence | enum `deliverable_cadence` | `monthly \| quarterly \| semiannual \| annual \| one_time` |
+| anchor_due_date | date not null | first due date; the n-th due date is `addMonthsClamped(anchor, n × months)` (`contractMath.ts`), so a 31st anchor clamps to month end |
+| effective_from | date not null | default: contract `start_date` when attached, else today |
+| effective_until | date null | set by the MSP, or by the contract-cancelled hook (§5.4) |
+| lead_days | int not null default 7 | occurrence opens this many days before due |
+| grace_days | int not null default 14 | occurrence becomes `missed` this many days after due without delivery |
+| artifact_required | bool not null default true | |
+| completion_mode | enum `deliverable_completion_mode` | `explicit \| on_ticket_resolve`, default `on_ticket_resolve` (§6) |
+| auto_evidence_report_id | uuid null | composite FK `(auto_evidence_report_id, org_id) → reports(id, org_id)` deferrable, `ON DELETE SET NULL`; when set, the sweep generates a run of this report on the due date and attaches it as evidence (§5.3 step 3, D12) |
+| owner_user_id | uuid null | FK users; ticket assignee; must hold access to the org (validated in the service) |
+| ticket_category_id | uuid null | FK ticket_categories; must belong to the partner (validated) |
+| portal_visible | bool not null default true | |
+| active | bool not null default true | soft off-switch, history kept |
+| sort_order | int not null default 0 | |
+| created_by, created_at, updated_at | | |
+
+Unique `(org_id, contract_id, name)` with `contract_id` coalesced to the nil uuid in
+a unique index expression, so two contracts may each have a "Monthly report".
+
+Covered period of an occurrence due on D with cadence of m months: `(D − m months,
+D]`, clamped. `one_time` has exactly one occurrence at `anchor_due_date`.
+
+### 4.2 `service_deliverable_occurrences` — shape 1
+
+| column | type | notes |
+|---|---|---|
+| id | uuid pk | |
+| org_id | uuid not null | |
+| deliverable_id | uuid not null | composite FK `(deliverable_id, org_id) → service_deliverables(id, org_id)` deferrable |
+| name_snapshot | varchar(200) not null | deliverable name at materialization; later renames do not rewrite history |
+| period_start, period_end | date not null | |
+| due_at | date not null | editable (reschedule); `original_due_at` keeps the first value |
+| original_due_at | date not null | |
+| status | enum `deliverable_occurrence_status` | `scheduled \| open \| awaiting_evidence \| delivered \| missed \| waived` |
+| ticket_id | uuid null | composite FK `(ticket_id, org_id) → tickets(id, org_id)` deferrable, `ON DELETE SET NULL (ticket_id)` |
+| delivered_at | timestamptz null | |
+| delivered_by_user_id | uuid null | |
+| delivery_note | text null | shown in the portal |
+| waived_at, waived_by_user_id, waived_reason | | all three set together |
+| created_at, updated_at | | |
+
+`UNIQUE (deliverable_id, period_start)` is the sweep's idempotency claim. `late` is
+derived (`delivered_at::date > due_at`), never stored. `missed` is not terminal.
+
+State machine:
+
+```
+scheduled ──(sweep: due_at − lead_days ≤ today)──▶ open
+open ──(deliver: evidence ok)──▶ delivered
+open ──(ticket resolved/closed, artifact_required, no evidence)──▶ awaiting_evidence
+awaiting_evidence ──(evidence added)──▶ delivered
+open | awaiting_evidence ──(sweep: due_at + grace_days < today)──▶ missed
+missed ──(deliver)──▶ delivered            (shown as late)
+open | awaiting_evidence | missed ──(waive: reason)──▶ waived
+delivered | waived ──(reopen)──▶ open      (clears delivery/waiver fields; ticket untouched)
+```
+
+### 4.3 `service_deliverable_evidence` — shape 1
+
+| column | type | notes |
+|---|---|---|
+| id | uuid pk | |
+| org_id | uuid not null | |
+| occurrence_id | uuid not null | composite FK to occurrences deferrable, `ON DELETE CASCADE` |
+| kind | enum `deliverable_evidence_kind` | `document \| report_run` |
+| document_id | uuid null | composite FK `(document_id, org_id) → org_documents(id, org_id)` deferrable, `ON DELETE CASCADE` |
+| report_id | uuid null | composite FK `(report_id, org_id) → reports(id, org_id)` deferrable (`reports_id_org_id_uniq` exists) |
+| report_run_id | uuid null | composite FK `(report_run_id, report_id) → report_runs(id, report_id)` `ON DELETE CASCADE`; the migration adds `UNIQUE (id, report_id)` on `report_runs` |
+| created_by_user_id, created_at | | |
+
+CHECK: `kind='document'` ⇔ `document_id IS NOT NULL AND report_id IS NULL`;
+`kind='report_run'` ⇔ both report columns set. Erasure pre-deletes `report_runs`
+(`tenantCascade.ts` ~line 853); `ON DELETE CASCADE` keeps that path clear.
+
+### 4.4 `org_documents` — shape 1
+
+| column | type | notes |
+|---|---|---|
+| id | uuid pk | |
+| org_id | uuid not null | |
+| title | varchar(200) not null | |
+| description | text | |
+| category | enum `org_document_category` | `baseline \| runbook \| policy \| evidence \| report \| export \| other` |
+| storage_backend | text not null | `s3 \| db`, chosen once at upload |
+| storage_key | text null | `org-documents/<documentId>`; no tenant id in the key, the row is the authority (same reasoning as ticket attachments) |
+| data | bytea null | when backend is `db` |
+| content_type | varchar(255) not null | |
+| byte_size | int not null | |
+| sha256 | char(64) not null | |
+| original_filename | varchar(255) not null | |
+| uploaded_by_user_id | uuid null | |
+| portal_visible | bool not null default false | fail closed |
+| supersedes_document_id | uuid null | composite self-FK `(supersedes_document_id, org_id)` deferrable; `UNIQUE (supersedes_document_id)` forbids branching; replace requires the target to be a head, which with the unique key rules out cycles |
+| deleted_at, deleted_by | | soft delete; erasure clears objects before rows |
+| created_at | | |
+
+Library listings and the portal show chain heads. Evidence rows point at a specific
+document id, so delivery history keeps the exact version even after replacement.
+Size cap and MIME allowlist follow `ticket_attachments`. The blob helper is
+extracted from `services/ticketAttachmentStorage.ts` into `services/blobStorage.ts`
+with the key prefix as a parameter; the ticket helper becomes a thin wrapper so its
+tests still pin behaviour (upload compensation, object-before-row deletion, 503
+`STORAGE_UNAVAILABLE`).
+
+### 4.5 `organization_key_dates` — shape 1
+
+| column | type | notes |
+|---|---|---|
+| id | uuid pk | |
+| org_id | uuid not null | |
+| label | varchar(200) not null | |
+| kind | enum `org_key_date_kind` | `insurance_renewal \| vendor_contract_end \| compliance_deadline \| audit \| other` |
+| date | date not null | |
+| recurs_annually | bool not null default false | |
+| remind_days_before | int null | null = no reminder |
+| owner_user_id | uuid null | reminder ticket assignee |
+| reminded_for_date | date null | dedupe by identity **and** the date the reminder was for |
+| reminder_ticket_id | uuid null | composite FK to tickets deferrable, `ON DELETE SET NULL` |
+| portal_visible | bool not null default false | |
+| notes | text | |
+| created_at, updated_at | | |
+
+Contract end dates are not copied; the read model unions `contracts.end_date` for
+contracts whose `end_date >= today` and status not in (`draft`, `cancelled`).
+
+### 4.6 `deliverable_template_sets`, `deliverable_template_items` — dual-axis, `org_id XOR partner_id`
+
+Sets: `id, org_id null, partner_id null, name, description, created_by, timestamps`,
+`<table>_one_owner_chk`, unique `(partner_id, name)` and `(org_id, name)`. Items:
+`id, set_id (composite with owner columns), org_id null, partner_id null (copied
+from the set, same XOR check), name, description, cadence, lead_days, grace_days,
+artifact_required, completion_mode, sort_order`. One dual-axis `FOR ALL` policy per
+table plus the separate SELECT-only partner-wide branch (template
+`2026-10-05-110000-config-policy-partner-wide-select.sql`). Writes to partner-wide
+rows gate on `canManagePartnerWidePolicies(auth)`. "Apply set" targets an org (and
+optionally a contract) and copies items into `service_deliverables` with
+`anchor_due_date` = end of the first full period after `effective_from`.
+
+### 4.7 `portal_branding` columns
+
+`enable_service boolean NOT NULL DEFAULT false`, `enable_documents boolean NOT NULL
+DEFAULT false`; added to `PORTAL_VISIBILITY_FLAG_KEYS`
+(`services/portal/portalFlags.ts`), gated with `createPortalFeatureGateStrict`,
+and classified `included` in `portal_branding`'s export-policy entry (the column
+rule).
+
+### 4.8 `tickets.work_kind`
+
+`work_kind ticket_work_kind NOT NULL DEFAULT 'support'`, enum `support \|
+deliverable \| project_task` (the third value reserved for Projects, unused in this
+feature). Set to `deliverable` by the sweep and by the key-date reminder. Consumers
+in this feature: SLA defaults are not applied when `work_kind <> 'support'`; the
+ticket list gains a filter; portal ticket lists exclude non-`support` kinds (the
+portal shows delivery records, not the tickets behind them). Classified `included`
+in `tickets`' export-policy entry (column rule).
+
+### 4.9 Registration checklist (mechanical, same PR as each migration)
+
+For every table in 4.1 to 4.6:
+
+- RLS enabled + forced + policy in the creating migration. Shape 1 tables are
+  auto-discovered; the two template tables go in `DUAL_AXIS_TENANT_TABLES` and
+  `XOR_OWNERSHIP_DUAL_AXIS_TABLES` in `rls-coverage.integration.test.ts`.
+- `CORE_ORG_CASCADE_DELETE_ORDER` (`services/tenantCascade.ts`), alphabetical by
+  `localeCompare`, children before parents: `service_deliverable_evidence` before
+  `service_deliverable_occurrences` before `service_deliverables`; evidence before
+  `org_documents`; `deliverable_template_items` before `deliverable_template_sets`.
+  Verify the order the comparator actually produces for each prefix pair (the
+  file's own warning near line 368).
+- S3 pre-clear in erasure extended from ticket attachments to `org_documents`.
+- `CORE_TENANT_EXPORT_POLICY` (`services/tenantExportPolicyRegistry.ts`): every
+  column classified; `org_documents.data` → `excludedOpen`; `storage_key` →
+  `included`; `sha256` → `reviewedIncluded`; the two new `portal_branding`
+  columns and `tickets.work_kind` added to their existing entries.
+- `services/orgMergeRegistry.ts`: every new `org_id` table in the plain `repoint`
+  list; `deliverable_template_sets` and `service_deliverables` use
+  `repoint-dedupe` on their org-scoped unique names.
+- No `device_id` anywhere, so no device cascade lists apply.
+- Migration filenames sort after the newest committed migration (as of 2026-09-10
+  that is `2026-10-15-160010-backup-snapshots-layout-manifest.sql`); re-check with
+  `ls apps/api/migrations | sort | tail -1` before committing.
+
+## 5. Scheduler
+
+### 5.1 Job
+
+`deliverable-sweep`, daily, in a new `jobs/deliverableWorker.ts` (same singleton
+Queue/Worker/schedule/initialize shape as `contractWorker.ts`). All date arithmetic
+and the "which occurrences should exist as of today" plan live in a pure module
+`services/recurrence.ts` (D13) with no database or queue imports; the worker only
+applies the plan. Cron allocated in
+`jobs/scheduleRegistry.ts` on the daily-tier lane (minute ≡ 3 mod 5; the plan picks
+a free slot and `scheduleRegistry.contract.test.ts` enforces it). Runs under
+`withSystemDbAccessContext`, honours `buildAutomationEligibleOrgPredicate`, one
+transaction per deliverable, failures logged with ids and skipped.
+
+### 5.2 Eligibility
+
+A deliverable is swept when `active` and `effective_from <= today` and
+(`effective_until IS NULL OR effective_until >= today`). Contract status is **not**
+consulted; the contract lifecycle writes `effective_until` instead (§5.4).
+
+### 5.3 Steps per deliverable
+
+1. **Materialize.** Compute every due date `d` from the anchor with `d <= today +
+   lead_days`, `d >= effective_from`, and `d > latest materialized due_at`. Insert
+   each missing occurrence as `scheduled` (`UNIQUE (deliverable_id, period_start)`
+   makes re-runs no-ops), capped at 12 per run. Occurrences whose `d + grace_days <
+   today` are inserted directly as `missed`, with no ticket: a sweep that was down
+   for weeks produces an honest history, not a burst of tickets.
+2. **Open.** For each `scheduled` occurrence with `due_at − lead_days <= today`, in
+   one transaction: create the ticket through `ticketService.createTicket`
+   (`source='api'`, `work_kind='deliverable'`, subject `"<name_snapshot> — <period
+   label>"`, description from the deliverable, `due_date = due_at`, `assigned_to =
+   owner_user_id`, `category_id = ticket_category_id`, SLA minutes explicitly
+   null), set `ticket_id`, set status `open`. If ticket creation is refused
+   (Service Management mode `off`) the occurrence still becomes `open` with
+   `ticket_id NULL` and is fulfilled manually; one warning per org per day.
+3. **Auto-evidence.** For each `open` occurrence whose deliverable has
+   `auto_evidence_report_id`, `due_at <= today`, and no evidence row of kind
+   `report_run` created by the sweep: generate a run of that report for the org
+   through the existing report runner (`requested_by_kind = 'system'`, added to the
+   enum if absent), insert the evidence row, and post an internal ticket comment
+   "Report attached, review and resolve". Generation failure logs and leaves the
+   occurrence untouched for the next run; the technician can still deliver
+   manually. Never generated more than once per occurrence.
+4. **Miss.** `open` or `awaiting_evidence` with `due_at + grace_days < today` →
+   `missed`. Ticket left alone.
+5. **Key dates.** Rows with `remind_days_before` set, `date − remind_days_before <=
+   today` and `reminded_for_date IS DISTINCT FROM date`: create a reminder ticket
+   (no SLA, assignee `owner_user_id`) and stamp `reminded_for_date`,
+   `reminder_ticket_id`. Rows with `recurs_annually` and `date < today`: `date +=
+   1 year`.
+
+### 5.4 Contract lifecycle hook
+
+On `contract.cancelled` (existing contract event) every deliverable with that
+`contract_id` and `effective_until IS NULL` gets `effective_until = cancellation
+date`. `paused` does not touch deliverables (billing pause is not a service pause;
+the MSP edits `effective_until` or `active` if it is). `expired` is ignored (D1).
+
+## 6. Ticket integration
+
+- **Creation**: only through `ticketService.createTicket`, so numbering, events,
+  the Service Management `off` refusal and outbox publication apply.
+- **Status subscriber**: `deliverable-status` registered in
+  `services/eventSubscribers.ts` for `ticket.status_changed` (lazy import, same
+  pattern as `ai-agent-ticket-helpdesk`). If an occurrence has that `ticket_id`:
+  - `to ∈ {resolved, closed}` and `completion_mode = on_ticket_resolve`: if
+    `artifact_required` and no evidence row → `awaiting_evidence`; else →
+    `delivered` (`delivered_by` = actor when present, `delivery_note` = the
+    ticket's resolution note when present).
+  - `to ∈ {resolved, closed}` and `completion_mode = explicit`: no change; the MSP
+    must press Deliver. The occurrence drawer shows "ticket resolved, delivery not
+    recorded".
+  - `to ∈ {new, open, pending, on_hold}` from `delivered` reached via the ticket:
+    → `open`, delivery fields cleared. An explicit UI delivery is never undone by
+    a ticket reopen.
+  - Idempotent; the same event twice is a no-op.
+- **Ticket move between orgs** (`move_org`): blocked with 409
+  `DELIVERABLE_TICKET_PINNED` when the ticket is linked to an occurrence; the guard
+  sits next to the existing move-org checks (`ticketOrgMoveLockOrder.ts`).
+- **Ticket soft delete** leaves the occurrence and its link; hard delete nulls
+  `ticket_id`.
+
+## 7. Delivery and evidence
+
+Actions (REST + MCP + UI):
+
+- **Deliver** `{ note?, evidence?: [{documentUpload | documentId | reportRunId}] }`:
+  when `artifact_required` and the occurrence has no evidence after this call →
+  400 `EVIDENCE_REQUIRED`. Uploaded evidence creates an `org_documents` row with
+  `category='evidence'` and `portal_visible` copied from the deliverable.
+- **Add evidence** on any non-waived occurrence; on `awaiting_evidence` this
+  completes delivery.
+- **Waive** `{ reason }` records actor and reason.
+- **Reopen** clears delivery or waiver fields.
+- **Reschedule** `{ dueAt }` moves `due_at`; `original_due_at` is kept and the
+  portal shows "rescheduled".
+
+Effort is not stored on occurrences. Time spent on a deliverable is the time logged
+against its ticket (`ticket_time_entries`), which is the same source a future
+Projects module will use for budget vs actual. No separate effort field, ever.
+
+## 8. Portal surface
+
+Flags fail closed. Routes follow the portal auth, CSRF, ETag and
+`private, max-age=30` pattern of `dashboard.ts`.
+
+- `GET /portal/service` → `{ groups: [{ source: 'contract' | 'standalone',
+  contract: {id, name} | null, deliverables: [{ id, name, description, cadence,
+  artifactRequired, lastDelivered: { at, late, note, evidence: [...] } | null,
+  nextDue: date | null, status: 'on_track' | 'due_soon' | 'late' | 'missed' }] }],
+  keyDates: [{ source: 'key_date' | 'contract_end', ... }] }` for `portal_visible`
+  deliverables in their effective window plus `portal_visible` key dates and
+  contract end dates. The `source` discriminators exist so a Projects module can add
+  `'project'` and `'project_milestone'` arms to the same page rather than a second
+  one.
+- `GET /portal/service/:deliverableId/occurrences` → last 24 occurrences: status,
+  dates, note, evidence links.
+- `GET /portal/documents` → chain heads with `portal_visible = true`, grouped by
+  category. `GET /portal/documents/:id/content` streams bytes with
+  `contentDispositionFor`; never a presigned URL.
+- Dashboard tile `serviceTile`: delivered on time / late / missed over the last 90
+  days and the next due item; added to `dashboardForOrg`'s `Promise.all`.
+
+Publication rules (D10):
+
+- The portal never shows or links a ticket. It shows the delivery record (date,
+  lateness, note) and evidence.
+- Document evidence appears under `enable_service` when the document is
+  `portal_visible`, regardless of `enable_documents` (which governs the library
+  page only).
+- Report-run evidence appears only when `enable_reports` is on and the report
+  definition is `portal_self_service`; otherwise the record reads "Delivered" with
+  the note.
+- A delivered occurrence with `artifact_required` and no portal-visible evidence
+  shows "Delivered (artifact held by the MSP)". Nothing pretends evidence exists.
+
+Pages: `apps/portal/src/pages/service/index.astro`,
+`apps/portal/src/pages/documents/index.astro`, nav entries gated by the flags.
+All new tables are shape 1, so `breeze_has_org_access(org_id)` is the only policy
+exercised by portal reads. `portalServiceRls.integration.test.ts` forges a
+cross-org read of each route.
+
+## 9. Web UI (MSP)
+
+- Contract detail (`components/contracts/ContractDetail.tsx`): "Deliverables" tab
+  (hash state): table with cadence, next due, last delivered, portal toggle; edit,
+  deactivate, "Apply template set"; occurrence drawer with Deliver (evidence
+  upload or pick), Waive, Reopen, Reschedule, open-ticket link.
+- Org record (`components/organizations/record/`): new `service` tab (every
+  deliverable for the org, contract or not, plus a 90-day upcoming list) and
+  `documents` tab (upload, replace as a superseding version, portal toggle,
+  download), both in `ORG_RECORD_TABS` with `TAB_PERMISSION` entries; key dates
+  card on the overview.
+- Settings: "Deliverable templates" page, partner-wide sets with the "All orgs"
+  badge and create-only ownerScope selector (pattern
+  `components/software/PolicyForm.tsx`); portal settings gain the two toggles.
+- All mutation handlers via `runAction`; new i18n keys in every locale with real
+  translations.
+
+## 10. API surface and MCP tools
+
+REST (Hono):
+
+- `routes/serviceDeliverables.ts`: `GET/POST /orgs/:orgId/deliverables`,
+  `PATCH/DELETE /orgs/:orgId/deliverables/:id`, `POST
+  /orgs/:orgId/deliverables/apply-template`, `GET
+  /orgs/:orgId/deliverables/:id/occurrences`, `POST
+  /orgs/:orgId/deliverables/occurrences/:oId/{deliver|waive|reopen|reschedule}`,
+  `POST/DELETE .../occurrences/:oId/evidence[/:eId]` (multipart or
+  `{ documentId } | { reportRunId }`). `GET /contracts/:id/deliverables` is a
+  filtered view of the org route for the contract tab.
+- `routes/orgs/documents.ts`: `GET/POST /orgs/:orgId/documents` (multipart), `GET
+  .../:id/content`, `PATCH .../:id`, `POST .../:id/replace`, `DELETE .../:id`.
+- `routes/orgs/keyDates.ts`: `GET/POST/PATCH/DELETE /orgs/:orgId/key-dates`.
+- `routes/deliverableTemplates.ts`: sets and items CRUD.
+
+Permissions: deliverables and templates reuse the `contracts` resource; documents
+and key dates get a new `documents` resource (`read`, `write`) in the canonical
+registry `packages/shared/src/constants/permissions.ts` and the role matrix,
+defaulting on for admin and technician roles. The org record tabs gate on
+`contracts:read` (service) and `documents:read` (documents).
+
+MCP tools (`services/aiToolsDeliverables.ts`, registered in the `aiTools.ts` hub):
+`list_deliverables`, `manage_deliverables` (create, update, deactivate,
+apply_template, deliver, waive, reopen, reschedule, link_evidence by document or
+report-run id), `list_org_documents`, `manage_org_documents` (metadata, portal
+visibility, supersede-by-id; no byte upload), `manage_key_dates`. `apply_template`
+is approval-gated (it arms unattended ticket creation); the rest are not.
+
+## 11. Tenancy contract
+
+- Shape 1 for 4.1 to 4.5; dual-axis XOR with the SELECT-only partner branch for 4.6.
+- Every FK to a tenant row is composite with `org_id` and deferrable; `report_runs`
+  is reached through `reports(id, org_id)`.
+- Sweep and subscriber run under `withSystemDbAccessContext` (via
+  `runOutsideDbContext` when reached from a request); worker-created tickets,
+  occurrences and evidence always take the **deliverable's** org.
+- `owner_user_id` and `ticket_category_id` are validated for partner/org access at
+  write time in the service layer.
+- Portal routes run as the portal session's org; no system escalation in any
+  portal read model.
+- Documents stream through the API under RLS; no presigned URLs.
+
+## 12. Error handling
+
+- Sweep: per-deliverable transaction; a failure logs ids and continues (billing
+  sweep pattern); a refused ticket leaves the occurrence `open` without a ticket.
+- Deliver without required evidence → 400 `EVIDENCE_REQUIRED`.
+- Upload over the size cap or outside the MIME allowlist → 413 / 415 with a
+  translated message; storage fault → 503 `STORAGE_UNAVAILABLE`, no row written.
+- Evidence link to a document or report run of another org → 404, never 403.
+- Apply template set where a deliverable name already exists on the target → 409
+  listing the collisions, nothing written.
+- Replace a document that already has a successor → 409 `NOT_HEAD`.
+- Move a deliverable ticket to another org → 409 `DELIVERABLE_TICKET_PINNED`.
+
+## 13. Testing
+
+- Unit (`services/recurrence.ts`): due-date arithmetic (clamped month ends, anchor
+  on the 31st, `one_time`), covered-period boundaries, catch-up materialization
+  plan (cap 12, direct `missed`); worker: auto-evidence once-only,
+  state machine transitions incl. `awaiting_evidence`, subscriber idempotency,
+  evidence badge derivation, template apply anchor computation.
+- Route tests (Vitest + Drizzle mocks) for every new route, including 404-not-403
+  on cross-org ids and `EVIDENCE_REQUIRED`.
+- Integration (real Postgres): `serviceDeliverablesRls.integration.test.ts`
+  (cross-org forge 42501, deferrable re-point under `SET CONSTRAINTS ALL DEFERRED`,
+  template XOR 23514, evidence ownership chain rejects a foreign report run),
+  `deliverableSweep.integration.test.ts` (materialize → open → resolved →
+  `awaiting_evidence` → delivered via a real `ticket.status_changed`; miss after
+  grace; idempotent re-run; downtime catch-up; `off` mode opens without a ticket;
+  cancelled-contract hook; auto-evidence run generated on due date and attached), `portalServiceRls.integration.test.ts`, plus the
+  standing contract suites: `rls-coverage`, `tenantCascade`, `tenant-export-policy`,
+  `tenantExportErasureRoundtrip` (with an S3-backed document),
+  `orgLifecycleFoundations` (merge), `scheduleRegistry.contract.test.ts`.
+- Web: component tests for the tabs and drawer; `no-silent-mutations`; locale
+  coverage. Portal: page tests alongside the existing `*/index.test.ts`.
+
+## 14. Wave split (one PR each)
+
+| Wave | Content | Depends on |
+|---|---|---|
+| W01 | Migrations + schema + registrations for 4.1, 4.2, 4.3 (without `document` kind), 4.5, 4.8 (`tickets.work_kind`); `services/recurrence.ts`; services; REST for deliverables, occurrences (deliver with report-run evidence, waive, reopen, reschedule), key dates; contract Deliverables tab; org record Service tab; key dates card | — |
+| W02 | `deliverableWorker` sweep incl. auto-evidence report generation, `deliverable-status` subscriber, contract-cancelled hook, move-org guard, key-date reminders and roll-over, SLA suppression for non-`support` work kinds, MCP tools for deliverables and key dates | W01 |
+| W03 | `org_documents` migration + blob helper extraction + erasure pre-clear + REST + org record Documents tab + `document` evidence kind + upload-on-deliver + MCP document tools | W01 |
+| W04 | Portal: flags, `/service`, `/documents`, dashboard tile, downloads, publication rules, portal RLS test | W02, W03 |
+| W05 | Template sets (4.6), settings page, apply-to-org/contract, first-customer backfill script (eight deliverables on the Northwind Law org and its Best-plan contract, seeded from its existing tracking tickets; ids supplied at run time, never committed) | W01 |
+
+W03 and W05 run in parallel with W02.
+
+## 15. First use: Northwind Law P.C. (fictional name)
+
+The eight Best deliverables map as: sign-in log review (monthly, artifact
+required), threat detection review (monthly, required), Intune management (monthly
+checkpoint, artifact optional), vulnerability management (monthly, required),
+documentation and configuration audit (quarterly, required), firewall rule review
+(quarterly, required), VPN and access policy management (monthly checkpoint,
+optional), IR runbooks and tabletop (annual, required). `effective_from` = contract
+start (provisional), owner = the account technician, `completion_mode = on_ticket_resolve`.
+Vulnerability management carries `auto_evidence_report_id` pointing at the org's
+vulnerability report definition so each monthly occurrence arrives with the scan
+result attached; a backup-verification deliverable would do the same with the
+backup SLA report.
+Key dates: cyber-insurance renewal, incumbent email-security vendor end date,
+contract term end (from the contract). Portal flags `enable_service` and
+`enable_documents` on after the onboarding documentation set is uploaded.
+
+## 16. Non-goals and known limits
+
+- No customer acknowledgement of delivery; portal read-only.
+- No ICS feed, no full-text search, no document preview.
+- Cadence or anchor changes do not rewrite existing occurrences.
+- Occurrences have no dependencies, phases, estimates or sub-tasks. `one_time` is
+  a contractual one-off (a tabletop, a baseline handover), not project work; when
+  Projects lands, project tasks get their own tables and reuse `org_documents`,
+  `tickets.work_kind`, `services/recurrence.ts` and the portal `source` arms (D14).
+- No generic polymorphic evidence or template tables; one join table per subject
+  type keeps composite-FK tenancy enforcement.
+- Checkpoint deliverables (former "continuous") have a due date but usually no
+  artifact; their on-time metric is the checkpoint, not the underlying work.
+
+## 17. Quorum record (2026-09-10)
+
+Codex gpt-6-astra, `xhigh`, read-only, twelve findings against the Fable draft.
+
+| Codex finding | Verified | Resolution |
+|---|---|---|
+| 1. Contract `active` cannot gate service; `expired` is set right after the final invoice | Yes, `contractService.ts` ~2013 | Adopted: eligibility by `effective_from/until`, contract status ignored (D1, §5.2). |
+| 2. Org-own deliverables, nullable `contract_id` | Yes, `contract_documents.contract_id` nullable precedent | Adopted (D1); renamed `service_deliverables`. |
+| 3. Occurrences justified; snapshot + explicit transaction | Yes | Adopted: `name_snapshot`, one transaction per claim + ticket (§5.3). |
+| 4. Reuse tickets; hook at `changeTicketStatus` | Yes, ~999 | Tickets reused. Hook kept on the event bus subscriber (repo precedent, retried, decoupled) rather than inside `changeTicketStatus`; acceptable because D4 makes the transition advisory, not the record of delivery. Tie-break: Fable. |
+| 5. Closure ≠ delivery; waiver actor; `missed` not terminal | Yes, ~942/967 | Adopted: `completion_mode`, `awaiting_evidence`, waiver fields, `missed → delivered` (D4, §4.2, §6). |
+| 6. SLA clock from `created_at`; `off` mode; occurrences must survive no ticket | Yes, `ticketSlaWorker.ts` ~74 | Adopted: SLA null on sweep tickets; `open` without ticket allowed (§5.3). |
+| 7. Extract storage, org-free keys, extend erasure pre-clear, multi-evidence, exact-version history, chain integrity | Yes, `tenantCascade.ts` ~1111 | Adopted: evidence join table (D6), `UNIQUE (supersedes_document_id)`, pre-clear extended (§4.4, §4.8). |
+| 8. Typed key dates; dedupe by identity + date | Yes | Already `reminded_for_date`; added `owner_user_id`. |
+| 9. Simple cadence; drop undefined `continuous`; define boundaries | Yes, `maintenance.ts` route ~281 | Adopted: `continuous` removed, checkpoint pattern, period/timezone/catch-up defined (D8, §4.1, §5.3). |
+| 10. Secondary refs need `org_id`; ticket move; `report_runs` has no `org_id`; erasure FK | Yes, `reports.ts` ~96, `tenantCascade.ts` ~853 | Adopted: composite FKs everywhere, move blocked, evidence chain through `reports(id, org_id)` with `ON DELETE CASCADE` (§4.3, §6). |
+| 11. Register merge policies; classify new branding columns | Yes | Adopted (§4.7, §4.8). |
+| 12. Portal publication rules; report evidence needs `portal_self_service` | Yes, `reportsSelfService.ts` ~174 | Adopted (D10, §8). |
+| Recommendation: defer ICS and templates | — | ICS deferred (D11). Templates kept as the last wave (D9) because they are the stated reason for the feature and no earlier wave depends on them. |
+
+Post-quorum additions 2026-09-10 (Todd's review): D12 auto-evidence, D13 recurrence
+module, D14 Projects-forward boundaries and `tickets.work_kind` replacing the tag
+(codex finding 4 had flagged the missing discriminator).

--- a/docs/superpowers/specs/billing/2026-09-10-service-deliverables-portal-design.md
+++ b/docs/superpowers/specs/billing/2026-09-10-service-deliverables-portal-design.md
@@ -4,8 +4,8 @@ Status: **approved by Todd 2026-09-10** (after the D12–D14 additions).
 Advisor quorum: Fable position formed, codex gpt-6-astra xhigh read-only review
 received; two disagreements resolved in codex's favour on the evidence, one split
 resolved by tie-break. See "Quorum record" (§17).
-Tracking: to be registered via feature-lifecycle after approval.
-Plan: to be written with `writing-plans` after approval.
+Tracking: LanternOps/breeze#5573 (waves #5574 W01, #5575 W02, #5576 W03, #5577 W04, #5578 W05).
+Plan: `docs/superpowers/plans/billing/2026-09-10-service-deliverables.md` (index, one plan per wave).
 
 ## 1. Problem and goal
 
@@ -87,8 +87,9 @@ Out (v1):
 
 Every composite FK that references an `org_id` column is `DEFERRABLE INITIALLY
 IMMEDIATE` (org merge contract, CLAUDE.md). Dates are calendar dates; "today" in
-the sweep is computed in the partner's configured timezone, falling back to UTC,
-exactly as the billing sweep does (the plan pins the helper).
+the sweep is the UTC calendar date, exactly as the contract billing sweep computes
+it (`contractWorker.ts`; there is no partner-timezone helper in `contractMath.ts`).
+Partner-local due dates are a follow-up if a customer near the date line needs them.
 
 ### 4.1 `service_deliverables` — shape 1 (direct `org_id`)
 


### PR DESCRIPTION
## Summary

Design spec and five wave plans for **service deliverables, org documents and key dates**, with a customer-portal Service scorecard. Tracking: #5573 (waves #5574–#5578).

MSPs sell service tiers whose value is scheduled human work (monthly sign-in log review, quarterly configuration audit, annual tabletop). Contracts bill money but cannot record those obligations, open the work when due, capture the artifact, or show the customer what was delivered. This spec adds:

- `service_deliverables` (org-owned, optional contract link, own effective dates) + materialized `service_deliverable_occurrences` + `service_deliverable_evidence` (join table, DB-enforced ownership through `reports(id, org_id)`)
- `org_documents` library (s3|db dual backend via a blob helper extracted from ticket attachments), `organization_key_dates` (typed), `tickets.work_kind`
- Daily sweep that opens deliverable tickets (no SLA), explicit delivery with a completion policy (`awaiting_evidence` when an artifact is required but missing), auto-evidence report runs
- Partner-wide deliverable template sets (org XOR partner, SELECT-only partner branch)
- Portal `/service` and `/documents` behind two new strict flags; curated delivery records only, never internal tickets

Advisor quorum (codex gpt-6-astra xhigh, read-only) reversed two of the initial positions on verified evidence; the record is in spec §17.

Docs-only: `docs/**` changes, no code. A fictional firm name stands in for the first customer.

## Files

- `docs/superpowers/specs/billing/2026-09-10-service-deliverables-portal-design.md`
- `docs/superpowers/plans/billing/2026-09-10-service-deliverables.md` (index) + `-w01-…` through `-w05-…`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZapbgLz3g2PEHCavYtbcF
