### PR TITLE
fix(peripheral): stop reconciling decommissioned devices (#5590)

### DIFF
--- a/apps/api/src/jobs/peripheralJobs.ts
+++ b/apps/api/src/jobs/peripheralJobs.ts
@@ -498,6 +498,7 @@ export async function processPeripheralPolicyReconciliationSweep(
     .where(and(
       eq(devices.isEphemeral, false),
       eq(devices.peripheralPolicyProtocolVersion, 2),
+      ne(devices.status, 'decommissioned'),
       ...(afterId ? [gt(devices.id, afterId)] : []),
     ))
     .orderBy(asc(devices.id))

--- a/apps/api/src/jobs/peripheralPolicyReconciliation.test.ts
+++ b/apps/api/src/jobs/peripheralPolicyReconciliation.test.ts
@@ -33,6 +33,7 @@ vi.mock('../db/schema', () => ({
     siteId: 'device.siteId',
     isEphemeral: 'device.isEphemeral',
     peripheralPolicyProtocolVersion: 'device.peripheralPolicyProtocolVersion',
+    status: 'device.status',
   },
   organizations: { id: 'organization.id', partnerId: 'organization.partnerId', type: 'organization.type' },
   peripheralEvents: {},
@@ -48,6 +49,8 @@ vi.mock('../services/peripheralPolicyState', () => ({
   reconcilePeripheralPolicyDevice: vi.fn(),
 }));
 
+import { and, eq, ne } from 'drizzle-orm';
+import { devices } from '../db/schema';
 import {
   processPeripheralPolicyReconciliationSweep,
   resolvePeripheralPolicyDeviceIds,
@@ -145,6 +148,25 @@ describe('schedulePeripheralPolicyDevice', () => {
       ['device-2', 'periodic_drift'],
       ['device-3', 'periodic_drift'],
     ]);
+  });
+
+  it('never sweeps decommissioned devices in the default fleet page query', async () => {
+    const where = vi.fn().mockReturnValue({
+      orderBy: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
+    });
+    selectMock.mockReturnValue({ from: vi.fn().mockReturnValue({ where }) });
+
+    await expect(processPeripheralPolicyReconciliationSweep({
+      pageSize: 50,
+      reconcile: vi.fn(),
+    })).resolves.toEqual({ scanned: 0, queued: 0, coalesced: 0, incompatible: 0 });
+
+    expect(where).toHaveBeenCalledTimes(1);
+    expect(where.mock.calls[0]?.[0]).toEqual(and(
+      eq(devices.isEphemeral, false),
+      eq(devices.peripheralPolicyProtocolVersion, 2),
+      ne(devices.status, 'decommissioned'),
+    ));
   });
 
   it('installs one jittered recurring sweep instead of synchronized fleet work', async () => {

--- a/apps/api/src/services/peripheralPolicyState.test.ts
+++ b/apps/api/src/services/peripheralPolicyState.test.ts
@@ -265,6 +265,7 @@ describe('reconcilePeripheralPolicyDevice trust gate', () => {
                 id: identity.deviceId,
                 orgId: identity.orgId,
                 peripheralPolicyProtocolVersion: 2,
+                status: 'active',
               }]),
             }),
           }),
@@ -276,6 +277,31 @@ describe('reconcilePeripheralPolicyDevice trust gate', () => {
         }),
       });
     loadEffectivePolicyMock.mockResolvedValue({ identity, effectivePolicies });
+  });
+
+  it('treats a decommissioned device as incompatible without consulting partner trust', async () => {
+    txMock.select.mockReset();
+    txMock.select.mockReturnValueOnce({
+      from: () => ({
+        where: () => ({
+          limit: () => ({
+            for: () => Promise.resolve([{
+              id: identity.deviceId,
+              orgId: identity.orgId,
+              peripheralPolicyProtocolVersion: 2,
+              status: 'decommissioned',
+            }]),
+          }),
+        }),
+      }),
+    });
+
+    await expect(reconcilePeripheralPolicyDevice(identity.deviceId, 'periodic_drift'))
+      .resolves.toBe('incompatible');
+
+    expect(assertDeviceExecuteAllowedMock).not.toHaveBeenCalled();
+    expect(txMock.insert).not.toHaveBeenCalled();
+    expect(txMock.update).not.toHaveBeenCalled();
   });
 
   it('warns and skips all writes when partner trust denies the policy push', async () => {

--- a/apps/api/src/services/peripheralPolicyState.ts
+++ b/apps/api/src/services/peripheralPolicyState.ts
@@ -181,11 +181,17 @@ export async function reconcilePeripheralPolicyDevice(
         id: devices.id,
         orgId: devices.orgId,
         peripheralPolicyProtocolVersion: devices.peripheralPolicyProtocolVersion,
+        status: devices.status,
       })
       .from(devices)
       .where(eq(devices.id, deviceId))
       .limit(1)
       .for('update');
+    // A decommissioned device can never execute a command, and reconciling it
+    // would reach the partner-trust gate below and spam capability_denied audit
+    // rows every sweep (issue #5590). Bail before any trust check or write.
+    if (device?.status === 'decommissioned') return 'incompatible';
+
     const resolved = device
       ? await loadAndResolveEffectivePeripheralPolicySetInCurrentDbContext(deviceId)
       : null;


### PR DESCRIPTION
Closes #5590

## Problem

`processPeripheralPolicyReconciliationSweep` (`apps/api/src/jobs/peripheralJobs.ts`, 15-min BullMQ repeat) paged the fleet filtered only on `isEphemeral=false` and `peripheralPolicyProtocolVersion=2` — no status predicate, unlike the org distribution path in the same file. So every decommissioned v2 device kept getting reconciled forever:

- **Probation partner** → `assertDeviceExecuteAllowed` writes a `partner.trust.capability_denied` audit row every sweep. On US prod one dead device (decommissioned 2 minutes after enrolment) produced 83 of the 96 trust denials in 3 days, polluting the counters the abuse sweep reads.
- **Trusted partner** → a pending `peripheral_policy_sync_v2` command is enqueued every 15 min to a device that will never come back.

## Changes

1. `peripheralJobs.ts` — default `loadPage` query now includes `ne(devices.status, 'decommissioned')`.
2. `peripheralPolicyState.ts` — `reconcilePeripheralPolicyDevice` selects `devices.status` and returns `'incompatible'` for a decommissioned device **before** resolving effective policies and before the partner-trust gate, so ad-hoc and `clear_legacy_applied` callers can't re-trigger it either.
3. Tests (red first):
   - `peripheralPolicyReconciliation.test.ts` exercises the *default* page query through the drizzle mock and asserts the where clause equals the expected `and(...)` including the bound `status` condition (structural equality against operators built in the test, not a deep value search).
   - `peripheralPolicyState.test.ts` asserts reconcile resolves `'incompatible'` for a decommissioned device with `assertDeviceExecuteAllowed` never called and no inserts/updates.

## Verification

- `npx vitest run src/jobs/peripheralPolicyReconciliation.test.ts src/services/peripheralPolicyState.test.ts src/jobs/peripheralJobs.test.ts` → 3 files, 23 tests passed.
- `npx tsc --noEmit` in `apps/api` → clean.
- No schema, migration or tenancy surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LVTfF92bPb8YZJYLptWr11