### PR TITLE
fix(ai): AI credit calls must use the /billing/api/internal prefix (#5591)

### DIFF
--- a/apps/api/src/__tests__/integration/partnerLlmByokBilling.integration.test.ts
+++ b/apps/api/src/__tests__/integration/partnerLlmByokBilling.integration.test.ts
@@ -90,7 +90,7 @@ describe('partner LLM BYOK billing split', () => {
 
       expect(fetchSpy).toHaveBeenCalledTimes(1);
       expect(fetchSpy).toHaveBeenCalledWith(
-        `https://billing.internal/api/internal/partners/${partner.id}/ai-credits/deduct`,
+        `https://billing.internal/billing/api/internal/partners/${partner.id}/ai-credits/deduct`,
         expect.objectContaining({ method: 'POST' }),
       );
     } finally {

--- a/apps/api/src/services/aiCostTracker.test.ts
+++ b/apps/api/src/services/aiCostTracker.test.ts
@@ -493,7 +493,7 @@ describe('recordUsageFromSdkResult', () => {
     expect(captured.aggregateValues.every((values) => values.billingSource === 'platform')).toBe(true);
     expect(captured.aggregateConflictSets.every((set) => set.billingSource === 'platform')).toBe(true);
     expect(fetchMock).toHaveBeenCalledWith(
-      'https://billing.internal/api/internal/partners/partner-1/ai-credits/deduct',
+      'https://billing.internal/billing/api/internal/partners/partner-1/ai-credits/deduct',
       expect.objectContaining({ method: 'POST' }),
     );
   });
@@ -1006,7 +1006,7 @@ describe('recordSessionlessSdkUsage', () => {
     await recordSessionlessSdkUsage('org-1', agentRunUsage, 'platform');
 
     expect(fetchMock).toHaveBeenCalledWith(
-      'https://billing.internal/api/internal/partners/partner-1/ai-credits/deduct',
+      'https://billing.internal/billing/api/internal/partners/partner-1/ai-credits/deduct',
       expect.objectContaining({ method: 'POST' }),
     );
     const body = JSON.parse((fetchMock.mock.calls[0]![1] as { body: string }).body);
@@ -1691,7 +1691,7 @@ describe('getUsageSummary: credit cache read-through (#4388 W04)', () => {
     expect(summary.credits).toMatchObject({ remaining: 777, includedBalance: 200, purchasedBalance: 577 });
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledWith(
-      'https://billing.internal/api/internal/partners/partner-1/ai-credits',
+      'https://billing.internal/billing/api/internal/partners/partner-1/ai-credits',
       expect.objectContaining({ headers: { Authorization: 'Bearer billing-key' } }),
     );
     expect(redisSet).toHaveBeenCalledWith(
@@ -1718,6 +1718,46 @@ describe('getUsageSummary: credit cache read-through (#4388 W04)', () => {
     redisGet.mockResolvedValueOnce(null);
 
     await expect(getUsageSummary('org1', { includeCredits: true })).resolves.toMatchObject({ credits: null });
+  });
+});
+
+// breeze-billing mounts its internal router at `/billing/api/internal`
+// (`app.route('/billing/api/internal', internalRoutes)`), and
+// `breezeBillingClient.cancelSubscription` already uses that prefix. These two
+// call sites were built against a bare `/api/internal`, so every credit check
+// and every deduction 404'd in production: the gate failed open and platform AI
+// spend was never deducted. Pin the full path so a prefix drift is a red test.
+describe('billing internal route prefix (#5591)', () => {
+  it('the credit check fetches /billing/api/internal/partners/:id/ai-credits', async () => {
+    setupDbMocks(null);
+    const fetchMock = enableBillingService();
+    fetchMock.mockResolvedValueOnce(billingCreditsResponse({
+      allowed: true, remainingCredits: 500, plan: 'pro',
+    }));
+    getLlmBillingSourceForOrgMock.mockResolvedValueOnce('platform');
+    redisGet.mockResolvedValue(null);
+
+    await getUsageSummary('org1', { includeCredits: true });
+
+    expect(new URL(fetchMock.mock.calls[0]![0] as string).pathname).toBe(
+      '/billing/api/internal/partners/partner-1/ai-credits',
+    );
+  });
+
+  it('the deduction posts to /billing/api/internal/partners/:id/ai-credits/deduct', async () => {
+    setupDbMocks(null);
+    const fetchMock = enableBillingService();
+
+    await recordSessionlessSdkUsage('org-1', {
+      costCents: 40,
+      usage: { input_tokens: 10, output_tokens: 20 },
+      numTurns: 1,
+      model: 'claude-sonnet-4-6',
+    }, 'platform');
+
+    expect(new URL(fetchMock.mock.calls[0]![0] as string).pathname).toBe(
+      '/billing/api/internal/partners/partner-1/ai-credits/deduct',
+    );
   });
 });
 

--- a/apps/api/src/services/aiCostTracker.ts
+++ b/apps/api/src/services/aiCostTracker.ts
@@ -194,7 +194,7 @@ async function fetchAndCachePartnerCredits(partnerId: string): Promise<PartnerCr
   if (!billingUrl || !billingKey) return { ok: false, reason: 'unconfigured' };
 
   try {
-    const res = await fetch(`${billingUrl}/api/internal/partners/${partnerId}/ai-credits`, {
+    const res = await fetch(`${billingUrl}/billing/api/internal/partners/${partnerId}/ai-credits`, {
       headers: { 'Authorization': `Bearer ${billingKey}` },
     });
 
@@ -375,7 +375,7 @@ export async function deductBillingCredits(orgId: string, costCents: number): Pr
   }
 
   try {
-    const res = await fetch(`${billingUrl}/api/internal/partners/${org.partnerId}/ai-credits/deduct`, {
+    const res = await fetch(`${billingUrl}/billing/api/internal/partners/${org.partnerId}/ai-credits/deduct`, {
       method: 'POST',
       headers: {
         'Authorization': `Bearer ${billingKey}`,


### PR DESCRIPTION
## Problem

`apps/api/src/services/aiCostTracker.ts` built both AI-credit URLs as
`${BILLING_SERVICE_URL}/api/internal/partners/:id/ai-credits[/deduct]`, but
breeze-billing mounts its internal router at `/billing/api/internal`
(`app.route('/billing/api/internal', internalRoutes)` in its `src/index.ts`;
the route handlers themselves are registered relative, `'/partners/:id/ai-credits'`).
The API's other caller of that router — `services/breezeBillingClient.ts`
`cancelSubscription` — already uses the `/billing/api/internal` prefix.

Result in production (verified on US prod v0.111.1, EU identical config):

- Credit gate **failed open** for every platform-billed org.
- AI spend was **never deducted** from partner credits.
- The credits card on the AI Usage page never rendered (`usage.credits` null —
  the cache is only written on a successful fetch).
- 139 `ai-credits` requests in the US billing container's full log history, 0 non-404.

## Fix

Both `fetchAndCachePartnerCredits` (line 197) and `deductBillingCredits`
(line 378) now target `/billing/api/internal/partners/...`. A repo-wide grep
(`apps/`, `packages/`, `ee/`) found **no other** `/api/internal/` billing URL
in the API — the only remaining hits are test assertions, all updated here.

## Tests

- The three existing full-URL assertions in `aiCostTracker.test.ts` and the one
  in `partnerLlmByokBilling.integration.test.ts` were corrected to the real path
  and **confirmed red against the unfixed source first** (3 failed / 98 passed).
- New `describe('billing internal route prefix (#5591)')` block asserts the
  fetched `pathname` for both the credit check and the deduct call by mocking
  global `fetch`. Proven non-vacuous: temporarily reverting the source URLs made
  both new tests fail (2 failed / 101 skipped), then pass again with the fix.
- `npx vitest run src/services/aiCostTracker.test.ts` → **103 passed**.
- `npx tsc --noEmit` for `apps/api` → clean.

Closes #5591

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eg6fDo1pYRJSgegy1LigNu