### PR TITLE
fix(web): render deliverable due dates and key dates as calendar dates (#5573 smoke)

### DIFF
--- a/apps/web/src/components/organizations/record/OrgKeyDatesCard.test.tsx
+++ b/apps/web/src/components/organizations/record/OrgKeyDatesCard.test.tsx
@@ -1,3 +1,7 @@
+// Date-only values (YYYY-MM-DD) are calendar dates, not instants. A zone west of
+// UTC is where parsing them as UTC midnight renders the previous day (#5573 smoke).
+process.env.TZ = 'America/Denver';
+
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -103,6 +107,8 @@ describe('OrgKeyDatesCard', () => {
     expect(within(contractRow).queryByTestId('key-date-delete-contract:c-1')).toBeNull();
 
     expect(within(keyRow).getByText('Insurance renewal')).toBeTruthy();
+    // 2026-11-01 must render as November 1st in every timezone, never October 31st.
+    expect(within(keyRow).getByText(/11\/1\/2026/)).toBeTruthy();
     expect(within(keyRow).getByTestId('key-date-edit-kd-1')).toBeTruthy();
     expect(within(keyRow).getByTestId('key-date-delete-kd-1')).toBeTruthy();
 

--- a/apps/web/src/components/organizations/record/OrgKeyDatesCard.tsx
+++ b/apps/web/src/components/organizations/record/OrgKeyDatesCard.tsx
@@ -10,7 +10,7 @@ import {
   type KeyDate,
   type KeyDateKind,
 } from '@/lib/api/orgKeyDates';
-import { formatDate } from '@/lib/dateTimeFormat';
+import { formatDate } from '@/components/billing/shared/format';
 import { ActionError, handleActionError } from '@/lib/runAction';
 import { runClientAction } from '@/lib/runClientAction';
 import { useLatest, type OrgFetch } from './orgRecordFetch';

--- a/apps/web/src/components/organizations/record/OrgServiceTab.test.tsx
+++ b/apps/web/src/components/organizations/record/OrgServiceTab.test.tsx
@@ -1,3 +1,7 @@
+// Date-only values (YYYY-MM-DD) are calendar dates, not instants. A zone west of
+// UTC is where parsing them as UTC midnight renders the previous day (#5573 smoke).
+process.env.TZ = 'America/Denver';
+
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -123,6 +127,10 @@ describe('OrgServiceTab', () => {
     expect(items.length).toBe(2);
     expect(items[0]).toContain('Soon');
     expect(items[1]).toContain('Later this quarter');
+    // The due date is a calendar date: render the same day the API sent, not the
+    // previous day that a UTC-midnight parse yields west of Greenwich.
+    const laterIso = isoDaysFromToday(60);
+    expect(items[1]).toContain(new Date(`${laterIso}T00:00:00`).toLocaleDateString());
     expect(upcoming.textContent).not.toContain('Far away');
     expect(upcoming.textContent).not.toContain('Overdue');
     expect(upcoming.textContent).not.toContain('Unscheduled');

--- a/apps/web/src/components/organizations/record/OrgServiceTab.tsx
+++ b/apps/web/src/components/organizations/record/OrgServiceTab.tsx
@@ -5,7 +5,7 @@ import DeliverableForm from '@/components/deliverables/DeliverableForm';
 import DeliverableTable from '@/components/deliverables/DeliverableTable';
 import OccurrenceDrawer from '@/components/deliverables/OccurrenceDrawer';
 import { listDeliverables, unwrapData, type Deliverable } from '@/lib/api/serviceDeliverables';
-import { formatDate } from '@/lib/dateTimeFormat';
+import { formatDate } from '@/components/billing/shared/format';
 import { ActionError } from '@/lib/runAction';
 import { useLatest, type OrgFetch } from './orgRecordFetch';
 


### PR DESCRIPTION
## Summary

Two W01 surfaces of #5573 formatted date-only API values (`YYYY-MM-DD`) through the timezone-aware `@/lib/dateTimeFormat` formatter, which parses them as UTC midnight. West of Greenwich that renders the previous calendar day.

Observed on the wt-stack browser smoke (America/Denver):
- Key dates card: a key date stored as `2027-03-01` displayed as **2/28/2027**.
- Service tab: the same occurrence read **9/29/2026** in the "Upcoming 90 days" list and **9/30/2026** in the deliverables table directly below it.

Fix: both components now use the date-only-safe `formatDate` from `components/billing/shared/format`, which is what the deliverable table and occurrence drawer already use, so all four surfaces agree.

## Tests

Red-first: both suites pin `process.env.TZ = 'America/Denver'` before any import so the regression is visible on CI's UTC runners. Ran unfixed → 2 failures (`10/31/2026` and the day-before due date); fixed → 15/15.

```
cd apps/web && npx vitest run src/components/organizations/record/OrgKeyDatesCard.test.tsx src/components/organizations/record/OrgServiceTab.test.tsx
```

`tsc --noEmit` (web) exit 0; eslint on the four files clean.

## Smoke result (W01 plan Task 15 step 4)

On a stack at `origin/main` (8cd00e1c49, contains W01 #5580): create deliverable → list under "No contract" → open occurrences drawer → mark delivered with note → reopen → waive with reason → add key date. Every transition persisted (checked in Postgres) and the API returned 200 on each route. Only this display defect found. Contract-linked creation was not smoked (no contract in the seeded stack); the HTTP-level integration suite in #5580 covers it.

Related: #5573

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182FGz9TgnURQQbBq44rMNa