### PR TITLE
fix(rebuild): resumed rebuilds reuse restore progress; validate skips known partial failures (#5493)

### DIFF
--- a/agent/internal/backup/rebuild/engine.go
+++ b/agent/internal/backup/rebuild/engine.go
@@ -53,6 +53,10 @@ type run struct {
 	layout       *layout.Manifest
 	manifest     *backup.Snapshot
 	warnings     []string
+	// failedFiles are source paths the restore phase could not place (only
+	// populated under AllowPartialRestore); validate must not sample them —
+	// they were already reported as a warning.
+	failedFiles map[string]bool
 }
 
 func targetKey(t Target) string {
@@ -147,6 +151,7 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 	r.result.DurationMs = time.Since(start).Milliseconds()
 	if !opts.DryRun {
 		_ = os.Remove(r.statePath)
+		_ = os.RemoveAll(restoreWorkRoot(opts.StateDir))
 	}
 	return r.result, nil
 }

--- a/agent/internal/backup/rebuild/engine_test.go
+++ b/agent/internal/backup/rebuild/engine_test.go
@@ -473,3 +473,46 @@ func TestRun_StrictRestoreFailsOnMissingObject(t *testing.T) {
 		t.Fatalf("res = %+v err=%v", res, err)
 	}
 }
+
+// TestRun_ResumeReusesRestoreProgress proves the restore phase resumes from
+// the persistent work root instead of re-downloading every file: run 1 hits a
+// missing object (strict restore fails after every other file landed), run 2
+// with AllowPartialRestore must report the landed files as skipped.
+func TestRun_ResumeReusesRestoreProgress(t *testing.T) {
+	skipUnlessLinuxSystemState(t)
+	resetBmrCalls()
+	dir := t.TempDir()
+	sys := newFakeSystem(dir, 100*GiB)
+	p := seedSnapshot(t, "snap-1", testLayout())
+	delete(p.files, "snapshots/snap-1/files/path_0/usr/bin/tool")
+	opts := Options{SnapshotID: "snap-1", Provider: p, Target: Target{Kind: TargetDisk, Path: "/dev/sdb"}, Identity: IdentityNew, StateDir: dir, StagingRoot: filepath.Join(dir, "mnt"), System: sys}
+	if res, err := Run(context.Background(), opts); err == nil || res == nil || res.PhaseReached != PhaseRestore {
+		t.Fatalf("first run = %+v err=%v", res, err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "work", "restore-work", "staging", "snap-1")); err != nil {
+		t.Fatalf("restore work root must survive a failed run: %v", err)
+	}
+	var skipped, restored int
+	opts.System = newFakeSystem(dir, 100*GiB)
+	opts.AllowPartialRestore = true
+	opts.Progress = func(ph Phase, msg string, _, _ int64) {
+		if ph != PhaseRestore {
+			return
+		}
+		if strings.Contains(msg, "skipped (resumed)") {
+			skipped++
+		} else if strings.HasPrefix(msg, "restored:") {
+			restored++
+		}
+	}
+	res2, err := Run(context.Background(), opts)
+	if err != nil || res2.Status != "completed" || !res2.Resumed {
+		t.Fatalf("second run = %+v err=%v", res2, err)
+	}
+	if skipped == 0 || restored != 0 {
+		t.Fatalf("resume must skip already-restored files: skipped=%d restored=%d", skipped, restored)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "work")); !os.IsNotExist(err) {
+		t.Fatalf("work root must be removed after a completed run (err=%v)", err)
+	}
+}

--- a/agent/internal/backup/rebuild/restore_tree.go
+++ b/agent/internal/backup/rebuild/restore_tree.go
@@ -59,7 +59,16 @@ func restoreTree(ctx context.Context, r *run) error {
 			return err
 		}
 	}
-	res, err := backup.RestoreFromSnapshotContext(ctx, r.opts.Provider, backup.RestoreConfig{SnapshotID: r.opts.SnapshotID, TargetPath: r.staging}, func(phase string, cur, total int64, msg string) {
+	// A persistent work root keeps the restore's resume state across engine
+	// runs: without it RestoreFromSnapshotContext creates an ephemeral work
+	// dir and deletes it on return, so a resumed rebuild re-restores every
+	// file instead of skipping the ones already on disk (found live on the
+	// W03 boot proof: 104k files restored twice).
+	workRoot := restoreWorkRoot(r.opts.StateDir)
+	if err := os.MkdirAll(workRoot, 0o700); err != nil {
+		return fmt.Errorf("create restore work root: %w", err)
+	}
+	res, err := backup.RestoreFromSnapshotContext(ctx, r.opts.Provider, backup.RestoreConfig{SnapshotID: r.opts.SnapshotID, TargetPath: r.staging, WorkRoot: workRoot}, func(phase string, cur, total int64, msg string) {
 		r.progress(PhaseRestore, msg, cur, total)
 	})
 	if err != nil {
@@ -73,6 +82,10 @@ func restoreTree(ctx context.Context, r *run) error {
 			return errors.New(msg)
 		}
 		r.warn("%s", msg)
+		r.failedFiles = make(map[string]bool, len(res.FailedFiles))
+		for _, f := range res.FailedFiles {
+			r.failedFiles[f] = true
+		}
 	}
 	if r.stateStaging != "" {
 		if entries, _ := os.ReadDir(r.stateStaging); len(entries) > 0 {
@@ -85,3 +98,7 @@ func restoreTree(ctx context.Context, r *run) error {
 	}
 	return nil
 }
+
+// restoreWorkRoot is where the restore keeps its resume state and manifest
+// scratch between engine runs. Removed by Run once the rebuild completes.
+func restoreWorkRoot(stateDir string) string { return filepath.Join(stateDir, "work") }

--- a/agent/internal/backup/rebuild/validate.go
+++ b/agent/internal/backup/rebuild/validate.go
@@ -40,6 +40,9 @@ func validate(ctx context.Context, r *run) error {
 			if r.opts.Identity == IdentityNew && identityMutatedPaths[f.SourcePath] {
 				continue
 			}
+			if r.failedFiles[f.SourcePath] {
+				continue // known partial-restore failure, already a warning
+			}
 			withSum = append(withSum, f)
 		}
 	}


### PR DESCRIPTION
Found live on the W03 boot proof (feature #5493): after a strict-mode failure the resumed `breeze-backup rebuild` re-restored all 104,731 files instead of skipping the 104,680 already on disk. Cause: the engine called `RestoreFromSnapshotContext` without `WorkRoot`, so the restore's resume state lived in an ephemeral work dir deleted on return.

- `restore_tree.go`: pass a persistent `WorkRoot` (`<StateDir>/work`); `engine.go` removes it once the rebuild completes.
- `validate.go`: under `AllowPartialRestore`, files the restore already reported as failed are excluded from the checksum sample (they are already a warning; sampling them turned a documented partial restore into a validate failure).
- New Linux test `TestRun_ResumeReusesRestoreProgress` (missing object → strict failure → resumed run reports every landed file as `skipped (resumed)`, zero re-restores, work root removed on completion).

Verification: `go test -race ./internal/backup/rebuild/` on Linux (Docker golang:1.26) and macOS; `go test -race ./cmd/breeze-backup/`; `golangci-lint run --new-from-rev=origin/main ./...` → 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NLb6JEZ2mPgPiaFBFtq11E