### PR TITLE
fix(backup): excluded directories stay in the manifest so mount points survive a rebuild (#5493)

### DIFF
--- a/agent/internal/backup/backup.go
+++ b/agent/internal/backup/backup.go
@@ -1446,6 +1446,11 @@ type backupFile struct {
 	linkTarget string
 	modeBits   uint32
 	owner      *FileOwner
+	// placeholder mirrors SnapshotFile.Placeholder — see that field's doc
+	// comment (snapshot.go). Set only via contentlessEntry for a KindDir
+	// entry the walker force-recorded because the directory matched an
+	// exclude pattern (#5493).
+	placeholder bool
 }
 
 // fullModeBits keeps perm + setuid/setgid/sticky; everything else (type bits)
@@ -1609,11 +1614,16 @@ func (m *BackupManager) collectBackupFilesFromPaths(ctx context.Context, paths [
 		//     require them to exist.
 		type walkedDir struct {
 			path, rel string
-			// forced marks a directory that was itself pattern-excluded (or
-			// inside journalDirs): it always gets a manifest entry — mode
-			// and ownership recorded, contents skipped — bypassing
-			// dirNeedsEntry's "would the default MkdirAll suffice" check,
-			// since nothing else will ever recreate this directory.
+			// forced marks a directory that was itself pattern-excluded
+			// (never the journal dir — see the walker below, which checks
+			// journalDirs first and returns before this can be set for
+			// it): it always gets a manifest entry — mode and ownership
+			// recorded, contents skipped — bypassing dirNeedsEntry's
+			// "would the default MkdirAll suffice" check, since nothing
+			// else will ever recreate this directory. Carried into the
+			// resulting backupFile/SnapshotFile as Placeholder, which
+			// restore uses to avoid re-permissioning an already-existing
+			// directory (review fix, #5493).
 			forced bool
 		}
 		var dirs []walkedDir
@@ -1643,25 +1653,29 @@ func (m *BackupManager) collectBackupFilesFromPaths(ctx context.Context, paths [
 				// whole checkpoint journal subtree — not just files that
 				// happen to match a glob — is pruned in one step (#5581).
 				//
-				// Only a PATTERN-excluded directory is force-recorded (see
-				// walkedDir.forced above): it represents a real, user-owned
-				// filesystem location (e.g. /proc, /tmp under the
-				// whole-machine preset) that a rebuild must still recreate.
-				// The journal directory is this run's own ephemeral
-				// bookkeeping location — ONLY it, on its own, must never
-				// appear in the manifest at all, forced or not (#5581,
-				// TestRunBackupContext_JournalHardExclude_MatchesVSSShadowPath) —
-				// so it is pruned with no entry, same as before. A directory
-				// that happens to be both pattern-excluded AND the journal
-				// dir still gets forced, consistent with "pattern exclusion
-				// always forces an entry" — that combination just doesn't
-				// arise for the journal dir in practice, since it isn't
-				// itself covered by any whole-machine preset pattern.
-				excludedByPattern := excl != nil && excl.matches(slashRel)
-				if excludedByPattern || isWithinAnyDir(path, journalDirs) {
-					if excludedByPattern {
-						dirs = append(dirs, walkedDir{path: path, rel: slashRel, forced: true})
-					}
+				// The journal-dir check runs FIRST and unconditionally wins
+				// (review fix): the journal directory is this run's own
+				// ephemeral bookkeeping location and must NEVER appear in
+				// the manifest at all — not even if it also happens to
+				// match a user-configured exclude pattern (e.g. an explicit
+				// "**/backup-journal/**" exclude, or simply a pattern broad
+				// enough to catch it incidentally). Checking journalDirs
+				// first, and returning before excludedByPattern is even
+				// evaluated, means that combination can never accidentally
+				// force an entry for it — see
+				// TestRunBackupContext_JournalHardExclude_MatchesVSSShadowPath
+				// and TestRunBackupContext_JournalHardExclude_WinsOverMatchingUserExclude.
+				//
+				// Only THEN does a PATTERN-excluded directory get
+				// force-recorded (see walkedDir.forced above): it
+				// represents a real, user-owned filesystem location (e.g.
+				// /proc, /tmp under the whole-machine preset) that a
+				// rebuild must still recreate.
+				if isWithinAnyDir(path, journalDirs) {
+					return fs.SkipDir
+				}
+				if excl != nil && excl.matches(slashRel) {
+					dirs = append(dirs, walkedDir{path: path, rel: slashRel, forced: true})
 					return fs.SkipDir
 				}
 				dirs = append(dirs, walkedDir{path: path, rel: slashRel})
@@ -1723,12 +1737,17 @@ func (m *BackupManager) collectBackupFilesFromPaths(ctx context.Context, paths [
 				continue
 			}
 			owner := fileOwner(info)
-			// A forced (pattern-excluded, or journal-dir) entry always gets
-			// recorded — dirNeedsEntry's emptiness/mode/owner heuristics are
-			// about whether the default restore behavior (MkdirAll 0755)
-			// would already recreate it correctly; an excluded directory is
-			// never recreated by anything else in the manifest, so it always
-			// needs its own entry regardless of what dirNeedsEntry would say.
+			// A forced (pattern-excluded — never the journal dir, see the
+			// walker above) entry always gets recorded — dirNeedsEntry's
+			// emptiness/mode/owner heuristics are about whether the default
+			// restore behavior (MkdirAll 0755) would already recreate it
+			// correctly; an excluded directory is never recreated by
+			// anything else in the manifest, so it always needs its own
+			// entry regardless of what dirNeedsEntry would say. It is also
+			// marked Placeholder (review fix, #5493): restore must only
+			// apply its mode/owner when creating it fresh, never re-apply
+			// them over a directory a customer may have deliberately
+			// reconfigured since the backup — see SnapshotFile.Placeholder.
 			if !d.forced && !dirNeedsEntry(info, owner, childCount[d.path] == 0) {
 				continue
 			}
@@ -1739,7 +1758,7 @@ func (m *BackupManager) collectBackupFilesFromPaths(ctx context.Context, paths [
 			seen[snapshotPath] = struct{}{}
 			files = append(files, backupFile{
 				sourcePath: d.path, snapshotPath: snapshotPath, modTime: info.ModTime(), mode: info.Mode(),
-				kind: KindDir, modeBits: fullModeBits(info.Mode()), owner: owner,
+				kind: KindDir, modeBits: fullModeBits(info.Mode()), owner: owner, placeholder: d.forced,
 			})
 		}
 	}

--- a/agent/internal/backup/backup.go
+++ b/agent/internal/backup/backup.go
@@ -1591,12 +1591,31 @@ func (m *BackupManager) collectBackupFilesFromPaths(ctx context.Context, paths [
 		// walkedDir/dirs/childCount defer the "does this directory need its
 		// own manifest entry" decision until after the walk: emptiness is
 		// only known once every child has been visited (see dirNeedsEntry).
-		// childCount is keyed by the ABSOLUTE parent path and counts every
-		// visited child (files, symlinks, subdirs) INCLUDING excluded ones,
-		// so an excluded-only directory still counts as non-empty and gets
-		// no entry of its own — its exclusion means "do not back this up",
-		// not "this is an empty directory worth recreating".
-		type walkedDir struct{ path, rel string }
+		// childCount is keyed by the ABSOLUTE parent path and counts only
+		// children that actually make it into the backup (non-excluded
+		// files/symlinks/subdirs) — an excluded child, file or directory,
+		// does NOT count. That matters two ways (#5493):
+		//   - a directory whose children are ALL excluded (e.g. a cache dir
+		//     holding only *.tmp files under a "*.tmp" exclude) still reads
+		//     as empty and gets its own manifest entry, same as a directory
+		//     that was always empty.
+		//   - a directory that is ITSELF excluded (walkedDir.forced below)
+		//     is force-recorded regardless of childCount/mode — its contents
+		//     are skipped, but the directory's presence, mode, and ownership
+		//     still need to survive a rebuild. This is what keeps mount
+		//     points like /proc, /tmp, and /var/tmp (whole-machine preset
+		//     excludes) present after a bare-metal restore: nothing else in
+		//     the manifest recreates them, and systemd/update-initramfs
+		//     require them to exist.
+		type walkedDir struct {
+			path, rel string
+			// forced marks a directory that was itself pattern-excluded (or
+			// inside journalDirs): it always gets a manifest entry — mode
+			// and ownership recorded, contents skipped — bypassing
+			// dirNeedsEntry's "would the default MkdirAll suffice" check,
+			// since nothing else will ever recreate this directory.
+			forced bool
+		}
 		var dirs []walkedDir
 		childCount := map[string]int{}
 
@@ -1618,22 +1637,41 @@ func (m *BackupManager) collectBackupFilesFromPaths(ctx context.Context, paths [
 				if path == cleanRoot {
 					return nil
 				}
-				// An excluded directory is skipped entirely (fs.SkipDir), not
-				// just its immediate files (#2418). The journal-dir check
-				// rides the same fs.SkipDir path so the whole checkpoint
-				// journal subtree — not just files that happen to match a
-				// glob — is pruned in one step (#5581).
-				if (excl != nil && excl.matches(slashRel)) || isWithinAnyDir(path, journalDirs) {
+				// An excluded directory's CONTENTS are skipped entirely
+				// (fs.SkipDir), not just its immediate files (#2418). The
+				// journal-dir check rides the same fs.SkipDir path so the
+				// whole checkpoint journal subtree — not just files that
+				// happen to match a glob — is pruned in one step (#5581).
+				//
+				// Only a PATTERN-excluded directory is force-recorded (see
+				// walkedDir.forced above): it represents a real, user-owned
+				// filesystem location (e.g. /proc, /tmp under the
+				// whole-machine preset) that a rebuild must still recreate.
+				// The journal directory is this run's own ephemeral
+				// bookkeeping location — ONLY it, on its own, must never
+				// appear in the manifest at all, forced or not (#5581,
+				// TestRunBackupContext_JournalHardExclude_MatchesVSSShadowPath) —
+				// so it is pruned with no entry, same as before. A directory
+				// that happens to be both pattern-excluded AND the journal
+				// dir still gets forced, consistent with "pattern exclusion
+				// always forces an entry" — that combination just doesn't
+				// arise for the journal dir in practice, since it isn't
+				// itself covered by any whole-machine preset pattern.
+				excludedByPattern := excl != nil && excl.matches(slashRel)
+				if excludedByPattern || isWithinAnyDir(path, journalDirs) {
+					if excludedByPattern {
+						dirs = append(dirs, walkedDir{path: path, rel: slashRel, forced: true})
+					}
 					return fs.SkipDir
 				}
 				dirs = append(dirs, walkedDir{path: path, rel: slashRel})
 				childCount[filepath.Dir(path)]++
 				return nil
 			}
-			childCount[filepath.Dir(path)]++
 			if excl.matches(slashRel) || isWithinAnyDir(path, journalDirs) {
 				return nil
 			}
+			childCount[filepath.Dir(path)]++
 			snapshotPath := filepath.ToSlash(filepath.Join(rootLabel, relPath))
 			if _, exists := seen[snapshotPath]; exists {
 				log.Debug("duplicate backup path skipped", "snapshotPath", snapshotPath)
@@ -1685,7 +1723,13 @@ func (m *BackupManager) collectBackupFilesFromPaths(ctx context.Context, paths [
 				continue
 			}
 			owner := fileOwner(info)
-			if !dirNeedsEntry(info, owner, childCount[d.path] == 0) {
+			// A forced (pattern-excluded, or journal-dir) entry always gets
+			// recorded — dirNeedsEntry's emptiness/mode/owner heuristics are
+			// about whether the default restore behavior (MkdirAll 0755)
+			// would already recreate it correctly; an excluded directory is
+			// never recreated by anything else in the manifest, so it always
+			// needs its own entry regardless of what dirNeedsEntry would say.
+			if !d.forced && !dirNeedsEntry(info, owner, childCount[d.path] == 0) {
 				continue
 			}
 			snapshotPath := filepath.ToSlash(filepath.Join(rootLabel, d.rel))

--- a/agent/internal/backup/backup_collect_test.go
+++ b/agent/internal/backup/backup_collect_test.go
@@ -324,3 +324,146 @@ func TestCollectBackupFiles_FidelityEntries(t *testing.T) {
 		t.Error("walker followed a directory symlink")
 	}
 }
+
+// #5493: found live on the bare-metal boot proof. The whole-machine preset
+// excludes /proc/**, /tmp/**, /var/tmp/** (and siblings). Before the fix, an
+// excluded directory was pruned via fs.SkipDir without ever being added to
+// the walker's candidate-directory list, so it could never get its own
+// manifest entry — and any directory whose children were all excluded still
+// looked "non-empty" to dirNeedsEntry because childCount counted excluded
+// children too. The rebuilt root ended up with no /proc, /tmp, or /var/tmp,
+// so systemd couldn't mount its API filesystems and update-initramfs failed
+// (mktemp: failed to create directory via template
+// '/var/tmp/mkinitramfs_XXXXXX': No such file or directory).
+//
+// An excluded directory must still be recorded (mode/owner preserved, e.g.
+// /tmp's sticky 1777) even though its contents are skipped, and an excluded
+// child (file or directory) must never count toward its parent's
+// childCount.
+func TestCollectBackupFiles_ExcludedDirectoriesStillGetManifestEntries(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix mode bits (sticky 1777) and ownership")
+	}
+	root := t.TempDir()
+	mustMkdir := func(rel string, mode os.FileMode) string {
+		p := pathpkg.Join(root, rel)
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chmod(p, mode); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	mustFile := func(rel string) {
+		p := pathpkg.Join(root, rel)
+		if err := os.MkdirAll(pathpkg.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	const sticky1777 = os.ModeSticky | 0o777
+	mustMkdir("proc", 0o755)
+	mustFile("proc/x")
+	mustMkdir("tmp", sticky1777)
+	mustFile("tmp/y")
+	mustMkdir("var/tmp", sticky1777)
+	mustFile("var/tmp/z")
+	mustFile("var/log/syslog")
+	mustFile("etc/hosts")
+
+	excl := newExcludeMatcher([]string{"/proc/**", "/tmp/**", "/var/tmp/**"})
+	files, err := NewBackupManager(BackupConfig{}).collectBackupFilesFromPaths(context.Background(), []string{root}, excl, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	byRel := map[string]backupFile{}
+	for _, f := range files {
+		rel, _ := pathpkg.Rel(root, f.sourcePath)
+		byRel[pathpkg.ToSlash(rel)] = f
+	}
+
+	// Excluded directories themselves must still be recorded, with their
+	// real mode preserved.
+	proc, ok := byRel["proc"]
+	if !ok || proc.kind != KindDir || proc.modeBits != 0o755 {
+		t.Errorf("proc entry = %+v (ok=%v), want KindDir mode 0755", proc, ok)
+	}
+	tmp, ok := byRel["tmp"]
+	if !ok || tmp.kind != KindDir || tmp.modeBits != uint32(sticky1777) {
+		t.Errorf("tmp entry = %+v (ok=%v), want KindDir mode sticky 1777", tmp, ok)
+	}
+	varTmp, ok := byRel["var/tmp"]
+	if !ok || varTmp.kind != KindDir || varTmp.modeBits != uint32(sticky1777) {
+		t.Errorf("var/tmp entry = %+v (ok=%v), want KindDir mode sticky 1777", varTmp, ok)
+	}
+
+	// Their contents must never appear.
+	if _, ok := byRel["proc/x"]; ok {
+		t.Error("proc/x should have been excluded, but is present in the manifest")
+	}
+	if _, ok := byRel["tmp/y"]; ok {
+		t.Error("tmp/y should have been excluded, but is present in the manifest")
+	}
+	if _, ok := byRel["var/tmp/z"]; ok {
+		t.Error("var/tmp/z should have been excluded, but is present in the manifest")
+	}
+
+	// var has an included, default-mode child (var/log/syslog) plus the
+	// excluded var/tmp — the excluded child must not count, but the
+	// included one does, so var itself must NOT get an entry (default
+	// MkdirAll 0755 already recreates it correctly).
+	if _, ok := byRel["var"]; ok {
+		t.Error("var should not get its own entry: it has an included child and default mode")
+	}
+	// Included files must still be captured normally.
+	if _, ok := byRel["var/log/syslog"]; !ok {
+		t.Error("var/log/syslog should have been backed up")
+	}
+	if _, ok := byRel["etc/hosts"]; !ok {
+		t.Error("etc/hosts should have been backed up")
+	}
+}
+
+// #5493: a directory that is not itself excluded, but whose ONLY children
+// are excluded by pattern, must still read as empty and get its own
+// manifest entry — otherwise it silently vanishes from a rebuild exactly
+// like a directly-excluded directory does.
+func TestCollectBackupFiles_DirectoryWithOnlyExcludedChildrenBecomesEmptyDirEntry(t *testing.T) {
+	root := t.TempDir()
+	cache := pathpkg.Join(root, "cache")
+	if err := os.MkdirAll(cache, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(pathpkg.Join(cache, "a.tmp"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(pathpkg.Join(cache, "b.tmp"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	excl := newExcludeMatcher([]string{"*.tmp"})
+	files, err := NewBackupManager(BackupConfig{}).collectBackupFilesFromPaths(context.Background(), []string{root}, excl, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	byRel := map[string]backupFile{}
+	for _, f := range files {
+		rel, _ := pathpkg.Rel(root, f.sourcePath)
+		byRel[pathpkg.ToSlash(rel)] = f
+	}
+
+	cacheEntry, ok := byRel["cache"]
+	if !ok || cacheEntry.kind != KindDir {
+		t.Errorf("cache entry = %+v (ok=%v), want an empty-dir KindDir entry", cacheEntry, ok)
+	}
+	if _, ok := byRel["cache/a.tmp"]; ok {
+		t.Error("cache/a.tmp should have been excluded")
+	}
+	if _, ok := byRel["cache/b.tmp"]; ok {
+		t.Error("cache/b.tmp should have been excluded")
+	}
+}

--- a/agent/internal/backup/backup_collect_test.go
+++ b/agent/internal/backup/backup_collect_test.go
@@ -302,6 +302,12 @@ func TestCollectBackupFiles_FidelityEntries(t *testing.T) {
 	if !ok || empty.kind != KindDir {
 		t.Fatalf("empty dir entry = %+v (ok=%v)", empty, ok)
 	}
+	// A genuinely empty directory (never itself pattern-excluded) is not a
+	// placeholder — see TestCollectBackupFiles_ExcludedDirectoriesStillGetManifestEntries
+	// for the pattern-excluded case, which IS (review fix, #5493).
+	if empty.placeholder {
+		t.Error("a genuinely empty dir must not be marked placeholder")
+	}
 	if _, ok := byRel["usr"]; ok {
 		t.Error("a plain non-empty 0755 directory must not get an entry")
 	}
@@ -387,18 +393,19 @@ func TestCollectBackupFiles_ExcludedDirectoriesStillGetManifestEntries(t *testin
 	}
 
 	// Excluded directories themselves must still be recorded, with their
-	// real mode preserved.
+	// real mode preserved, and marked Placeholder — restore must not
+	// re-permission them if they already exist (review fix, #5493).
 	proc, ok := byRel["proc"]
-	if !ok || proc.kind != KindDir || proc.modeBits != 0o755 {
-		t.Errorf("proc entry = %+v (ok=%v), want KindDir mode 0755", proc, ok)
+	if !ok || proc.kind != KindDir || proc.modeBits != 0o755 || !proc.placeholder {
+		t.Errorf("proc entry = %+v (ok=%v), want KindDir mode 0755 placeholder=true", proc, ok)
 	}
 	tmp, ok := byRel["tmp"]
-	if !ok || tmp.kind != KindDir || tmp.modeBits != uint32(sticky1777) {
-		t.Errorf("tmp entry = %+v (ok=%v), want KindDir mode sticky 1777", tmp, ok)
+	if !ok || tmp.kind != KindDir || tmp.modeBits != uint32(sticky1777) || !tmp.placeholder {
+		t.Errorf("tmp entry = %+v (ok=%v), want KindDir mode sticky 1777 placeholder=true", tmp, ok)
 	}
 	varTmp, ok := byRel["var/tmp"]
-	if !ok || varTmp.kind != KindDir || varTmp.modeBits != uint32(sticky1777) {
-		t.Errorf("var/tmp entry = %+v (ok=%v), want KindDir mode sticky 1777", varTmp, ok)
+	if !ok || varTmp.kind != KindDir || varTmp.modeBits != uint32(sticky1777) || !varTmp.placeholder {
+		t.Errorf("var/tmp entry = %+v (ok=%v), want KindDir mode sticky 1777 placeholder=true", varTmp, ok)
 	}
 
 	// Their contents must never appear.
@@ -459,6 +466,13 @@ func TestCollectBackupFiles_DirectoryWithOnlyExcludedChildrenBecomesEmptyDirEntr
 	cacheEntry, ok := byRel["cache"]
 	if !ok || cacheEntry.kind != KindDir {
 		t.Errorf("cache entry = %+v (ok=%v), want an empty-dir KindDir entry", cacheEntry, ok)
+	}
+	// cache itself was never pattern-excluded (only its children were), so
+	// this is an ordinary "genuinely empty" dir entry, not a placeholder —
+	// its mode was legitimately captured and restore must always reapply
+	// it, unlike a Placeholder entry (review fix, #5493).
+	if cacheEntry.placeholder {
+		t.Error("cache is genuinely empty (not itself excluded), must not be marked placeholder")
 	}
 	if _, ok := byRel["cache/a.tmp"]; ok {
 		t.Error("cache/a.tmp should have been excluded")

--- a/agent/internal/backup/bmr/bmr.go
+++ b/agent/internal/backup/bmr/bmr.go
@@ -246,6 +246,13 @@ type manifestFile struct {
 	LinkTarget string             `json:"linkTarget,omitempty"`
 	ModeBits   uint32             `json:"modeBits,omitempty"`
 	Owner      *manifestFileOwner `json:"owner,omitempty"`
+	// Placeholder mirrors backup.SnapshotFile.Placeholder — same
+	// deliberately-independent-mirror rationale as the fields above. True
+	// only for a "dir" entry the walker force-recorded because the
+	// directory matched an exclude pattern (#5493); see
+	// restoreContentlessEntry's "dir" case for how it changes restore
+	// behavior (review fix).
+	Placeholder bool `json:"placeholder,omitempty"`
 }
 
 // manifestFileOwner mirrors backup.FileOwner.
@@ -1113,6 +1120,16 @@ func restoreContentlessEntry(targetPath string, file manifestFile) error {
 		}
 		return symlinkFile(file.LinkTarget, targetPath)
 	case "dir":
+		// Placeholder (review fix, #5493): mirrors backup.RestoreContentlessEntry's
+		// KindDir case (agent/internal/backup/restore.go) — an already-existing
+		// directory is left untouched rather than re-chmod'd, so this reinstall-
+		// then-recover path can't silently revert permissions a customer
+		// tightened on a pattern-excluded directory (e.g. /tmp) since the backup.
+		if file.Placeholder {
+			if info, statErr := os.Lstat(targetPath); statErr == nil && info.IsDir() {
+				return nil
+			}
+		}
 		if mkErr := os.MkdirAll(targetPath, 0o750); mkErr != nil {
 			return mkErr
 		}

--- a/agent/internal/backup/exclude_test.go
+++ b/agent/internal/backup/exclude_test.go
@@ -140,6 +140,11 @@ func TestCollectBackupFiles_Excludes(t *testing.T) {
 			},
 		},
 		{
+			// #5493: the excluded directory's CONTENTS are pruned, but the
+			// directory itself now gets its own (contentless) manifest
+			// entry — see TestCollectBackupFiles_ExcludedDirectoriesStillGetManifestEntries
+			// for why: without it, a directory excluded by the whole-machine
+			// preset (e.g. /proc, /tmp) never gets recreated by a rebuild.
 			name:     "directory name exclusion skips whole subtree",
 			excludes: []string{"node_modules"},
 			want: []string{
@@ -147,6 +152,7 @@ func TestCollectBackupFiles_Excludes(t *testing.T) {
 				"path_0/junk.tmp",
 				"path_0/keep.txt",
 				"path_0/src/app.ts",
+				"path_0/src/node_modules",
 			},
 		},
 		{
@@ -157,14 +163,17 @@ func TestCollectBackupFiles_Excludes(t *testing.T) {
 				"path_0/junk.tmp",
 				"path_0/keep.txt",
 				"path_0/src/app.ts",
+				"path_0/src/node_modules",
 			},
 		},
 		{
 			name:     "combined patterns",
 			excludes: []string{"*.tmp", "node_modules/**", "cache/**"},
 			want: []string{
+				"path_0/cache",
 				"path_0/keep.txt",
 				"path_0/src/app.ts",
+				"path_0/src/node_modules",
 			},
 		},
 	}
@@ -219,8 +228,11 @@ func TestCollectBackupFiles_BaseNameGlobExcludesDirectorySubtree(t *testing.T) {
 	if err != nil {
 		t.Fatalf("collectBackupFiles failed: %v", err)
 	}
-	if len(files) != 1 || files[0].snapshotPath != "path_0/keep.txt" {
-		t.Fatalf("expected only path_0/keep.txt (cache.tmp/ subtree pruned), got %+v", files)
+	// #5493: cache.tmp/ contents are pruned (data.txt never appears), but
+	// the excluded directory itself now gets a contentless KindDir entry —
+	// see TestCollectBackupFiles_ExcludedDirectoriesStillGetManifestEntries.
+	if len(files) != 2 || files[0].snapshotPath != "path_0/cache.tmp" || files[0].kind != KindDir || files[1].snapshotPath != "path_0/keep.txt" {
+		t.Fatalf("expected path_0/cache.tmp (dir) + path_0/keep.txt (cache.tmp/ subtree pruned), got %+v", files)
 	}
 }
 

--- a/agent/internal/backup/rebuild/boot.go
+++ b/agent/internal/backup/rebuild/boot.go
@@ -72,6 +72,37 @@ func grubTarget(arch string) (target, efiFile string) {
 
 var pseudoMounts = []string{"/dev", "/dev/pts", "/proc", "/sys", "/run"}
 
+// ensureMountpoints is belt-and-braces against #5493: the whole-machine
+// backup preset excludes /proc/**, /sys/**, /dev/**, /run/**, /tmp/**,
+// /var/tmp/**, /mnt/**, /media/** (apps/web's backupTabPresets.ts), and the
+// backup walker now force-records an excluded directory's own manifest
+// entry (backup.go collectBackupFilesFromPaths) precisely so these
+// directories survive a restore. This is the second line of defense for any
+// snapshot taken before that fix, or with a different exclude list, so a
+// rebuild is never left without the directories systemd needs to mount its
+// API filesystems (see boot's pseudoMounts/BindMount calls above, which
+// target exactly proc/sys/dev/run) and update-initramfs needs for scratch
+// space (mktemp under /var/tmp). Idempotent and safe to call unconditionally
+// — MkdirAll no-ops on an existing directory, and the sticky-bit chmod on
+// tmp/var/tmp is a no-op when it's already 1777.
+func ensureMountpoints(root string) error {
+	for _, name := range []string{"proc", "sys", "dev", "run", "mnt", "media"} {
+		if err := os.MkdirAll(filepath.Join(root, name), 0o755); err != nil {
+			return fmt.Errorf("ensure mount point %s: %w", name, err)
+		}
+	}
+	for _, name := range []string{"tmp", filepath.Join("var", "tmp")} {
+		dir := filepath.Join(root, name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("ensure mount point %s: %w", name, err)
+		}
+		if err := os.Chmod(dir, os.ModeSticky|0o777); err != nil {
+			return fmt.Errorf("chmod mount point %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
 func boot(ctx context.Context, r *run) error {
 	if r.opts.SkipBoot {
 		r.warn("boot phase skipped by request (SkipBoot)")

--- a/agent/internal/backup/rebuild/engine_test.go
+++ b/agent/internal/backup/rebuild/engine_test.go
@@ -360,6 +360,56 @@ func TestRun_FullLinuxFlowOnFakeSystem(t *testing.T) {
 	}
 }
 
+// #5493: found live on the bare-metal boot proof. The whole-machine backup
+// preset excludes /proc, /sys, /dev, /run, /tmp, /var/tmp, /mnt, /media, so
+// a snapshot taken before the backup-side fix (collectBackupFilesFromPaths
+// force-recording an excluded directory's own manifest entry) never
+// contains them at all — restore alone leaves the staging root without
+// them. boot()'s pseudoMounts/BindMount calls normally paper over this on a
+// real system (a bind mount creates its target), but a SkipBoot run (or any
+// run where boot() is skipped/fails before reaching them) must not depend on
+// that: restoreTree's ensureMountpoints call is the belt-and-braces fix.
+//
+// This proves it in isolation: SkipBoot means boot() never executes (and
+// fakeSystem's own BindMount, which happens to os.MkdirAll its target, never
+// fires either), and the seeded snapshot's content map (seedSnapshot) has no
+// proc/sys/dev/run/tmp entries — so these directories can only exist
+// afterward because ensureMountpoints created them.
+func TestRun_EnsureMountpointsSurvivesSkipBoot(t *testing.T) {
+	skipUnlessLinuxSystemState(t)
+	resetBmrCalls()
+	dir := t.TempDir()
+	sys := newFakeSystem(dir, 100*GiB)
+	p := seedSnapshot(t, "snap-1", testLayout())
+	staging := filepath.Join(dir, "mnt")
+	res, err := Run(context.Background(), Options{
+		SnapshotID: "snap-1", Provider: p, Target: Target{Kind: TargetImage, Path: filepath.Join(dir, "t.img"), ImageSizeBytes: 100 * GiB},
+		Identity: IdentityOriginal, StateDir: dir, StagingRoot: staging, System: sys, SkipBoot: true,
+	})
+	if err != nil {
+		t.Fatalf("err=%v\n%s", err, sys.dump())
+	}
+	if res.Status != "completed" {
+		t.Fatalf("res = %+v\n%s", res, sys.dump())
+	}
+	if sys.has("mount --bind") {
+		t.Fatalf("SkipBoot run must never bind-mount (that would mask the defect this test checks): %s", sys.dump())
+	}
+	for _, name := range []string{"proc", "sys", "dev", "run"} {
+		fi, statErr := os.Stat(filepath.Join(staging, name))
+		if statErr != nil || !fi.IsDir() {
+			t.Errorf("%s missing after a SkipBoot run: %v", name, statErr)
+		}
+	}
+	fi, statErr := os.Stat(filepath.Join(staging, "tmp"))
+	if statErr != nil || !fi.IsDir() {
+		t.Fatalf("tmp missing after a SkipBoot run: %v", statErr)
+	}
+	if fi.Mode()&os.ModeSticky == 0 || fi.Mode().Perm() != 0o777 {
+		t.Errorf("tmp mode = %v, want sticky 1777", fi.Mode())
+	}
+}
+
 func TestRun_ResumeSkipsProvisionAndReusesPlan(t *testing.T) {
 	skipUnlessLinuxSystemState(t)
 	resetBmrCalls()

--- a/agent/internal/backup/rebuild/restore_tree.go
+++ b/agent/internal/backup/rebuild/restore_tree.go
@@ -87,6 +87,14 @@ func restoreTree(ctx context.Context, r *run) error {
 			r.failedFiles[f] = true
 		}
 	}
+	// Belt-and-braces (#5493): run this even when boot() will be skipped
+	// (Options.SkipBoot) — boot() is the phase that actually bind-mounts
+	// /proc, /sys, /dev, /run, but a SkipBoot run still produces a staging
+	// tree that must be a bootable disk image, so the mount points must
+	// exist regardless of whether boot() itself runs.
+	if err := ensureMountpoints(r.staging); err != nil {
+		return fmt.Errorf("ensure mount points: %w", err)
+	}
 	if r.stateStaging != "" {
 		if entries, _ := os.ReadDir(r.stateStaging); len(entries) > 0 {
 			warnings, err := bmr.RestoreSystemStateOffline(ctx, r.staging, r.stateStaging)

--- a/agent/internal/backup/restore.go
+++ b/agent/internal/backup/restore.go
@@ -341,6 +341,7 @@ func RestoreFromSnapshotContext(ctx context.Context, provider providers.BackupPr
 		// itself is created with symlinkat and the directory with mkdirat,
 		// both relative to that pinned parent — never by pathname.
 		var entryErr error
+		skippedExistingPlaceholder := false
 		switch entry.Kind {
 		case KindSymlink:
 			var linkWarnings []error
@@ -349,14 +350,35 @@ func RestoreFromSnapshotContext(ctx context.Context, provider providers.BackupPr
 				result.Warnings = append(result.Warnings, fmt.Sprintf("recreated %s with reduced fidelity: %v", displayPath, warning))
 			}
 		case KindDir:
-			mode := os.FileMode(entry.ModeBits)
-			if !applyOwnership {
-				// A non-root owner may legitimately set sticky/setgid on its
-				// own directory; setuid on a directory is vanishingly rare and
-				// this path cannot confirm root, so it strips only that bit.
-				mode &^= os.ModeSetuid
+			// Placeholder (review fix, #5493): a pattern-excluded directory
+			// (e.g. /tmp, /proc under the whole-machine preset) is recorded
+			// purely so a rebuild recreates it at all — it is NOT a
+			// deliberately-configured mode/owner capture the way an
+			// ordinary empty-dir entry is. If it already exists, a customer
+			// may have tightened its permissions since the backup ran; an
+			// ordinary backup_restore must not silently revert that. Only
+			// apply mode/owner when this restore is the one creating the
+			// directory. securefs.StatFile is the symlink-safe existence
+			// check: it walks the same descriptor-pinned path InstallDir
+			// would, so this can't be fooled by a planted symlink into
+			// skipping (or performing) the wrong directory's metadata
+			// apply.
+			if entry.Placeholder {
+				if info, statErr := securefs.StatFile(targetBase, relativeEntry); statErr == nil && info.IsDir() {
+					skippedExistingPlaceholder = true
+				}
 			}
-			entryErr = securefs.InstallDir(targetBase, relativeEntry, mode, entry.ModeBits != 0, entryOwner(entry, applyOwnership), entry.ModTime)
+			if !skippedExistingPlaceholder {
+				mode := os.FileMode(entry.ModeBits)
+				if !applyOwnership {
+					// A non-root owner may legitimately set sticky/setgid on
+					// its own directory; setuid on a directory is
+					// vanishingly rare and this path cannot confirm root,
+					// so it strips only that bit.
+					mode &^= os.ModeSetuid
+				}
+				entryErr = securefs.InstallDir(targetBase, relativeEntry, mode, entry.ModeBits != 0, entryOwner(entry, applyOwnership), entry.ModTime)
+			}
 		default:
 			entryErr = fmt.Errorf("entry %s has content; use the file path", displayPath)
 		}
@@ -366,7 +388,7 @@ func RestoreFromSnapshotContext(ctx context.Context, provider providers.BackupPr
 			result.Warnings = append(result.Warnings, fmt.Sprintf("could not recreate %s: %v", displayPath, entryErr))
 			continue
 		}
-		if !applyOwnership && entry.Owner != nil {
+		if !skippedExistingPlaceholder && !applyOwnership && entry.Owner != nil {
 			warnOwnership()
 		}
 		result.FilesRestored++
@@ -807,6 +829,19 @@ func RestoreContentlessEntry(targetPath string, entry SnapshotFile, applyOwnersh
 			return err
 		}
 	case KindDir:
+		// Placeholder (review fix, #5493): see the matching comment in
+		// RestoreFromSnapshotContext's dir pass above — a pattern-excluded
+		// directory's manifest entry exists purely so a rebuild recreates
+		// it at all, not because its mode/owner were deliberately captured.
+		// If it's already there, a customer may have tightened its
+		// permissions since the backup; leave it untouched rather than
+		// silently reverting that, and skip the applyOwnership tail below
+		// too (return directly).
+		if entry.Placeholder {
+			if info, err := os.Lstat(targetPath); err == nil && info.IsDir() {
+				return nil
+			}
+		}
 		if err := os.MkdirAll(targetPath, 0o755); err != nil {
 			return err
 		}

--- a/agent/internal/backup/restore_test.go
+++ b/agent/internal/backup/restore_test.go
@@ -1214,6 +1214,105 @@ func TestRestore_RecreatesSymlinksDirsAndModes(t *testing.T) {
 	}
 }
 
+// Review fix (#5493): a Placeholder dir entry — the backup walker's force-
+// recorded manifest entry for a directory that matched an exclude pattern
+// (e.g. /tmp under the whole-machine preset) — must NOT have its mode/owner
+// reapplied over an ALREADY-EXISTING directory. A customer may have
+// deliberately tightened permissions on an excluded directory (or simply
+// has real, live data under it) since the backup ran; an ordinary
+// backup_restore silently reverting that would be a real regression. A
+// non-placeholder dir entry (an ordinary empty directory whose mode really
+// was captured because it mattered) keeps the existing behavior: its mode
+// is always (re)applied, even over a pre-existing directory.
+func TestRestore_PlaceholderDirLeavesExistingDirectoryUntouched(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix mode bits and ownership")
+	}
+	provider, snapshotID := setupRestoreTestSnapshot(t, map[string]string{"keep.txt": "keep"})
+
+	manifestKey := filepath.ToSlash(filepath.Join("snapshots", snapshotID, "manifest.json"))
+	tmp := filepath.Join(t.TempDir(), "m.json")
+	if err := provider.Download(manifestKey, tmp); err != nil {
+		t.Fatal(err)
+	}
+	var snap Snapshot
+	data, _ := os.ReadFile(tmp)
+	if err := json.Unmarshal(data, &snap); err != nil {
+		t.Fatal(err)
+	}
+	const sticky1777 = os.ModeSticky | 0o777
+	snap.Files = append(snap.Files,
+		SnapshotFile{SourcePath: "/original/tmp", Kind: KindDir, ModeBits: uint32(sticky1777), Placeholder: true, ModTime: time.Now().UTC()},
+		SnapshotFile{SourcePath: "/original/var/empty", Kind: KindDir, ModeBits: 0o700, ModTime: time.Now().UTC()},
+	)
+	snap.FormatVersion = manifestFormatFidelity
+	out, _ := json.Marshal(snap)
+	if err := os.WriteFile(tmp, out, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := provider.Upload(tmp, manifestKey); err != nil {
+		t.Fatal(err)
+	}
+
+	target := t.TempDir()
+	// Pre-create the placeholder's target directory with a mode the
+	// manifest does NOT carry, and a file inside it — simulating a
+	// customer who tightened /tmp's permissions (or just has real data
+	// there) since the backup ran.
+	existingTmp := filepath.Join(target, "original", "tmp")
+	if err := os.MkdirAll(existingTmp, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(existingTmp, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	existingFile := filepath.Join(existingTmp, "existing.txt")
+	if err := os.WriteFile(existingFile, []byte("do not touch"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Pre-create the NON-placeholder empty-dir target too, with a
+	// different mode than the manifest carries, to prove the fix is
+	// scoped to Placeholder entries only.
+	existingEmpty := filepath.Join(target, "original", "var", "empty")
+	if err := os.MkdirAll(existingEmpty, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := RestoreFromSnapshot(provider, RestoreConfig{SnapshotID: snapshotID, TargetPath: target}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != "completed" || res.FilesFailed != 0 {
+		t.Fatalf("result = %+v", res)
+	}
+	// keep.txt (1) + tmp (1, placeholder, metadata skipped but still
+	// counted as restored) + var/empty (1) = 3.
+	if res.FilesRestored != 3 {
+		t.Errorf("FilesRestored = %d, want 3 (the placeholder dir still counts as restored)", res.FilesRestored)
+	}
+
+	fi, err := os.Stat(existingTmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Mode()&os.ModeSticky != 0 || fi.Mode().Perm() != 0o700 {
+		t.Errorf("placeholder dir mode = %v, want unchanged 0700 (no sticky bit applied)", fi.Mode())
+	}
+	if data, err := os.ReadFile(existingFile); err != nil || string(data) != "do not touch" {
+		t.Errorf("existing file inside the placeholder dir was touched: data=%q err=%v", data, err)
+	}
+
+	// The non-placeholder empty-dir entry DOES get its mode (re)applied —
+	// existing behavior, unaffected by this fix.
+	fi, err = os.Stat(existingEmpty)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Mode().Perm() != 0o700 {
+		t.Errorf("non-placeholder empty dir mode = %v, want 0700 applied from the manifest", fi.Mode())
+	}
+}
+
 // Review finding #1 (PR #5520): a resumed restore's file pass must never
 // write THROUGH an ancestor that is a symlink. A prior (possibly
 // interrupted) run may have already recreated a directory-shaped manifest

--- a/agent/internal/backup/snapshot.go
+++ b/agent/internal/backup/snapshot.go
@@ -286,6 +286,21 @@ type SnapshotFile struct {
 	// uploaded. Omitted (false) for the overwhelming majority of files,
 	// keeping ordinary manifests byte-identical to before this field existed.
 	Volatile bool `json:"volatile,omitempty"`
+	// Placeholder is true ONLY for a KindDir entry that the walker force-
+	// recorded because the directory itself matched a user/preset exclude
+	// pattern (#5493) — e.g. /proc, /tmp under the whole-machine preset.
+	// Its mode/owner exist so a rebuild into an EMPTY tree still gets them,
+	// but they were never a deliberate "this directory's permissions
+	// matter" capture the way a genuinely empty or non-default-mode dir
+	// entry's are. Restore honors that distinction: mode/owner are applied
+	// only when creating the directory fresh; an ALREADY-EXISTING
+	// directory is left untouched, so an ordinary backup_restore can never
+	// silently revert permissions a customer tightened on an excluded
+	// directory after the backup ran (review fix). Never set for a
+	// genuinely empty or non-default-mode directory, nor for a file or
+	// symlink. Omitted (false) for every manifest written before this field
+	// existed, keeping them byte-identical.
+	Placeholder bool `json:"placeholder,omitempty"`
 }
 
 // HasContent reports whether the entry has an uploaded object at BackupPath.
@@ -313,6 +328,7 @@ func contentlessEntry(f backupFile) SnapshotFile {
 		LinkTarget:   f.linkTarget,
 		ModeBits:     f.modeBits,
 		Owner:        f.owner,
+		Placeholder:  f.placeholder,
 	}
 }
 

--- a/agent/internal/backup/vss_provider_seam_test.go
+++ b/agent/internal/backup/vss_provider_seam_test.go
@@ -502,3 +502,49 @@ func TestRunBackupContext_JournalHardExclude_MatchesVSSShadowPath(t *testing.T) 
 		}
 	}
 }
+
+// Review fix (#5493): the journal directory must never appear in the
+// manifest — not even when it ALSO happens to match a user-configured
+// exclude pattern broad enough to catch it by name (e.g. an explicit
+// "**/backup-journal/**" exclude). Before the fix, the walker's dir branch
+// checked the pattern-match branch before the journalDirs hard-exclude, so
+// a directory that was BOTH the journal dir AND pattern-excluded got
+// force-recorded as a Placeholder KindDir manifest entry — reintroducing
+// exactly what #5581 was meant to prevent. Sibling of
+// TestRunBackupContext_JournalHardExclude_MatchesVSSShadowPath above (which
+// covers the VSS-shadow-path case); no VSS involved here.
+func TestRunBackupContext_JournalHardExclude_WinsOverMatchingUserExclude(t *testing.T) {
+	srcDir := t.TempDir()
+	journalDir := filepath.Join(srcDir, "backup-journal")
+	if err := os.MkdirAll(journalDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	createTempFile(t, journalDir, "backup-journal-deadbeefdeadbeef.jsonl", "{\"snapshotId\":\"stale\"}\n")
+	createTempFile(t, srcDir, "real.txt", "keep me")
+
+	provider := newMockProvider()
+	mgr := NewBackupManager(BackupConfig{
+		Provider: provider,
+		Paths:    []string{srcDir},
+		// Broad enough to ALSO match the journal dir by name — the
+		// scenario that must not force a manifest entry for it.
+		Excludes:   []string{"**/backup-journal/**"},
+		StagingDir: journalDir,
+	})
+
+	job, err := mgr.RunBackupContext(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("RunBackupContext failed: %v", err)
+	}
+	if job.Snapshot == nil {
+		t.Fatal("expected a snapshot")
+	}
+	if len(job.Snapshot.Files) != 1 || job.Snapshot.Files[0].SourcePath != filepath.Join(srcDir, "real.txt") {
+		t.Fatalf("expected only real.txt in the snapshot — the journal dir must get no entry, forced or not, got %+v", job.Snapshot.Files)
+	}
+	for _, call := range provider.uploadCalls {
+		if strings.Contains(call.localPath, "backup-journal") {
+			t.Errorf("must never upload a file from the checkpoint-journal directory, got upload of %q", call.localPath)
+		}
+	}
+}


### PR DESCRIPTION
## Defect

Found live on the bare-metal boot proof (feature #5493). The whole-machine preset excludes `/proc/**`, `/sys/**`, `/dev/**`, `/run/**`, `/tmp/**`, `/var/tmp/**`, `/mnt/**`, `/media/**`.

In `agent/internal/backup/backup.go` `collectBackupFilesFromPaths`, an excluded directory was pruned with `fs.SkipDir` and never added to the walker's candidate-directory list at all, so it could never become its own `dir` manifest entry (W02 `dirNeedsEntry`). Separately, `childCount[parent]++` ran for excluded children too, so a directory whose children were all excluded (but which wasn't itself excluded) still looked non-empty and also got no entry.

Result: the rebuilt root had **no `/proc`, `/sys`, `/dev`, `/run`, `/tmp`, `/var/tmp`** directories. systemd could not mount its API filesystems, and `update-initramfs` failed with:

```
mktemp: failed to create directory via template '/var/tmp/mkinitramfs_XXXXXX': No such file or directory
```

## Changes

- **`backup.go`**: a directory excluded by pattern (`excl.matches(slashRel)` → `fs.SkipDir`) is now force-recorded as a `KindDir` manifest entry — mode/owner captured via the existing `dirNeedsEntry`/`fileOwner` path but bypassing `dirNeedsEntry`'s emptiness/mode check, since nothing else in the manifest will ever recreate an excluded directory. It no longer contributes to its own parent's `childCount`. An excluded **file** also no longer contributes to its parent's `childCount` (the increment moved after the exclusion check), so a directory whose children are all excluded — not just a directory that is itself excluded — still reads as empty and gets its own entry.
  - The journal directory (`#5581`'s hard-exclude, riding the same `fs.SkipDir` path) is deliberately **not** forced: it's this run's own ephemeral bookkeeping location and must never appear in the manifest at all — `TestRunBackupContext_JournalHardExclude_MatchesVSSShadowPath` pins this.
  - The walk root itself is still never recorded (unchanged).
- **`rebuild/boot.go` + `rebuild/restore_tree.go`**: belt-and-braces `ensureMountpoints(root string) error` creates `proc sys dev run mnt media` (0755) and chmods `tmp`, `var/tmp` to sticky 1777 under the staging root. Called from `restoreTree` right after the file restore so it **always** runs even when `SkipBoot` is set (`boot()` itself, which normally bind-mounts these into existence as a side effect, is skipped in that case). Covers any snapshot taken before this fix, or with a different exclude list.

## Tests (red-first)

Reverted each fix (`git checkout --` on the source files, keeping only the new/updated tests), confirmed the new tests failed against the unfixed code, then reapplied the fix and confirmed green.

- `backup_collect_test.go`:
  - `TestCollectBackupFiles_ExcludedDirectoriesStillGetManifestEntries` — tree `root/{proc/x, tmp(1777)/y, var/tmp(1777)/z, var/log/syslog, etc/hosts}` with excludes `/proc/**`, `/tmp/**`, `/var/tmp/**`: entries include `proc` (dir, 0755), `tmp` (dir, sticky 1777), `var/tmp` (dir, sticky 1777); NOT `proc/x`, `tmp/y`, `var/tmp/z`; `var` gets no entry (included child + default mode); `var/log/syslog` and `etc/hosts` are backed up normally.
  - `TestCollectBackupFiles_DirectoryWithOnlyExcludedChildrenBecomesEmptyDirEntry` — a `cache/` dir holding only `*.tmp` files under a `*.tmp` exclude becomes an empty-dir entry.
- `exclude_test.go`: updated three `TestCollectBackupFiles_Excludes` table cases and `TestCollectBackupFiles_BaseNameGlobExcludesDirectorySubtree`, which encoded the old (buggy) "excluded dir never gets an entry" behavior as their expected output.
- `restore_test.go`: `TestRestore_RecreatesSymlinksDirsAndModes` already asserts a `KindDir` entry with `ModeBits` sticky 1777 (the `usr/bin` case) restores as sticky 1777 — left as-is per the task's "may already exist; if so, leave it."
- `rebuild/engine_test.go`: `TestRun_EnsureMountpointsSurvivesSkipBoot` — runs with `SkipBoot: true` (so `boot()`'s own `BindMount`, which happens to `MkdirAll` its target on `fakeSystem`, never fires) against a seeded snapshot whose content map has no `proc/sys/dev/run/tmp` entries at all; asserts they exist afterward, with `tmp` at sticky 1777 — proving `ensureMountpoints`, not `boot()`, created them.

## Verification

```
cd agent && go test -race -count=1 ./internal/backup/... ./cmd/breeze-backup/
# ok

GOOS=windows go vet ./internal/backup/...
# clean except 3 pre-existing "possible misuse of unsafe.Pointer" in
# vss_windows.go — untouched by this change, present on origin/main already

docker run --rm -v "$PWD":/src -w /src golang:1.26 go test -race -count=1 ./internal/backup/rebuild/
# ok (Linux-gated rebuild tests, including the new SkipBoot one)

git fetch origin main && golangci-lint run --new-from-rev=origin/main ./...
# 0 issues.
```

## Deviations

None from the task's instructions. The one judgment call: only the pattern-exclusion branch of the shared `fs.SkipDir` path forces a manifest entry — the journal-dir hard-exclude branch does not, since an existing test (`TestRunBackupContext_JournalHardExclude_MatchesVSSShadowPath`) requires the journal directory itself to never appear in the manifest.


## Review fixes

Two confirmed issues from review, fixed red-first on this branch (commit `c075113751`):

1. **Live/selective restores re-permissioned existing pattern-excluded directories.** `restore.go`'s `KindDir` dir pass → `securefs.InstallDir` → `installDir`'s `Fchown`/`Fchmod` ran on an already-existing directory (opened via `Mkdirat`+`EEXIST`). A customer who tightened an excluded dir's permissions (e.g. `/tmp`) since the backup got that silently reverted by an ordinary `backup_restore`.
   - Fix: new `SnapshotFile.Placeholder bool` (`json:"placeholder,omitempty"`), set by the walker **only** for forced (pattern-excluded) dir entries — never for genuinely empty/non-default-mode dirs, never for files/symlinks. On restore (`RestoreFromSnapshotContext`'s dir pass, `RestoreContentlessEntry`, and bmr's `restoreContentlessEntry`), a `Placeholder` dir gets its recorded mode/owner applied **only** when it does not already exist; an existing directory is left completely untouched (still counted toward `FilesRestored`). The existence check uses `securefs.StatFile` — the same symlink-safe, descriptor-pinned walk `InstallDir` itself uses. The rebuild engine restores into an empty tree, so placeholders still land with their modes there. Manifests without the field stay byte-identical.
2. **A directory that was both pattern-excluded AND the journal dir got force-recorded.** `backup.go`'s walker evaluated `excludedByPattern` before `isWithinAnyDir(path, journalDirs)`, so a user exclude broad enough to also match the journal dir by name (e.g. `**/backup-journal/**`) would reintroduce exactly what #5581's hard-exclude was meant to prevent.
   - Fix: reordered the walker to check `journalDirs` **first** and return `fs.SkipDir` immediately, before the pattern-exclusion branch is even evaluated — the journal dir now unconditionally wins.

**Tests (red-first):** reverted each fix's behavior in place (keeping the tests), confirmed the tests failed against unfixed code, restored the fix, confirmed green.
- `backup_collect_test.go`: extended `TestCollectBackupFiles_ExcludedDirectoriesStillGetManifestEntries` to assert `Placeholder=true` on the `proc`/`tmp`/`var/tmp` entries; the "cache" (all-children-excluded) and "var/empty" (genuinely-empty) entries assert `Placeholder=false`.
- `restore_test.go`: new `TestRestore_PlaceholderDirLeavesExistingDirectoryUntouched` — pre-creates `target/original/tmp` at mode 0700 with a file inside, restores a manifest whose `tmp` entry is `Placeholder` with `ModeBits` sticky 1777 → mode stays 0700, the file is untouched, `FilesRestored` still counts it; a sibling non-placeholder empty-dir entry pre-created at a different mode DOES get its manifest mode reapplied (existing behavior). Red repro (neutralized the `Placeholder` branch): the dir ended up sticky 1777, reproducing the exact defect.
- `vss_provider_seam_test.go`: new `TestRunBackupContext_JournalHardExclude_WinsOverMatchingUserExclude` (sibling of the existing VSS-shadow-path journal test) — an explicit `**/backup-journal/**` exclude that also matches the journal dir by name; asserts the snapshot contains only the unrelated file, never an entry for the journal dir. Red repro (restored the old evaluation order): a `Placeholder:true` `KindDir` entry for `backup-journal` appeared in the manifest, reproducing the exact defect.

**Verification (re-run in full):**
```
cd agent && go test -race -count=1 ./internal/backup/... ./cmd/breeze-backup/
# ok

docker run --rm -v "$PWD":/src -w /src golang:1.26 go test -race -count=1 ./internal/backup/rebuild/
# ok

GOOS=windows go vet ./internal/backup/...
# clean except the same 3 pre-existing "possible misuse of unsafe.Pointer"
# in vss_windows.go — untouched by this change, present on origin/main already

golangci-lint run --new-from-rev=origin/main ./...
# 0 issues.
```

Part of #5497

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NLb6JEZ2mPgPiaFBFtq11E
