### PR TITLE
fix(backup): manifest size/checksum reflect the uploaded bytes; volatile files are advisory on restore; exclude the run's own journal (#5581)

### DIFF
--- a/agent/internal/backup/backup.go
+++ b/agent/internal/backup/backup.go
@@ -502,20 +502,23 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 	// is an optimization, never worth a world-writable root-owned write.
 	var journal *snapshotJournal
 	var resumedJournal bool
-	// journalDirForExclude is threaded into collectBackupFilesFromPaths below
-	// so the walker never backs up this run's own checkpoint-journal files
-	// (or another run's, sharing the same directory) as ordinary content —
-	// see collectBackupFilesFromPaths's journalDir doc comment and #5581. Set
-	// whenever a secure journal directory resolved, even if opening the
-	// journal itself failed (the directory can still hold OTHER journal
-	// files, e.g. from a concurrent run with a different destination
-	// identity); left empty only when resolveJournalDir found nowhere secure
+	// journalDirsForExclude is threaded into collectBackupFilesFromPaths
+	// below so the walker never backs up this run's own checkpoint-journal
+	// files (or another run's, sharing the same directory) as ordinary
+	// content — see collectBackupFilesFromPaths's journalDirs doc comment
+	// and #5581. Holds the LITERAL journal directory whenever one resolved,
+	// even if opening the journal itself failed (the directory can still
+	// hold OTHER journal files, e.g. from a concurrent run with a different
+	// destination identity); a second, VSS-shadow-rewritten form is
+	// appended below once vssSession is known (a VSS run's walker only ever
+	// visits shadow-copy paths, never the literal ones — see that block's
+	// comment). Left nil only when resolveJournalDir found nowhere secure
 	// to journal at all, matching "no journal, nothing to exclude".
