### PR TITLE
fix(ai): persist approvalMode on the first ai_budgets save (#5592)

### DIFF
--- a/apps/api/src/services/aiCostTracker.test.ts
+++ b/apps/api/src/services/aiCostTracker.test.ts
@@ -14,6 +14,7 @@ import {
   recordUsage,
   recordUsageFromSdkResult,
   sumInputTokens,
+  updateBudget,
 } from './aiCostTracker';
 import { db, withSystemDbAccessContext } from '../db';
 import { getEffectiveAiBudget } from './effectiveSettings';
@@ -1906,5 +1907,103 @@ describe('billing telemetry', () => {
     // A deployment mode, not a failure — reporting it would be pure noise.
     expect(vi.mocked(captureMessage)).not.toHaveBeenCalled();
     expect(vi.mocked(captureException)).not.toHaveBeenCalled();
+  });
+});
+
+// ============================================
+// updateBudget — #5592
+// ============================================
+
+/**
+ * Wire `db` for updateBudget: `existingRow` drives the `ai_budgets` lookup
+ * (`undefined` = no row yet, so the insert branch runs). Returns the values
+ * handed to `db.insert(aiBudgets).values(...)` / `db.update(...).set(...)`.
+ */
+function setupBudgetDbMocks(existingRow?: Record<string, unknown>) {
+  const capture: {
+    insertValues?: Record<string, unknown>;
+    updateSet?: Record<string, unknown>;
+  } = {};
+
+  mockDb.select.mockImplementation(() => ({
+    from: vi.fn(() => ({
+      where: vi.fn(() => ({
+        limit: vi.fn().mockResolvedValue(existingRow ? [existingRow] : []),
+      })),
+    })),
+  }));
+
+  mockDb.insert.mockReturnValue({
+    values: vi.fn(async (values: Record<string, unknown>) => {
+      capture.insertValues = values;
+    }),
+  });
+
+  mockDb.update.mockReturnValue({
+    set: vi.fn((values: Record<string, unknown>) => {
+      capture.updateSet = values;
+      return { where: vi.fn().mockResolvedValue(undefined) };
+    }),
+  });
+
+  return capture;
+}
+
+describe('updateBudget', () => {
+  it('persists approvalMode on the FIRST save for an org with no ai_budgets row', async () => {
+    const capture = setupBudgetDbMocks();
+
+    await updateBudget('org-budget-1', { approvalMode: 'auto_approve' });
+
+    expect(mockDb.insert).toHaveBeenCalledTimes(1);
+    expect(mockDb.update).not.toHaveBeenCalled();
+    // The bug (#5592): the insert branch enumerated columns and omitted
+    // approvalMode, so the row fell back to the `per_step` column default and
+    // the user's choice was silently discarded until a second save.
+    expect(capture.insertValues?.approvalMode).toBe('auto_approve');
+  });
+
+  it('defaults approvalMode to per_step when the first save does not set it', async () => {
+    const capture = setupBudgetDbMocks();
+
+    await updateBudget('org-budget-2', { enabled: false });
+
+    expect(capture.insertValues?.approvalMode).toBe('per_step');
+  });
+
+  it('carries every settings field through the insert branch', async () => {
+    const capture = setupBudgetDbMocks();
+
+    await updateBudget('org-budget-3', {
+      enabled: false,
+      monthlyBudgetCents: 5000,
+      dailyBudgetCents: 250,
+      maxTurnsPerSession: 10,
+      messagesPerMinutePerUser: 5,
+      messagesPerHourPerOrg: 60,
+      approvalMode: 'hybrid_plan',
+      alertThresholdPercents: [50, 90],
+    });
+
+    expect(capture.insertValues).toMatchObject({
+      orgId: 'org-budget-3',
+      enabled: false,
+      monthlyBudgetCents: 5000,
+      dailyBudgetCents: 250,
+      maxTurnsPerSession: 10,
+      messagesPerMinutePerUser: 5,
+      messagesPerHourPerOrg: 60,
+      approvalMode: 'hybrid_plan',
+      alertThresholdPercents: [50, 90],
+    });
+  });
+
+  it('updates in place (no insert) when a row already exists', async () => {
+    const capture = setupBudgetDbMocks({ orgId: 'org-budget-4' });
+
+    await updateBudget('org-budget-4', { approvalMode: 'action_plan' });
+
+    expect(mockDb.insert).not.toHaveBeenCalled();
+    expect(capture.updateSet?.approvalMode).toBe('action_plan');
   });
 });

--- a/apps/api/src/services/aiCostTracker.ts
+++ b/apps/api/src/services/aiCostTracker.ts
@@ -1349,6 +1349,11 @@ export async function updateBudget(orgId: string, settings: {
       maxTurnsPerSession: settings.maxTurnsPerSession ?? 50,
       messagesPerMinutePerUser: settings.messagesPerMinutePerUser ?? 20,
       messagesPerHourPerOrg: settings.messagesPerHourPerOrg ?? 200,
+      // #5592 — this branch enumerates columns, so every field of the
+      // `settings` parameter must appear here. Omitting one silently discards
+      // the user's choice on the FIRST save (the row takes the column default)
+      // and only sticks on the second save, which takes the update branch.
+      approvalMode: settings.approvalMode ?? 'per_step',
       alertThresholdPercents: settings.alertThresholdPercents ?? null,
     });
   }


### PR DESCRIPTION
Closes #5592

## Problem

`updateBudget` (`apps/api/src/services/aiCostTracker.ts`) has two branches. The update branch spreads `settings`, so `approvalMode` persists. The insert branch — taken on the **first** save for an org with no `ai_budgets` row — enumerated columns explicitly and omitted `approvalMode`, so the row was created with the column default `per_step` regardless of what the user chose. Saving a second time persisted it, because that takes the update branch.

Verified on US prod (v0.111.1) for org `8f2318e1`: `audit_logs` recorded `ai.budget.update`, but the row had `approval_mode = 'per_step'` with `created_at = updated_at`.

## Fix

Add `approvalMode: settings.approvalMode ?? 'per_step'` to the insert branch, matching the column default.

Audited the insert branch against the full `updateBudget` settings parameter type — `approvalMode` was the **only** dropped field; the other seven (`enabled`, `monthlyBudgetCents`, `dailyBudgetCents`, `maxTurnsPerSession`, `messagesPerMinutePerUser`, `messagesPerHourPerOrg`, `alertThresholdPercents`) were all already present.

## Tests

Four new unit tests in `aiCostTracker.test.ts` (red-first — the first three failed against the unfixed code, the fourth passed as the control for the update branch):

- first save with `approvalMode: 'auto_approve'` inserts that value
- first save without `approvalMode` inserts `per_step`
- every field of the settings type is carried through the insert branch (so the next added setting cannot be dropped the same way)
- an existing row takes the update branch, no insert

`npx vitest run src/services/aiCostTracker.test.ts` → 105 passed. `npx tsc --noEmit` in `apps/api` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eg6fDo1pYRJSgegy1LigNu