-	var journalDirForExclude string
+	var journalDirsForExclude []string
 	if journalDir, ok := resolveJournalDir(m.GetStagingDir()); !ok {
 		log.Warn("no secure checkpoint journal directory available, proceeding without resume support")
 	} else {
-		journalDirForExclude = journalDir
+		journalDirsForExclude = append(journalDirsForExclude, journalDir)
 		var journalErr error
 		journal, resumedJournal, journalErr = openSnapshotJournal(journalDir, backupIdentity(m.config.Provider, m.config.Paths), journalMaxAge)
 		if journalErr != nil {
@@ -783,6 +786,34 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 		sourceLiveness = newShadowRootLiveness(vssSession.ShadowPaths)
 		var unmappedIdx []int
 		backupPaths, unmappedIdx = rewritePathsForVSS(backupPaths, vssSession.ShadowPaths, systemStateStagingIdx)
+
+		// journalDirsForExclude was computed from the LITERAL staging dir
+		// above, before this rewrite — but the walker below only ever
+		// visits the REWRITTEN backupPaths on a VSS run, never the literal
+		// ones. That alone would make the hard-exclude silently never fire
+		// under VSS: VSS snapshots the WHOLE volume, so the shadow copy
+		// also contains whatever the journal directory held at the instant
+		// of the snapshot (a real, uploadable file, not a hypothetical) —
+		// only the whole-machine preset's glob exclude would be left
+		// protecting a whole-machine run, and nothing would protect a
+		// custom path selection (review finding on #5583). Run every
+		// already-collected literal journal dir through the SAME
+		// volume→shadow substitution rewritePathsForVSS just used, and add
+		// whichever ones actually mapped to a shadow root (a dir on a
+		// volume VSS couldn't shadow is unmapped — matches
+		// rewritePathsForVSS's own live-volume fallback, nothing to add).
+		literalJournalDirs := journalDirsForExclude
+		rewrittenJournalDirs, unmappedJournalIdx := rewritePathsForVSS(literalJournalDirs, vssSession.ShadowPaths, noStagingIdx)
+		unmappedJournalSet := make(map[int]struct{}, len(unmappedJournalIdx))
+		for _, idx := range unmappedJournalIdx {
+			unmappedJournalSet[idx] = struct{}{}
+		}
+		for i, shadowed := range rewrittenJournalDirs {
+			if _, unmapped := unmappedJournalSet[i]; unmapped {
+				continue
+			}
+			journalDirsForExclude = append(journalDirsForExclude, shadowed)
+		}
 		if liveReads := reportableLiveReads(backupPaths, unmappedIdx, systemStateStagingIdx); len(liveReads) > 0 {
 			shadowedVolumes := make([]string, 0, len(vssSession.ShadowPaths))
 			for vol := range vssSession.ShadowPaths {
@@ -826,7 +857,7 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 	// timing in snapshot.go (#2790).
 	log.Info("scanning backup paths", "jobId", job.ID, "pathCount", len(backupPaths))
 	scanStart := time.Now()
-	files, scanErr := m.collectBackupFilesFromPaths(runCtx, backupPaths, newExcludeMatcher(excludes), journalDirForExclude)
+	files, scanErr := m.collectBackupFilesFromPaths(runCtx, backupPaths, newExcludeMatcher(excludes), journalDirsForExclude)
 	if scanErr != nil {
 		if errors.Is(scanErr, errBackupStopped) {
 			return stopBackupRun()
@@ -1453,12 +1484,12 @@ func dirNeedsEntry(info os.FileInfo, owner *FileOwner, empty bool) bool {
 }
 
 func (m *BackupManager) collectBackupFiles() ([]backupFile, error) {
-	return m.collectBackupFilesFromPaths(context.Background(), m.config.Paths, newExcludeMatcher(m.config.Excludes), "")
+	return m.collectBackupFilesFromPaths(context.Background(), m.config.Paths, newExcludeMatcher(m.config.Excludes), nil)
 }
 
 // isWithinDir reports whether path IS dir, or lies somewhere inside it.
 // Used to hard-exclude this run's own checkpoint-journal directory from the
-// backup walk (see collectBackupFilesFromPaths's journalDir parameter)
+// backup walk (see collectBackupFilesFromPaths's journalDirs parameter)
 // independent of any user-configured exclude pattern: a live journal file
 // growing while the walker is mid-scan is exactly the #5581 failure mode,
 // and this guard must keep working even when an operator edits or removes
@@ -1483,13 +1514,34 @@ func isWithinDir(path, dir string) bool {
 	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
-// journalDir, when non-empty, is this run's own checkpoint-journal
-// directory (see resolveJournalDir) — its subtree is skipped entirely
-// regardless of excl, so the walker never captures the very journal file
-// this run is writing to (or another run's, in the same directory) as
-// ordinary backup content. Empty for callers with no journal context (the
-// collectBackupFiles() test/legacy helper above).
-func (m *BackupManager) collectBackupFilesFromPaths(ctx context.Context, paths []string, excl *excludeMatcher, journalDir string) ([]backupFile, error) {
+// isWithinAnyDir reports whether path is within (or equal to) any of dirs —
+// see isWithinDir. collectBackupFilesFromPaths passes both the journal's
+// literal directory and, on a VSS run, its shadow-copy-rewritten form
+// (#5583 review fix): the walker only ever visits ONE of those two forms
+// depending on whether VSS is active, but journalDirs carries both
+// unconditionally, so this must check every candidate rather than just the
+// first.
+func isWithinAnyDir(path string, dirs []string) bool {
+	for _, dir := range dirs {
+		if isWithinDir(path, dir) {
+			return true
+		}
+	}
+	return false
+}
+
+// journalDirs, when non-empty, are every path form that identifies this
+// run's own checkpoint-journal directory: the literal directory (see
+// resolveJournalDir) and, on a VSS run, its shadow-copy-rewritten form —
+// the walker below visits the REWRITTEN backupPaths under VSS, never the
+// literal ones, and VSS snapshots the whole volume, so the shadow copy also
+// contains whatever the journal directory held at snapshot time (#5583).
+// Every directory's subtree is skipped entirely regardless of excl, so the
+// walker never captures the very journal file this run is writing to (or
+// another run's, in the same directory) as ordinary backup content. Empty
+// for callers with no journal context (the collectBackupFiles() test/legacy
+// helper above).
+func (m *BackupManager) collectBackupFilesFromPaths(ctx context.Context, paths []string, excl *excludeMatcher, journalDirs []string) ([]backupFile, error) {
 	var files []backupFile
 	var errs []error
 	seen := make(map[string]struct{})
@@ -1515,7 +1567,7 @@ func (m *BackupManager) collectBackupFilesFromPaths(ctx context.Context, paths [
 				continue
 			}
 			relPath := filepath.Base(cleanRoot)
-			if excl.matches(relPath) || isWithinDir(cleanRoot, journalDir) {
+			if excl.matches(relPath) || isWithinAnyDir(cleanRoot, journalDirs) {
 				continue
 			}
 			snapshotPath := filepath.ToSlash(filepath.Join(rootLabel, relPath))
@@ -1571,7 +1623,7 @@ func (m *BackupManager) collectBackupFilesFromPaths(ctx context.Context, paths [
 				// rides the same fs.SkipDir path so the whole checkpoint
 				// journal subtree — not just files that happen to match a
 				// glob — is pruned in one step (#5581).
-				if (excl != nil && excl.matches(slashRel)) || isWithinDir(path, journalDir) {
+				if (excl != nil && excl.matches(slashRel)) || isWithinAnyDir(path, journalDirs) {
 					return fs.SkipDir
 				}
 				dirs = append(dirs, walkedDir{path: path, rel: slashRel})
@@ -1579,7 +1631,7 @@ func (m *BackupManager) collectBackupFilesFromPaths(ctx context.Context, paths [
 				return nil
 			}
 			childCount[filepath.Dir(path)]++
-			if excl.matches(slashRel) || isWithinDir(path, journalDir) {
+			if excl.matches(slashRel) || isWithinAnyDir(path, journalDirs) {
 				return nil
 			}
 			snapshotPath := filepath.ToSlash(filepath.Join(rootLabel, relPath))

--- a/agent/internal/backup/backup.go
+++ b/agent/internal/backup/backup.go
@@ -502,9 +502,20 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 	// is an optimization, never worth a world-writable root-owned write.
 	var journal *snapshotJournal
 	var resumedJournal bool
+	// journalDirForExclude is threaded into collectBackupFilesFromPaths below
+	// so the walker never backs up this run's own checkpoint-journal files
+	// (or another run's, sharing the same directory) as ordinary content —
+	// see collectBackupFilesFromPaths's journalDir doc comment and #5581. Set
+	// whenever a secure journal directory resolved, even if opening the
+	// journal itself failed (the directory can still hold OTHER journal
+	// files, e.g. from a concurrent run with a different destination
+	// identity); left empty only when resolveJournalDir found nowhere secure
+	// to journal at all, matching "no journal, nothing to exclude".
+	var journalDirForExclude string
 	if journalDir, ok := resolveJournalDir(m.GetStagingDir()); !ok {
 		log.Warn("no secure checkpoint journal directory available, proceeding without resume support")
 	} else {
+		journalDirForExclude = journalDir
 		var journalErr error
 		journal, resumedJournal, journalErr = openSnapshotJournal(journalDir, backupIdentity(m.config.Provider, m.config.Paths), journalMaxAge)
 		if journalErr != nil {
@@ -815,7 +826,7 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 	// timing in snapshot.go (#2790).
 	log.Info("scanning backup paths", "jobId", job.ID, "pathCount", len(backupPaths))
 	scanStart := time.Now()
-	files, scanErr := m.collectBackupFilesFromPaths(runCtx, backupPaths, newExcludeMatcher(excludes))
+	files, scanErr := m.collectBackupFilesFromPaths(runCtx, backupPaths, newExcludeMatcher(excludes), journalDirForExclude)
 	if scanErr != nil {
 		if errors.Is(scanErr, errBackupStopped) {
 			return stopBackupRun()
@@ -1121,6 +1132,17 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 		failureWarning := summarizeUploadFailures(snapshot.UploadFailures, len(files))
 		appendWarning(job, failureWarning)
 		log.Warn("snapshot completed with upload failures", "warning", failureWarning, "errorCount", job.ErrorCount)
+	}
+
+	// Volatile files (#5581): kept changing while being backed up, so their
+	// manifest entry describes the last pre-upload measurement rather than
+	// any single instant an observer could point to. Not an error (the
+	// files ARE backed up, and restore/verify treat a mismatch on them as
+	// advisory) — surfaced as a Warning only, no ErrorCount contribution.
+	if snapshot != nil && snapshot.VolatileFiles > 0 {
+		volatileWarning := fmt.Sprintf("%d file(s) were modified while being backed up (recorded as volatile)", snapshot.VolatileFiles)
+		appendWarning(job, volatileWarning)
+		log.Warn("snapshot completed with volatile files", "warning", volatileWarning, "volatileFiles", snapshot.VolatileFiles)
 	}
 
 	// Collection-phase (scan) errors — permission-denied files, walk failures,
@@ -1431,10 +1453,43 @@ func dirNeedsEntry(info os.FileInfo, owner *FileOwner, empty bool) bool {
 }
 
 func (m *BackupManager) collectBackupFiles() ([]backupFile, error) {
-	return m.collectBackupFilesFromPaths(context.Background(), m.config.Paths, newExcludeMatcher(m.config.Excludes))
+	return m.collectBackupFilesFromPaths(context.Background(), m.config.Paths, newExcludeMatcher(m.config.Excludes), "")
 }
 
-func (m *BackupManager) collectBackupFilesFromPaths(ctx context.Context, paths []string, excl *excludeMatcher) ([]backupFile, error) {
+// isWithinDir reports whether path IS dir, or lies somewhere inside it.
+// Used to hard-exclude this run's own checkpoint-journal directory from the
+// backup walk (see collectBackupFilesFromPaths's journalDir parameter)
+// independent of any user-configured exclude pattern: a live journal file
+// growing while the walker is mid-scan is exactly the #5581 failure mode,
+// and this guard must keep working even when an operator edits or removes
+// the whole-machine preset excludes that also target this directory
+// (apps/web/.../backupTabPresets.ts) by name. An unresolvable relative path
+// (different volumes on Windows, etc.) is treated as "not within" — the
+// same fail-open default filepath.Rel errors already get everywhere else in
+// this file.
+func isWithinDir(path, dir string) bool {
+	if dir == "" {
+		return false
+	}
+	path = filepath.Clean(path)
+	dir = filepath.Clean(dir)
+	if path == dir {
+		return true
+	}
+	rel, err := filepath.Rel(dir, path)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+// journalDir, when non-empty, is this run's own checkpoint-journal
+// directory (see resolveJournalDir) — its subtree is skipped entirely
+// regardless of excl, so the walker never captures the very journal file
+// this run is writing to (or another run's, in the same directory) as
+// ordinary backup content. Empty for callers with no journal context (the
+// collectBackupFiles() test/legacy helper above).
+func (m *BackupManager) collectBackupFilesFromPaths(ctx context.Context, paths []string, excl *excludeMatcher, journalDir string) ([]backupFile, error) {
 	var files []backupFile
 	var errs []error
 	seen := make(map[string]struct{})
@@ -1460,7 +1515,7 @@ func (m *BackupManager) collectBackupFilesFromPaths(ctx context.Context, paths [
 				continue
 			}
 			relPath := filepath.Base(cleanRoot)
-			if excl.matches(relPath) {
+			if excl.matches(relPath) || isWithinDir(cleanRoot, journalDir) {
 				continue
 			}
 			snapshotPath := filepath.ToSlash(filepath.Join(rootLabel, relPath))
@@ -1512,8 +1567,11 @@ func (m *BackupManager) collectBackupFilesFromPaths(ctx context.Context, paths [
 					return nil
 				}
 				// An excluded directory is skipped entirely (fs.SkipDir), not
-				// just its immediate files (#2418).
-				if excl != nil && excl.matches(slashRel) {
+				// just its immediate files (#2418). The journal-dir check
+				// rides the same fs.SkipDir path so the whole checkpoint
+				// journal subtree — not just files that happen to match a
+				// glob — is pruned in one step (#5581).
+				if (excl != nil && excl.matches(slashRel)) || isWithinDir(path, journalDir) {
 					return fs.SkipDir
 				}
 				dirs = append(dirs, walkedDir{path: path, rel: slashRel})
@@ -1521,7 +1579,7 @@ func (m *BackupManager) collectBackupFilesFromPaths(ctx context.Context, paths [
 				return nil
 			}
 			childCount[filepath.Dir(path)]++
-			if excl.matches(slashRel) {
+			if excl.matches(slashRel) || isWithinDir(path, journalDir) {
 				return nil
 			}
 			snapshotPath := filepath.ToSlash(filepath.Join(rootLabel, relPath))

--- a/agent/internal/backup/backup_collect_test.go
+++ b/agent/internal/backup/backup_collect_test.go
@@ -285,7 +285,7 @@ func TestCollectBackupFiles_FidelityEntries(t *testing.T) {
 	mk("var/spool/cron/root", 0o600)
 
 	mgr := NewBackupManager(BackupConfig{Paths: []string{root}})
-	files, err := mgr.collectBackupFilesFromPaths(context.Background(), []string{root}, nil, "")
+	files, err := mgr.collectBackupFilesFromPaths(context.Background(), []string{root}, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/agent/internal/backup/backup_collect_test.go
+++ b/agent/internal/backup/backup_collect_test.go
@@ -285,7 +285,7 @@ func TestCollectBackupFiles_FidelityEntries(t *testing.T) {
 	mk("var/spool/cron/root", 0o600)
 
 	mgr := NewBackupManager(BackupConfig{Paths: []string{root}})
-	files, err := mgr.collectBackupFilesFromPaths(context.Background(), []string{root}, nil)
+	files, err := mgr.collectBackupFilesFromPaths(context.Background(), []string{root}, nil, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/agent/internal/backup/backup_test.go
+++ b/agent/internal/backup/backup_test.go
@@ -239,6 +239,52 @@ func TestRunBackupContext_StopPreservesRemotePrefixAndJournal(t *testing.T) {
 	}
 }
 
+// TestRunBackupContext_ExcludesOwnCheckpointJournal proves #5581's third
+// fix directly through the full manager wiring: a run whose configured
+// backup path is an ANCESTOR of its own checkpoint-journal directory
+// (StagingDir) must never upload the journal file it is itself writing to
+// as ordinary backup content — that file grows across the run by
+// construction (Record appends an entry per uploaded file), which is
+// exactly the #5581 "manifest describes stale bytes" failure mode, and it
+// is the agent's own internal state, not anything the operator asked to
+// back up.
+func TestRunBackupContext_ExcludesOwnCheckpointJournal(t *testing.T) {
+	provider := newMockProvider()
+	dataDir := t.TempDir()
+	journalDir := pathpkg.Join(dataDir, "backup-journal")
+	if err := os.MkdirAll(journalDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	createTempFile(t, dataDir, "real.txt", "keep me")
+	// Seed a PRE-EXISTING journal file under journalDir (a different
+	// destination identity, so this run's own openSnapshotJournal call
+	// leaves it untouched) — this run's own journal file is created,
+	// written to, and then DELETED again by journal.Complete() on a
+	// successful run, so asserting against it would only prove "the file
+	// happened not to exist by the time we looked," not that the walker
+	// actually skips the directory. This seeded file survives the whole
+	// run and gives the test something durable to catch a regression with.
+	createTempFile(t, journalDir, "backup-journal-deadbeefdeadbeef.jsonl", "{\"snapshotId\":\"stale\"}\n")
+
+	mgr := NewBackupManager(BackupConfig{Provider: provider, Paths: []string{dataDir}, StagingDir: journalDir})
+
+	job, err := mgr.RunBackupContext(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("RunBackupContext failed: %v", err)
+	}
+	if job.Snapshot == nil {
+		t.Fatal("expected a snapshot")
+	}
+	if len(job.Snapshot.Files) != 1 || job.Snapshot.Files[0].SourcePath != pathpkg.Join(dataDir, "real.txt") {
+		t.Fatalf("expected only real.txt in the snapshot, got %+v", job.Snapshot.Files)
+	}
+	for _, call := range provider.uploadCalls {
+		if strings.Contains(call.localPath, "backup-journal") {
+			t.Errorf("must never upload a file from the checkpoint-journal directory, got upload of %q", call.localPath)
+		}
+	}
+}
+
 // TestRunBackupContext_StaleJournalDiscardedWithoutRemoteCleanup proves the
 // D18 §3.5 fix directly: a journal older than journalMaxAge is discarded
 // and the run proceeds fresh with a brand new snapshot ID, but the STALE

--- a/agent/internal/backup/exclude_test.go
+++ b/agent/internal/backup/exclude_test.go
@@ -237,7 +237,7 @@ func TestCollectBackupFilesFromPaths_PerRunExcludesOverrideConfig(t *testing.T) 
 
 	// Per-run override: exclude *.tmp instead (as backup_run payload would).
 	files, err := mgr.collectBackupFilesFromPaths(
-		t.Context(), []string{root}, newExcludeMatcher([]string{"*.tmp"}), "",
+		t.Context(), []string{root}, newExcludeMatcher([]string{"*.tmp"}), nil,
 	)
 	if err != nil {
 		t.Fatalf("collectBackupFilesFromPaths failed: %v", err)

--- a/agent/internal/backup/exclude_test.go
+++ b/agent/internal/backup/exclude_test.go
@@ -237,7 +237,7 @@ func TestCollectBackupFilesFromPaths_PerRunExcludesOverrideConfig(t *testing.T) 
 
 	// Per-run override: exclude *.tmp instead (as backup_run payload would).
 	files, err := mgr.collectBackupFilesFromPaths(
-		t.Context(), []string{root}, newExcludeMatcher([]string{"*.tmp"}),
+		t.Context(), []string{root}, newExcludeMatcher([]string{"*.tmp"}), "",
 	)
 	if err != nil {
 		t.Fatalf("collectBackupFilesFromPaths failed: %v", err)

--- a/agent/internal/backup/restore.go
+++ b/agent/internal/backup/restore.go
@@ -239,23 +239,42 @@ func RestoreFromSnapshotContext(ctx context.Context, provider providers.BackupPr
 			slog.Warn("failed to stat restored file", "target", targetPath, "error", fmt.Sprint(statErr))
 			continue
 		} else if info.Size() != file.Size {
-			result.FilesFailed++
-			result.FailedFiles = append(result.FailedFiles, displayPath)
-			_ = os.Remove(stagingFile)
-			result.Warnings = append(result.Warnings,
-				fmt.Sprintf("restored %s failed size check: manifest %d, restored %d", displayPath, file.Size, info.Size()))
-			slog.Warn("restored file failed size check",
-				"target", targetPath, "manifestSize", file.Size, "restoredSize", info.Size())
-			continue
+			if file.Volatile {
+				// The source kept changing while it was being backed up
+				// (#5581) — the manifest's Size/Checksum describe the last
+				// pre-upload measurement, not necessarily what a fresh
+				// read of the (still-live) object would show. A mismatch
+				// here is expected, not corruption: warn and restore the
+				// bytes anyway rather than failing the file.
+				result.Warnings = append(result.Warnings,
+					fmt.Sprintf("restored %s: size differs from manifest (manifest %d, restored %d) — file was volatile during backup", displayPath, file.Size, info.Size()))
+				slog.Warn("restored volatile file has a size mismatch (advisory, not a failure)",
+					"target", targetPath, "manifestSize", file.Size, "restoredSize", info.Size())
+			} else {
+				result.FilesFailed++
+				result.FailedFiles = append(result.FailedFiles, displayPath)
+				_ = os.Remove(stagingFile)
+				result.Warnings = append(result.Warnings,
+					fmt.Sprintf("restored %s failed size check: manifest %d, restored %d", displayPath, file.Size, info.Size()))
+				slog.Warn("restored file failed size check",
+					"target", targetPath, "manifestSize", file.Size, "restoredSize", info.Size())
+				continue
+			}
 		}
 		if file.Checksum != "" && !checksumMatches(stagingFile, file.Checksum) {
-			result.FilesFailed++
-			result.FailedFiles = append(result.FailedFiles, displayPath)
-			_ = os.Remove(stagingFile)
-			result.Warnings = append(result.Warnings,
-				fmt.Sprintf("restored %s failed checksum check (manifest %s)", displayPath, file.Checksum))
-			slog.Warn("restored file failed checksum check", "target", targetPath)
-			continue
+			if file.Volatile {
+				result.Warnings = append(result.Warnings,
+					fmt.Sprintf("restored %s: checksum differs from manifest (manifest %s) — file was volatile during backup", displayPath, file.Checksum))
+				slog.Warn("restored volatile file has a checksum mismatch (advisory, not a failure)", "target", targetPath)
+			} else {
+				result.FilesFailed++
+				result.FailedFiles = append(result.FailedFiles, displayPath)
+				_ = os.Remove(stagingFile)
+				result.Warnings = append(result.Warnings,
+					fmt.Sprintf("restored %s failed checksum check (manifest %s)", displayPath, file.Checksum))
+				slog.Warn("restored file failed checksum check", "target", targetPath)
+				continue
+			}
 		}
 
 		// Publish only verified bytes. Linux, macOS and Windows pin the

--- a/agent/internal/backup/restore_test.go
+++ b/agent/internal/backup/restore_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -476,6 +477,95 @@ func TestRestoreFromSnapshot_NoFiles(t *testing.T) {
 	}
 	if len(result.Warnings) == 0 {
 		t.Error("expected warning about no matching files")
+	}
+}
+
+// TestRestoreFromSnapshot_VolatileSizeMismatch_WarnsNotFails proves #5581's
+// restore-side policy: a Volatile manifest entry (the source kept changing
+// while it was backed up) whose restored size disagrees with the manifest
+// is restored anyway, with an advisory warning, not counted as a failure.
+// An ordinary (non-Volatile) mismatch must still fail exactly as before —
+// covered in the same test to prove the fix didn't loosen the check
+// generally, only for entries explicitly marked Volatile.
+func TestRestoreFromSnapshot_VolatileSizeMismatch_WarnsNotFails(t *testing.T) {
+	provider := newMockProvider()
+	snapshotID := "test-snap-volatile"
+	prefix := path.Join(snapshotRootDir, snapshotID)
+
+	// The manifest declares 5 bytes (its last pre-upload measurement) but
+	// the stored object is actually 10 bytes (the file kept growing) —
+	// exactly the drift #5581 makes self-consistent at backup time and
+	// advisory at restore time via Volatile.
+	volatileBackupPath := path.Join(prefix, "files", "volatile.log.gz")
+	provider.files[volatileBackupPath] = []byte("0123456789")
+
+	// A same-shaped mismatch on a NON-volatile entry must still fail —
+	// proves this change didn't loosen size checking generally.
+	staleBackupPath := path.Join(prefix, "files", "stale.txt.gz")
+	provider.files[staleBackupPath] = []byte("0123456789")
+
+	snapshot := &Snapshot{
+		ID:        snapshotID,
+		Timestamp: time.Now().UTC(),
+		Files: []SnapshotFile{
+			{
+				SourcePath: "/data/volatile.log",
+				BackupPath: volatileBackupPath,
+				Size:       5,
+				ModTime:    time.Now().UTC(),
+				Volatile:   true,
+			},
+			{
+				SourcePath: "/data/stale.txt",
+				BackupPath: staleBackupPath,
+				Size:       5,
+				ModTime:    time.Now().UTC(),
+				// Volatile: false (default) — an ordinary manifest entry.
+			},
+		},
+	}
+	snapshot.Size = totalSize(snapshot.Files)
+	storeManifest(t, provider, snapshot)
+
+	cfg := RestoreConfig{
+		SnapshotID: snapshotID,
+		TargetPath: t.TempDir(),
+		WorkRoot:   t.TempDir(),
+	}
+	result, err := RestoreFromSnapshot(provider, cfg, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.FilesFailed != 1 {
+		t.Errorf("FilesFailed = %d, want 1 (only the non-volatile mismatch)", result.FilesFailed)
+	}
+	if result.FilesRestored != 1 {
+		t.Errorf("FilesRestored = %d, want 1 (the volatile entry restores despite the mismatch)", result.FilesRestored)
+	}
+	if len(result.FailedFiles) != 1 || result.FailedFiles[0] != "/data/stale.txt" {
+		t.Errorf("FailedFiles = %v, want only /data/stale.txt", result.FailedFiles)
+	}
+
+	foundVolatileWarning := false
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "/data/volatile.log") && strings.Contains(w, "volatile") {
+			foundVolatileWarning = true
+		}
+	}
+	if !foundVolatileWarning {
+		t.Errorf("expected an advisory warning mentioning the volatile file, got %v", result.Warnings)
+	}
+
+	// The volatile file's bytes on disk must be the ACTUAL restored bytes
+	// (10 bytes), not silently dropped.
+	restoredPath := filepath.Join(cfg.TargetPath, "data", "volatile.log")
+	data, err := os.ReadFile(restoredPath)
+	if err != nil {
+		t.Fatalf("expected the volatile file to be restored to disk: %v", err)
+	}
+	if len(data) != 10 {
+		t.Errorf("restored volatile file is %d bytes, want 10", len(data))
 	}
 }
 

--- a/agent/internal/backup/snapshot.go
+++ b/agent/internal/backup/snapshot.go
@@ -202,6 +202,12 @@ type Snapshot struct {
 	// as a green job with zero errors (an incomplete restore point that looks
 	// complete).
 	UploadFailures []error `json:"-"`
+	// VolatileFiles counts this run's entries recorded with Volatile: true
+	// (see that field). In-memory only, like UploadFailures — RunBackupContext
+	// folds it into a job Warning so a run with volatile files is visible
+	// server-side instead of silently carrying entries whose mismatch checks
+	// are quietly downgraded to warnings on every future restore/verify.
+	VolatileFiles int `json:"-"`
 }
 
 // SnapshotFile captures metadata for a backed up file.
@@ -268,6 +274,18 @@ type SnapshotFile struct {
 	ModeBits uint32 `json:"modeBits,omitempty"`
 	// Owner is nil when unknown (Windows, pre-W02 manifests).
 	Owner *FileOwner `json:"owner,omitempty"`
+	// Volatile is true when the source file kept changing while it was being
+	// backed up (grew/shrank/rewritten between the pre-upload measurement and
+	// the re-upload retry — see reconcileAfterUpload) and Size/Checksum
+	// therefore describe the LAST measurement that was actually uploaded,
+	// not necessarily the file's state at any single instant an observer
+	// could point to. Restore/verify treat a size or checksum mismatch on a
+	// Volatile entry as a warning, not a failed file (#5581) — the file is
+	// inherently a moving target (a live log, the agent's own checkpoint
+	// journal) and the manifest is already self-consistent with what was
+	// uploaded. Omitted (false) for the overwhelming majority of files,
+	// keeping ordinary manifests byte-identical to before this field existed.
+	Volatile bool `json:"volatile,omitempty"`
 }
 
 // HasContent reports whether the entry has an uploaded object at BackupPath.
@@ -646,6 +664,7 @@ func createSnapshotWithProgress(ctx context.Context, provider providers.BackupPr
 	}
 
 	var errs []error
+	var volatileCount int
 
 	var bytesTotal int64
 	for _, file := range files {
@@ -917,6 +936,31 @@ func createSnapshotWithProgress(ctx context.Context, provider providers.BackupPr
 		backupPath := path.Join(prefix, snapshotFilesDir, file.snapshotPath)
 		backupPath = ensureGzipExtension(backupPath)
 
+		// Measure (stat + hash) the source immediately before handing it to
+		// the upload, so the manifest entry can describe the SAME read that
+		// is about to be uploaded rather than a walk-time stat plus a
+		// separate post-upload hash from a third point in time (#5581). A
+		// measurement failure here (source vanished/unreadable since the
+		// walk) is not fatal on its own: fall through with the walk-time
+		// size/modTime and let the upload attempt itself surface (and
+		// classify) the failure the way it always has.
+		//
+		// Only uploadFile.size is adjusted (feeds uploadDeadline below) —
+		// the manifest entry's ModTime stays file.modTime (the walk-time
+		// value, unchanged) even when a measurement is available. The
+		// journal's resume matching (journal.Lookup) keys on that walk-time
+		// (sourcePath, size, modTime) triple; a live-mutating file's
+		// pre-upload modTime would never match on a later resumed run
+		// anyway (the file has moved on again), so there is nothing to gain
+		// by substituting it here — only Size/Checksum need to describe the
+		// uploaded bytes (#5581).
+		pre, preErr := measureBeforeUpload(file.sourcePath)
+		uploadFile := file
+		haveMeasurement := preErr == nil
+		if haveMeasurement {
+			uploadFile.size = pre.size
+		}
+
 		// Log the file we are ABOUT to upload, at debug, before we block on it.
 		// This is the line that makes a wedged backup diagnosable: the deadline
 		// below scales with file size and has no ceiling, so a large file whose
@@ -924,17 +968,17 @@ func createSnapshotWithProgress(ctx context.Context, provider providers.BackupPr
 		// output. Without a start line the last thing in the log is the
 		// previous file's success and there is no way to tell which file is
 		// stuck (#2790, #2798).
-		deadline := uploadDeadline(file.size)
+		deadline := uploadDeadline(uploadFile.size)
 		log.Debug("uploading file",
 			"path", file.sourcePath,
 			"backupPath", backupPath,
-			"bytes", file.size,
+			"bytes", uploadFile.size,
 			"deadlineMs", deadline.Milliseconds(),
 			"snapshotId", snapshot.ID,
 		)
 
 		uploadStart := time.Now()
-		uploadErr := attemptFileUpload(ctx, provider, file, backupPath)
+		uploadErr := attemptFileUpload(ctx, provider, uploadFile, backupPath)
 		if uploadErr != nil && !errors.Is(uploadErr, errBackupStopped) {
 			// Before spending anything else on this failure, make sure the
 			// source we are reading from still exists. If the shadow copy died,
@@ -957,7 +1001,7 @@ func createSnapshotWithProgress(ctx context.Context, provider providers.BackupPr
 				// UploadFailures (and so job.ErrorCount), job carries on.
 				log.Warn("file upload failed permanently, skipping without retry",
 					"path", file.sourcePath,
-					"bytes", file.size,
+					"bytes", uploadFile.size,
 					"elapsedMs", time.Since(uploadStart).Milliseconds(),
 					"reason", reason,
 					"error", uploadErr.Error(),
@@ -986,7 +1030,7 @@ func createSnapshotWithProgress(ctx context.Context, provider providers.BackupPr
 				}
 				log.Warn("file upload failed, retrying once",
 					"path", file.sourcePath,
-					"bytes", file.size,
+					"bytes", uploadFile.size,
 					"elapsedMs", time.Since(uploadStart).Milliseconds(),
 					"deadlineMs", deadline.Milliseconds(),
 					"retryDelayMs", retryDelay.Milliseconds(),
@@ -997,7 +1041,7 @@ func createSnapshotWithProgress(ctx context.Context, provider providers.BackupPr
 				case <-ctx.Done():
 					uploadErr = errBackupStopped
 				case <-time.After(retryDelay):
-					uploadErr = attemptFileUpload(ctx, provider, file, backupPath)
+					uploadErr = attemptFileUpload(ctx, provider, uploadFile, backupPath)
 				}
 			}
 		}
@@ -1021,7 +1065,7 @@ func createSnapshotWithProgress(ctx context.Context, provider providers.BackupPr
 			// shipping, and count it so the summary at the end is trustworthy.
 			log.Warn("file upload failed, skipping file",
 				"path", file.sourcePath,
-				"bytes", file.size,
+				"bytes", uploadFile.size,
 				"elapsedMs", time.Since(uploadStart).Milliseconds(),
 				"failedSoFar", len(errs),
 				"error", uploadErr.Error(),
@@ -1030,54 +1074,89 @@ func createSnapshotWithProgress(ctx context.Context, provider providers.BackupPr
 		}
 		uploadMs := time.Since(uploadStart).Milliseconds()
 
-		// Checksum the source bytes so integrity/test-restore can detect silent
-		// corruption of the stored object. A hash failure here is non-fatal —
-		// the file is still backed up; it just won't carry a checksum (verify
-		// falls back to a size check for it).
-		//
-		// NOTE: this re-reads the source after the upload above. On a host with
-		// no snapshotting (Unix has no VSS), a file that mutates between the
-		// upload read and this hash read yields a checksum that won't match the
-		// stored object, so a later verify raises a false "corruption" alert.
-		// That's the safe direction (a false alarm, not a silent pass) and is
-		// consistent with the pre-existing size-from-collection vs content-from-
-		// upload race. Eliminating it fully requires hashing the bytes as they
-		// stream to the provider (a provider-interface change) — left as future work.
-		// Timed separately from the upload: this is a second full read of the
-		// source file, so on a large file or a slow/network-mounted path it is
-		// a real chunk of wall-clock that produces zero network traffic and
-		// zero progress movement. Without its own timing it looks identical to
-		// a stalled upload from the outside.
-		sumStart := time.Now()
-		checksum, sumErr := sha256File(file.sourcePath)
-		if sumErr != nil {
-			log.Warn("checksum failed, file stored without one",
+		// Determine the manifest's Size/Checksum/Volatile for this entry so
+		// they describe the bytes that were actually uploaded (#5581)
+		// rather than a walk-time stat paired with a separately-timed
+		// post-upload hash. ModTime is deliberately NOT touched here — it
+		// stays file.modTime (the walk-time value) in every case; see the
+		// comment above the pre-measurement for why. The common path
+		// (haveMeasurement) re-stats immediately after the upload and, only
+		// on a mismatch, re-measures and re-uploads once — see
+		// reconcileAfterUpload's doc comment for the full policy, including
+		// what happens if it drifts again.
+		var (
+			finalSize     int64
+			finalChecksum string
+			volatile      bool
+		)
+		if haveMeasurement {
+			sumStart := time.Now()
+			reconciled, isVolatile, reconcileErr := reconcileAfterUpload(ctx, provider, file.sourcePath, backupPath, pre)
+			if reconcileErr != nil {
+				// Only errBackupStopped is ever returned here (a job cancel
+				// during the reconciliation retry) — abort exactly like any
+				// other errBackupStopped in this loop.
+				return abortStopped()
+			}
+			finalSize = reconciled.size
+			finalChecksum = reconciled.checksum
+			volatile = isVolatile
+			if volatile {
+				volatileCount++
+				log.Warn("file was modified while being backed up, recorded as volatile",
+					"path", file.sourcePath,
+					"bytes", finalSize,
+					"snapshotId", snapshot.ID,
+				)
+			}
+			log.Debug("file uploaded",
+				"path", file.sourcePath,
+				"bytes", finalSize,
+				"uploadMs", uploadMs,
+				"checksumMs", time.Since(sumStart).Milliseconds(),
+				"volatile", volatile,
+				"snapshotId", snapshot.ID,
+			)
+		} else {
+			// The pre-upload measurement failed (source vanished/unreadable
+			// right before the upload), yet the upload itself just
+			// succeeded — a narrow race. Fall back to the walk-time size
+			// and a best-effort post-upload hash, matching this package's
+			// behavior before #5581.
+			finalSize = file.size
+			sumStart := time.Now()
+			checksum, sumErr := sha256File(file.sourcePath)
+			if sumErr != nil {
+				log.Warn("checksum failed, file stored without one",
+					"path", file.sourcePath,
+					"bytes", file.size,
+					"error", sumErr.Error(),
+				)
+			}
+			finalChecksum = checksum
+			log.Debug("file uploaded",
 				"path", file.sourcePath,
 				"bytes", file.size,
-				"error", sumErr.Error(),
+				"uploadMs", uploadMs,
+				"checksumMs", time.Since(sumStart).Milliseconds(),
+				"snapshotId", snapshot.ID,
 			)
 		}
-		log.Debug("file uploaded",
-			"path", file.sourcePath,
-			"bytes", file.size,
-			"uploadMs", uploadMs,
-			"checksumMs", time.Since(sumStart).Milliseconds(),
-			"snapshotId", snapshot.ID,
-		)
 
 		entry := SnapshotFile{
 			SourcePath:   file.sourcePath,
 			OriginalPath: file.originalPath,
 			BackupPath:   backupPath,
-			Size:         file.size,
+			Size:         finalSize,
 			ModTime:      file.modTime,
-			Checksum:     checksum,
+			Checksum:     finalChecksum,
 			Mode:         uint32(file.mode.Perm()),
 			ModeBits:     file.modeBits,
 			Owner:        file.owner,
+			Volatile:     volatile,
 		}
 		snapshot.Files = append(snapshot.Files, entry)
-		snapshot.Size += file.size
+		snapshot.Size += entry.Size
 		markDone(1, file.size)
 		emitProgress(false)
 		if journal != nil {
@@ -1110,6 +1189,7 @@ func createSnapshotWithProgress(ctx context.Context, provider providers.BackupPr
 	// silently dropping them here (they used to be returned only when ZERO
 	// files uploaded).
 	snapshot.UploadFailures = errs
+	snapshot.VolatileFiles = volatileCount
 
 	if err := ctx.Err(); err != nil {
 		return abortStopped()
@@ -1445,6 +1525,92 @@ func attemptFileUpload(ctx context.Context, provider providers.BackupProvider, f
 		uploadErr = fmt.Errorf("upload stalled: no completion within %s", deadline)
 	}
 	return uploadErr
+}
+
+// filePreUploadMeasurement is a stat+hash of a source file taken as a single
+// unit, immediately before it is handed to an upload attempt — so
+// size/modTime/checksum all describe the SAME instant, and that instant is
+// as close as possible to the bytes the provider is about to read (see
+// measureBeforeUpload / reconcileAfterUpload, #5581).
+type filePreUploadMeasurement struct {
+	size     int64
+	modTime  time.Time
+	checksum string
+}
+
+// measureBeforeUpload stats and hashes sourcePath as one unit. Providers
+// upload from a path (BackupProvider.Upload(localPath, remotePath)), not a
+// reader, so there is no way to hash the exact bytes as they stream through
+// an in-flight upload without changing that interface; this is the closest
+// approximation available without it — stat+hash right before the upload
+// call, rather than a walk-time stat paired with a post-upload hash from a
+// third point in time (the original bug: two reads, two different instants).
+func measureBeforeUpload(sourcePath string) (filePreUploadMeasurement, error) {
+	info, err := os.Stat(sourcePath)
+	if err != nil {
+		return filePreUploadMeasurement{}, err
+	}
+	checksum, err := sha256File(sourcePath)
+	if err != nil {
+		return filePreUploadMeasurement{}, err
+	}
+	return filePreUploadMeasurement{size: info.Size(), modTime: info.ModTime(), checksum: checksum}, nil
+}
+
+// reconcileAfterUpload re-stats sourcePath immediately after a successful
+// upload and compares it against pre — the stat+hash taken right before that
+// upload began, describing exactly the bytes that were (supposed to be)
+// sent. If the source is unchanged, pre already describes the uploaded
+// object and is returned as-is: no warning, no extra work, the common case.
+//
+// If the source drifted (grew, shrank, or was otherwise modified) during the
+// upload window, the file is re-measured and re-uploaded ONCE so the
+// manifest has a chance to catch up with a fast-moving but eventually-still
+// file. If it drifts again even across that retry, chasing it further would
+// only delay the run against a file that is not going to hold still (a live
+// log, the agent's own checkpoint journal) — the entry is recorded as
+// volatile (return volatile=true) using the LAST pre-upload measurement,
+// which is self-consistent with what backupPath actually holds (that
+// measurement is what the retry's own upload sent).
+//
+// Returns errBackupStopped when ctx is cancelled during the retry — the
+// caller aborts the run exactly as it does for any other errBackupStopped;
+// no other error is returned (a retry upload failure or a vanished source is
+// folded into volatile=true rather than failing the file, since the object
+// already stored at backupPath from the FIRST, successful upload remains a
+// valid — if volatile — restore point).
+func reconcileAfterUpload(ctx context.Context, provider providers.BackupProvider, sourcePath, backupPath string, pre filePreUploadMeasurement) (measurement filePreUploadMeasurement, volatile bool, err error) {
+	post, statErr := os.Stat(sourcePath)
+	if statErr == nil && post.Size() == pre.size && post.ModTime().Equal(pre.modTime) {
+		return pre, false, nil
+	}
+
+	pre2, pre2Err := measureBeforeUpload(sourcePath)
+	if pre2Err != nil {
+		// Can no longer read the source at all (e.g. deleted moments after
+		// the first upload completed). What's already stored at backupPath
+		// came from pre — keep describing that, flagged volatile.
+		return pre, true, nil
+	}
+	reuploadFile := backupFile{sourcePath: sourcePath, size: pre2.size}
+	if uploadErr := attemptFileUpload(ctx, provider, reuploadFile, backupPath); uploadErr != nil {
+		if errors.Is(uploadErr, errBackupStopped) {
+			return pre, true, errBackupStopped
+		}
+		// Re-upload failed outright (destination error, deadline expiry).
+		// backupPath still holds whatever the FIRST upload put there, i.e.
+		// pre — keep describing that, flagged volatile since we now know
+		// the source didn't hold still.
+		return pre, true, nil
+	}
+
+	post2, statErr2 := os.Stat(sourcePath)
+	if statErr2 == nil && post2.Size() == pre2.size && post2.ModTime().Equal(pre2.modTime) {
+		return pre2, false, nil
+	}
+	// Changed again: stop chasing it and record the LAST pre-upload
+	// measurement — pre2, what was actually just re-uploaded — as volatile.
+	return pre2, true, nil
 }
 
 func uploadSnapshotFile(ctx context.Context, provider providers.BackupProvider, localPath, remotePath string) error {

--- a/agent/internal/backup/snapshot_test.go
+++ b/agent/internal/backup/snapshot_test.go
@@ -201,6 +201,161 @@ func TestCreateSnapshot_EmptyFileSlice(t *testing.T) {
 	}
 }
 
+// growOnceProvider wraps mockProvider and, on the first N Upload calls for a
+// specific source path, appends extra bytes to that source file AFTER the
+// (successful) upload lands — simulating a file that keeps changing while it
+// is being backed up (a live log, the agent's own checkpoint journal, #5581).
+// Each grow also advances the file's mtime by a full second so the
+// post-upload os.Stat comparison in reconcileAfterUpload reliably observes a
+// change even on filesystems with 1-second mtime resolution.
+type growOnceProvider struct {
+	*mockProvider
+	growPath string
+	extra    []byte
+	grows    int // number of remaining times to grow growPath on Upload
+
+	mu              sync.Mutex
+	growPathUploads int
+}
+
+func (p *growOnceProvider) Upload(localPath, remotePath string) error {
+	if err := p.mockProvider.Upload(localPath, remotePath); err != nil {
+		return err
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if localPath != p.growPath || p.grows <= 0 {
+		return nil
+	}
+	p.grows--
+	p.growPathUploads++
+	f, err := os.OpenFile(p.growPath, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return nil
+	}
+	_, _ = f.Write(p.extra)
+	_ = f.Close()
+	// Force the mtime forward so a coarse (1s) mtime clock can't make this
+	// growth look like a no-op to reconcileAfterUpload's comparison.
+	future := time.Now().Add(time.Duration(p.growPathUploads) * time.Second)
+	_ = os.Chtimes(p.growPath, future, future)
+	return nil
+}
+
+// TestCreateSnapshot_GrowingFile_ReconciledOnRetry proves #5581's core fix:
+// a file that grows between the pre-upload measurement and the upload
+// itself is re-measured and re-uploaded ONCE, and the manifest entry ends
+// up describing exactly the bytes that landed in that retry — not the
+// walk-time size, and not a checksum read at some other, unrelated instant.
+func TestCreateSnapshot_GrowingFile_ReconciledOnRetry(t *testing.T) {
+	tmpDir := t.TempDir()
+	growPath := createTempFile(t, tmpDir, "growing.log", "start")
+
+	backing := newMockProvider()
+	provider := &growOnceProvider{mockProvider: backing, growPath: growPath, extra: []byte("-MORE"), grows: 1}
+
+	files := []backupFile{
+		{sourcePath: growPath, snapshotPath: "path_0/growing.log", size: 5, modTime: time.Now()},
+	}
+	snapshot, err := CreateSnapshot(provider, files)
+	if err != nil {
+		t.Fatalf("CreateSnapshot failed: %v", err)
+	}
+	if len(snapshot.Files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(snapshot.Files))
+	}
+	entry := snapshot.Files[0]
+	if entry.Volatile {
+		t.Errorf("a file that stabilizes after ONE retry must not be marked Volatile, got %+v", entry)
+	}
+
+	finalContent, err := os.ReadFile(growPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	wantSize := int64(len(finalContent))
+	wantChecksum, err := sha256File(growPath)
+	if err != nil {
+		t.Fatalf("sha256File: %v", err)
+	}
+	if entry.Size != wantSize {
+		t.Errorf("entry.Size = %d, want %d (the grown file's final size)", entry.Size, wantSize)
+	}
+	if entry.Checksum != wantChecksum {
+		t.Errorf("entry.Checksum = %q, want %q (the grown file's final checksum)", entry.Checksum, wantChecksum)
+	}
+
+	// The uploaded OBJECT must itself be wantSize bytes — not just the
+	// manifest's claim — proving Size/Checksum describe the bytes that were
+	// actually stored, the whole point of the fix.
+	uploadedBytes, ok := backing.files[entry.BackupPath]
+	if !ok {
+		t.Fatalf("no object stored at %s", entry.BackupPath)
+	}
+	if int64(len(uploadedBytes)) != wantSize {
+		t.Errorf("stored object is %d bytes, want %d", len(uploadedBytes), wantSize)
+	}
+}
+
+// TestCreateSnapshot_FileChangesTwice_RecordedVolatile proves the other half
+// of #5581's policy: a file that keeps changing even across the single
+// reconciliation retry is not chased forever — it is recorded Volatile with
+// the LAST pre-upload measurement (what the retry itself actually
+// uploaded), and the run carries a warning-worthy volatile count rather than
+// failing the file.
+func TestCreateSnapshot_FileChangesTwice_RecordedVolatile(t *testing.T) {
+	tmpDir := t.TempDir()
+	growPath := createTempFile(t, tmpDir, "growing.log", "start")
+
+	backing := newMockProvider()
+	provider := &growOnceProvider{mockProvider: backing, growPath: growPath, extra: []byte("-MORE"), grows: 2}
+
+	files := []backupFile{
+		{sourcePath: growPath, snapshotPath: "path_0/growing.log", size: 5, modTime: time.Now()},
+	}
+	snapshot, err := CreateSnapshot(provider, files)
+	if err != nil {
+		t.Fatalf("CreateSnapshot failed: %v", err)
+	}
+	if len(snapshot.Files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(snapshot.Files))
+	}
+	entry := snapshot.Files[0]
+	if !entry.Volatile {
+		t.Fatalf("a file that changes again across the retry must be recorded Volatile, got %+v", entry)
+	}
+	if snapshot.VolatileFiles != 1 {
+		t.Errorf("snapshot.VolatileFiles = %d, want 1", snapshot.VolatileFiles)
+	}
+
+	// The entry must describe what the RETRY actually uploaded (the second
+	// upload call for growPath), not the walk-time stat nor the very first
+	// upload's bytes.
+	uploadedBytes, ok := backing.files[entry.BackupPath]
+	if !ok {
+		t.Fatalf("no object stored at %s", entry.BackupPath)
+	}
+	if entry.Size != int64(len(uploadedBytes)) {
+		t.Errorf("entry.Size = %d, want %d (bytes actually stored at BackupPath)", entry.Size, len(uploadedBytes))
+	}
+	gotChecksum := sha256HashBytes(t, uploadedBytes)
+	if entry.Checksum != gotChecksum {
+		t.Errorf("entry.Checksum = %q, want %q (checksum of bytes actually stored)", entry.Checksum, gotChecksum)
+	}
+}
+
+// sha256HashBytes hashes b the same way sha256File hashes a file, for
+// comparing a manifest entry's checksum against in-memory upload bytes.
+func sha256HashBytes(t *testing.T, b []byte) string {
+	t.Helper()
+	tmp := createTempFile(t, t.TempDir(), "hashme", string(b))
+	sum, err := sha256File(tmp)
+	if err != nil {
+		t.Fatalf("sha256File: %v", err)
+	}
+	return sum
+}
+
 // cancelAfterFirstUploadProvider wraps mockProvider and cancels the given
 // CancelFunc right after the FIRST real Upload lands, so an aborted run has
 // something concrete under ITS OWN prefix for the abort cleanup to act on

--- a/agent/internal/backup/verify.go
+++ b/agent/internal/backup/verify.go
@@ -27,7 +27,13 @@ type VerifyResult struct {
 	SizeBytes     int64    `json:"sizeBytes"`
 	DurationMs    int64    `json:"durationMs"`
 	FailedFiles   []string `json:"failedFiles,omitempty"`
-	Error         string   `json:"error,omitempty"`
+	// Warnings carries advisory notes that did not fail a file — currently
+	// only a size/checksum mismatch on a Volatile entry (#5581): the source
+	// kept changing while it was backed up, so the manifest describes the
+	// last pre-upload measurement rather than any single instant, and a
+	// mismatch against it is expected rather than corruption.
+	Warnings []string `json:"warnings,omitempty"`
+	Error    string   `json:"error,omitempty"`
 }
 
 // TestRestoreResult holds the outcome of a test restore operation.
@@ -41,7 +47,10 @@ type TestRestoreResult struct {
 	RestorePath        string   `json:"restorePath"`
 	CleanedUp          bool     `json:"cleanedUp"`
 	FailedFiles        []string `json:"failedFiles,omitempty"`
-	Error              string   `json:"error,omitempty"`
+	// Warnings carries advisory notes that did not fail a file — see
+	// VerifyResult.Warnings.
+	Warnings []string `json:"warnings,omitempty"`
+	Error    string   `json:"error,omitempty"`
 }
 
 // VerifyIntegrity checks a snapshot's manifest and validates each file
@@ -130,21 +139,39 @@ func VerifyIntegrity(provider providers.BackupProvider, snapshotID string) (*Ver
 			continue
 		}
 		if info.Size() != file.Size {
-			os.Remove(tempPath)
-			result.FilesFailed++
-			result.FailedFiles = append(result.FailedFiles, file.BackupPath)
-			log.Warn("size mismatch", "phase", "verify", "backupPath", file.BackupPath,
-				"expectedBytes", file.Size, "actualBytes", info.Size())
-			continue
-		}
-		if file.Checksum != "" {
-			if !checksumMatches(tempPath, file.Checksum) {
+			if file.Volatile {
+				// The source kept changing while it was backed up (#5581):
+				// the manifest's Size describes the last pre-upload
+				// measurement, not necessarily the object's current state.
+				// Advisory only — count the file verified, don't fail it.
+				result.Warnings = append(result.Warnings,
+					fmt.Sprintf("%s: size differs from manifest (manifest %d, actual %d) — file was volatile during backup", file.BackupPath, file.Size, info.Size()))
+				log.Warn("volatile file size mismatch (advisory, not a failure)", "phase", "verify", "backupPath", file.BackupPath,
+					"expectedBytes", file.Size, "actualBytes", info.Size())
+			} else {
 				os.Remove(tempPath)
 				result.FilesFailed++
 				result.FailedFiles = append(result.FailedFiles, file.BackupPath)
-				log.Warn("checksum mismatch", "phase", "verify", "backupPath", file.BackupPath,
-					"expected", file.Checksum)
+				log.Warn("size mismatch", "phase", "verify", "backupPath", file.BackupPath,
+					"expectedBytes", file.Size, "actualBytes", info.Size())
 				continue
+			}
+		}
+		if file.Checksum != "" {
+			if !checksumMatches(tempPath, file.Checksum) {
+				if file.Volatile {
+					result.Warnings = append(result.Warnings,
+						fmt.Sprintf("%s: checksum differs from manifest (manifest %s) — file was volatile during backup", file.BackupPath, file.Checksum))
+					log.Warn("volatile file checksum mismatch (advisory, not a failure)", "phase", "verify", "backupPath", file.BackupPath,
+						"expected", file.Checksum)
+				} else {
+					_ = os.Remove(tempPath)
+					result.FilesFailed++
+					result.FailedFiles = append(result.FailedFiles, file.BackupPath)
+					log.Warn("checksum mismatch", "phase", "verify", "backupPath", file.BackupPath,
+						"expected", file.Checksum)
+					continue
+				}
 			}
 		} else {
 			result.FilesSizeOnly++
@@ -293,19 +320,24 @@ func TestRestore(provider providers.BackupProvider, snapshotID, workRoot string,
 			result.FilesFailed++
 			result.FailedFiles = append(result.FailedFiles, file.BackupPath)
 			log.Warn("stat failed", "phase", "restore", "backupPath", file.BackupPath, "error", errString(statErr))
-		case info.Size() != file.Size:
+		case info.Size() != file.Size && !file.Volatile:
 			// A real test-restore must confirm the bytes came back intact, not
 			// just that a file appeared (same blind spot as VerifyIntegrity).
 			result.FilesFailed++
 			result.FailedFiles = append(result.FailedFiles, file.BackupPath)
 			log.Warn("size mismatch", "phase", "restore", "backupPath", file.BackupPath,
 				"expectedBytes", file.Size, "actualBytes", info.Size())
-		case file.Checksum != "" && !checksumMatches(destPath, file.Checksum):
+		case file.Checksum != "" && !file.Volatile && !checksumMatches(destPath, file.Checksum):
 			result.FilesFailed++
 			result.FailedFiles = append(result.FailedFiles, file.BackupPath)
 			log.Warn("checksum mismatch", "phase", "restore", "backupPath", file.BackupPath,
 				"expected", file.Checksum)
 		default:
+			if file.Volatile && (info.Size() != file.Size || (file.Checksum != "" && !checksumMatches(destPath, file.Checksum))) {
+				result.Warnings = append(result.Warnings,
+					fmt.Sprintf("%s: differs from manifest — file was volatile during backup", file.BackupPath))
+				log.Warn("volatile file mismatch (advisory, not a failure)", "phase", "restore", "backupPath", file.BackupPath)
+			}
 			result.FilesVerified++
 			result.SizeBytes += info.Size()
 		}

--- a/agent/internal/backup/verify_test.go
+++ b/agent/internal/backup/verify_test.go
@@ -153,6 +153,82 @@ func TestVerifyIntegrity_MissingFile(t *testing.T) {
 	}
 }
 
+// TestVerifyIntegrity_VolatileSizeMismatch_WarnsNotFails proves #5581's
+// verify-side policy: a Volatile manifest entry's size mismatch is a
+// warning, counted as verified, not a failure — while an ordinary
+// (non-Volatile) entry with the exact same kind of mismatch still fails,
+// proving this doesn't loosen verification generally.
+func TestVerifyIntegrity_VolatileSizeMismatch_WarnsNotFails(t *testing.T) {
+	basePath := t.TempDir()
+	snapshotID := "snapshot-volatile"
+	prefix := path.Join("snapshots", snapshotID)
+	srcDir := t.TempDir()
+
+	volatileSrc := filepath.Join(srcDir, "volatile.log")
+	if err := os.WriteFile(volatileSrc, []byte("0123456789"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	provider := providers.NewLocalProvider(basePath)
+	volatileBackupPath := path.Join(prefix, "files", "volatile.log.gz")
+	if err := provider.Upload(volatileSrc, volatileBackupPath); err != nil {
+		t.Fatal(err)
+	}
+
+	staleSrc := filepath.Join(srcDir, "stale.txt")
+	if err := os.WriteFile(staleSrc, []byte("0123456789"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	staleBackupPath := path.Join(prefix, "files", "stale.txt.gz")
+	if err := provider.Upload(staleSrc, staleBackupPath); err != nil {
+		t.Fatal(err)
+	}
+
+	// Both objects are actually 10 bytes; the manifest declares a stale 5
+	// bytes for each, but only the volatile one carries Volatile: true.
+	manifest := Snapshot{
+		ID: snapshotID,
+		Files: []SnapshotFile{
+			{SourcePath: volatileSrc, BackupPath: volatileBackupPath, Size: 5, Volatile: true},
+			{SourcePath: staleSrc, BackupPath: staleBackupPath, Size: 5},
+		},
+		Size: 10,
+	}
+	manifestBytes, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestDir := filepath.Join(basePath, prefix)
+	if err := os.MkdirAll(manifestDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(manifestDir, "manifest.json"), manifestBytes, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := VerifyIntegrity(provider, snapshotID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.FilesVerified != 1 {
+		t.Errorf("FilesVerified = %d, want 1 (the volatile entry counts as verified despite the mismatch)", result.FilesVerified)
+	}
+	if result.FilesFailed != 1 {
+		t.Errorf("FilesFailed = %d, want 1 (only the non-volatile mismatch)", result.FilesFailed)
+	}
+	if len(result.FailedFiles) != 1 || result.FailedFiles[0] != staleBackupPath {
+		t.Errorf("FailedFiles = %v, want only %q", result.FailedFiles, staleBackupPath)
+	}
+	foundVolatileWarning := false
+	for _, w := range result.Warnings {
+		if strings.Contains(w, volatileBackupPath) && strings.Contains(w, "volatile") {
+			foundVolatileWarning = true
+		}
+	}
+	if !foundVolatileWarning {
+		t.Errorf("expected an advisory warning mentioning the volatile file, got %v", result.Warnings)
+	}
+}
+
 func TestVerifyIntegrity_CorruptedGzip(t *testing.T) {
 	basePath := t.TempDir()
 	snapshotID := "snapshot-corrupt"

--- a/agent/internal/backup/vss_provider_seam_test.go
+++ b/agent/internal/backup/vss_provider_seam_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -433,5 +434,71 @@ func TestResolveVSSProvider(t *testing.T) {
 				t.Errorf("provider = %v, want the injected instance", provider)
 			}
 		})
+	}
+}
+
+// TestRunBackupContext_JournalHardExclude_MatchesVSSShadowPath is the #5583
+// review fix: journalDirForExclude (RunBackupContext) is computed from the
+// LITERAL StagingDir before rewritePathsForVSS rewrites backupPaths to
+// shadow-copy device paths, but collectBackupFilesFromPaths's walker only
+// ever visits the REWRITTEN paths under VSS. Because VSS snapshots the
+// WHOLE volume, the shadow copy also contains whatever the checkpoint-
+// journal directory held at the instant of the snapshot — a real,
+// uploadable file, not a hypothetical. Without ALSO matching the
+// shadow-rewritten form of the journal directory, the hard-exclude
+// silently never fires on a VSS run: only the whole-machine preset's glob
+// exclude protects that one case, and nothing protects a custom path
+// selection that happens to include the journal's volume.
+func TestRunBackupContext_JournalHardExclude_MatchesVSSShadowPath(t *testing.T) {
+	shadowRoot := t.TempDir()
+	srcDir := t.TempDir()
+	shadowed := shadowedSourceDir(t, shadowRoot, srcDir)
+
+	// journalDir is the LITERAL staging dir the agent resolves and opens its
+	// journal in (resolveJournalDir(m.GetStagingDir())). Its content at
+	// VSS-snapshot time is mirrored under the shadow copy by construction
+	// (VSS snapshots the whole volume) — modeled here by writing directly
+	// under the shadow path, the same way shadowedSourceDir already models
+	// the rest of srcDir's shadow copy.
+	journalDir := filepath.Join(srcDir, "backup-journal")
+	shadowedJournalDir := filepath.Join(shadowed, "backup-journal")
+	if err := os.MkdirAll(shadowedJournalDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	createTempFile(t, shadowedJournalDir, "backup-journal-deadbeefdeadbeef.jsonl", "{\"snapshotId\":\"stale\"}\n")
+	createTempFile(t, shadowed, "real.txt", "keep me")
+
+	vssProvider := &fakeVSSProvider{
+		session: &vss.VSSSession{
+			ID:          "shadow-set-1",
+			Volumes:     []string{filepath.VolumeName(srcDir)},
+			ShadowPaths: map[string]string{filepath.VolumeName(srcDir): shadowRoot},
+			CreatedAt:   time.Now().UTC(),
+		},
+	}
+
+	provider := newMockProvider()
+	mgr := NewBackupManager(BackupConfig{
+		Provider:    provider,
+		Paths:       []string{srcDir},
+		VSSEnabled:  true,
+		VSSProvider: vssProvider,
+		StagingDir:  journalDir,
+	})
+
+	job, err := mgr.RunBackupContext(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("RunBackupContext failed: %v", err)
+	}
+	if job.Snapshot == nil {
+		t.Fatal("expected a snapshot")
+	}
+	if len(job.Snapshot.Files) != 1 || job.Snapshot.Files[0].SourcePath != filepath.Join(shadowed, "real.txt") {
+		t.Fatalf("expected only real.txt (under its shadow path) in the snapshot, got %+v", job.Snapshot.Files)
+	}
+	for _, call := range provider.uploadCalls {
+		if strings.Contains(call.localPath, "backup-journal") {
+			t.Errorf("must never upload a file from the checkpoint-journal directory even under its VSS shadow-copy path, got upload of %q", call.localPath)
+		}
 	}
 }

--- a/apps/web/src/components/configurationPolicies/featureTabs/backupTabPresets.test.ts
+++ b/apps/web/src/components/configurationPolicies/featureTabs/backupTabPresets.test.ts
@@ -62,4 +62,21 @@ describe('createWholeMachinePresets', () => {
       expect(WINDOWS_WHOLE_MACHINE_EXCLUDES).toContain(must);
     }
   });
+
+  // #5581: a whole-machine backup must never capture the agent's own
+  // live checkpoint-journal (or bare-metal rebuild scratch) state — a
+  // journal file GROWS across the very run that is backing it up, which is
+  // exactly the "manifest describes stale bytes" failure mode. Defense in
+  // depth alongside the agent's own hard-exclude of its resolved journal
+  // directory (agent/internal/backup/backup.go, collectBackupFilesFromPaths):
+  // this preset-level exclude is what protects a custom (non-whole-machine)
+  // path selection that happens to include /var/lib/breeze, and keeps the
+  // whole-machine preset itself clean even if an operator inspects the glob
+  // list rather than relying on the agent-side guard.
+  it('excludes the agent\'s own checkpoint-journal and rebuild-scratch state (#5581)', () => {
+    for (const must of ['/var/lib/breeze/backup-journal/**', '/var/lib/breeze/rebuild/**']) {
+      expect(LINUX_WHOLE_MACHINE_EXCLUDES).toContain(must);
+    }
+    expect(WINDOWS_WHOLE_MACHINE_EXCLUDES).toContain('/ProgramData/Breeze/data/backup-journal/**');
+  });
 });

--- a/apps/web/src/components/configurationPolicies/featureTabs/backupTabPresets.ts
+++ b/apps/web/src/components/configurationPolicies/featureTabs/backupTabPresets.ts
@@ -217,6 +217,16 @@ export const LINUX_WHOLE_MACHINE_EXCLUDES: string[] = [
   "/swapfile",
   "/swap.img",
   "**/lost+found/**",
+  // #5581: the agent's own live checkpoint journal and bare-metal rebuild
+  // scratch space. The journal file GROWS across the very run that is
+  // backing it up (a Record append per uploaded file) — capturing it is
+  // exactly the "manifest describes stale bytes" failure mode, and it is
+  // internal agent state, never something an operator asked to back up.
+  // Defense in depth alongside the agent's own hard-exclude of its
+  // resolved journal directory regardless of these presets (see
+  // agent/internal/backup/backup.go's collectBackupFilesFromPaths).
+  "/var/lib/breeze/backup-journal/**",
+  "/var/lib/breeze/rebuild/**",
 ];
 
 export const WINDOWS_WHOLE_MACHINE_EXCLUDES: string[] = [
@@ -228,6 +238,8 @@ export const WINDOWS_WHOLE_MACHINE_EXCLUDES: string[] = [
   "/Windows/Temp/**",
   "/Windows/SoftwareDistribution/Download/**",
   "**/AppData/Local/Temp/**",
+  // #5581 — see the matching Linux comment above.
+  "/ProgramData/Breeze/data/backup-journal/**",
 ];
 
 export type WholeMachinePreset = {


### PR DESCRIPTION
## Summary

A whole-machine snapshot recorded `SnapshotFile.Size` from the walk-time stat and `Checksum` from a separate post-upload read — two different points in time. A file that kept changing during the run (a live log, the agent's own checkpoint journal) got a manifest entry that didn't describe any single real state of the file, so restore's size check rejected it (`agent/internal/backup/snapshot.go` upload loop, `attemptFileUpload` → `uploadSnapshotFile` → post-upload `sha256File`).

## Approach

1. **`agent/internal/backup/snapshot.go`** — `measureBeforeUpload` stats + hashes the source *immediately before* the upload call (a single read, as close as possible to the actual upload), and that size feeds `uploadDeadline`. After a successful upload, `reconcileAfterUpload` re-stats the source:
   - Unchanged → the pre-upload measurement is correct as-is (the common case).
   - Changed once → re-measure and re-upload ONCE.
   - Changed again → stop chasing it; record the entry from the **last** pre-upload measurement (self-consistent with the bytes actually stored) and mark the new `SnapshotFile.Volatile bool json:"volatile,omitempty"` field. `ModTime` deliberately stays the walk-time value in every case — the checkpoint journal's resume matching (`journal.Lookup`) keys on the walk-time `(sourcePath, size, modTime)` triple, and a live-mutating file's pre-upload modTime would never match on a later resumed run anyway.
   - `Snapshot.VolatileFiles` (in-memory only, like `UploadFailures`) counts these; `backup.go` folds a non-zero count into a job `Warning`: *"N file(s) were modified while being backed up (recorded as volatile)"*.
   - Providers upload from a path, not a reader (`BackupProvider.Upload(localPath, remotePath)`), so hashing the exact in-flight bytes isn't possible without a provider-interface change — this is the closest correct approximation without one.

2. **`agent/internal/backup/restore.go` / `verify.go`** — a size or checksum mismatch on a `Volatile` entry is now a warning, not a failed file (`TestRestore` in verify.go updated too, for consistency with `VerifyIntegrity`). An ordinary (non-volatile) mismatch still fails exactly as before.

3. **`agent/internal/backup/backup.go`** — `collectBackupFilesFromPaths` now takes the run's own resolved checkpoint-journal directory and hard-excludes that whole subtree (`fs.SkipDir`) independent of any user-configured exclude pattern, so the agent never backs up the journal file it is itself writing to (or another run's journal sharing the same directory).

4. **`apps/web/.../backupTabPresets.ts`** — whole-machine presets additionally exclude `/var/lib/breeze/backup-journal/**`, `/var/lib/breeze/rebuild/**` (Linux) and `/ProgramData/Breeze/data/backup-journal/**` (Windows), as defense in depth alongside (3).

## Tests

- `snapshot_test.go`: `TestCreateSnapshot_GrowingFile_ReconciledOnRetry` (a file that grows once ends up with Size/Checksum matching the uploaded bytes after the retry), `TestCreateSnapshot_FileChangesTwice_RecordedVolatile` (a file that changes across the retry too is recorded `Volatile: true` from the last pre-upload measurement, `Snapshot.VolatileFiles == 1`).
- `restore_test.go`: `TestRestoreFromSnapshot_VolatileSizeMismatch_WarnsNotFails` (a volatile entry with a mismatched size restores with a warning, `FilesFailed == 0` for it; a same-shaped mismatch on a non-volatile entry still fails).
- `verify_test.go`: `TestVerifyIntegrity_VolatileSizeMismatch_WarnsNotFails` (same policy for `VerifyIntegrity`).
- `backup_test.go`: `TestRunBackupContext_ExcludesOwnCheckpointJournal` (a run whose path is an ancestor of its own `StagingDir` never uploads anything from the journal directory).
- `backupTabPresets.test.ts`: asserts the new exclude patterns are present on both whole-machine presets.

Every new/failing-path test was verified red-first (confirmed by stubbing out the corresponding fix and re-running).

## Verification

```
cd agent && go test -race -count=1 ./internal/backup/... ./cmd/breeze-backup/...   # ok
GOOS=windows go vet ./internal/backup/...                                          # clean (pre-existing vss_windows.go unsafe.Pointer notices only, untouched file)
golangci-lint run --new-from-rev=origin/main ./...                                 # 0 issues.
cd apps/web && npx vitest run src/components/configurationPolicies/featureTabs     # 28 files / 293 tests passed
```

## Deviations from the dispatch contract

- `ModTime` is **not** updated to the pre-upload measurement (only `Size`/`Checksum`/`Volatile` are) — the contract's own wording only specifies "set Size/Checksum from the LAST pre-upload measurement." Updating `ModTime` too broke checkpoint-journal resume matching in an existing test (`TestCreateSnapshot_SourceGoneWithJournal_PreservesPrefixAndJournal`, which keys `journal.Lookup` on the walk-time modTime triple) and offered no compensating benefit, since a live-mutating file's modTime wouldn't match on a future resumed run regardless.
- `verify.go`'s `TestRestore` (test-restore path) was also updated to treat `Volatile` as advisory, in addition to `VerifyIntegrity` — the contract named "verify.go" generally and both functions share the identical mismatch-handling shape in that file; leaving `TestRestore` inconsistent would have reintroduced the exact bug in a sibling code path.

## Review fix

Review found a confirmed gap in commit `63a23bfcb4`: `journalDirForExclude` in `RunBackupContext` (~backup.go:514-528) was computed from the **literal** staging-dir path before `rewritePathsForVSS` (~backup.go:782-786) rewrites the backup roots to shadow-copy device paths, and `isWithinDir` treats a `filepath.Rel` error as "not within". On a Windows whole-machine backup under VSS, `collectBackupFilesFromPaths`'s walker only ever visits the **rewritten** (shadow) paths, so the literal-path exclude never matched anything — the hard-exclude promised by the code comments silently did nothing; only the preset glob exclude (`backupTabPresets.ts`) was actually protecting a whole-machine run, and nothing protected a custom path selection.

Fixed in `969e0fc2a9`:
- `journalDirsForExclude` (now a `[]string`) additionally runs every literal journal dir through the same volume→shadow substitution `rewritePathsForVSS` just applied to `backupPaths`, and keeps whichever form(s) actually mapped to a shadow root.
- `collectBackupFilesFromPaths` takes `journalDirs []string` instead of a single string; a new `isWithinAnyDir` checks the walker's candidate path against every form. Linux/non-VSS behavior is unchanged (the slice just holds the one literal entry).
- Red-first test `TestRunBackupContext_JournalHardExclude_MatchesVSSShadowPath` (`vss_provider_seam_test.go`) uses the existing `fakeVSSProvider`/`shadowedSourceDir` seam to simulate a VSS session mapping a volume to a fake shadow root, places a journal file only under the shadow-copy path (modeling what a real VSS snapshot of the whole volume would capture), and proves it is excluded while a sibling file still backs up. Confirmed red against the pre-fix code (reproduced the exact upload of the journal file), green after.

Verification rerun after the fix:
```
go test -race -count=1 ./internal/backup/...        # ok
GOOS=windows go vet ./internal/backup/...            # clean (pre-existing vss_windows.go notices only)
golangci-lint run --new-from-rev=origin/main ./...   # 0 issues.
```

Closes #5581

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NLb6JEZ2mPgPiaFBFtq11E
