### PR TITLE
fix(ai): bind chat sessions to the page-context device org and use effective approval mode (#5593)

### DIFF
--- a/apps/api/src/services/aiAgent.pageContextOrg.test.ts
+++ b/apps/api/src/services/aiAgent.pageContextOrg.test.ts
@@ -1,0 +1,191 @@
+/**
+ * #5593 — the AI sidebar opened from a device page sends `pageContext` but no
+ * `deviceId`/`orgId`. A partner-scoped caller (`auth.orgId` null) used to fall
+ * through to `accessibleOrgIds[0]`, so the session bound to an unrelated org
+ * and the device's org-level settings (approval mode, M365 connection) and
+ * tool-audit rows all resolved against the wrong tenant.
+ *
+ * Mirrors the mock harness of aiAgent.deviceTask.test.ts.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const selectMock = vi.fn();
+const insertMock = vi.fn();
+const updateMock = vi.fn();
+const resolveLlmConfigForOrgMock = vi.fn();
+
+vi.mock('../db', () => ({
+  db: {
+    select: (...args: unknown[]) => selectMock(...args),
+    insert: (...args: unknown[]) => insertMock(...args),
+    update: (...args: unknown[]) => updateMock(...args),
+  },
+}));
+
+vi.mock('../db/schema', () => ({
+  aiSessions: { id: 'aiSessions.id', orgId: 'aiSessions.orgId' },
+  aiMessages: { sessionId: 'aiMessages.sessionId', createdAt: 'aiMessages.createdAt' },
+  aiToolExecutions: {
+    id: 'aiToolExecutions.id',
+    sessionId: 'aiToolExecutions.sessionId',
+    status: 'aiToolExecutions.status',
+  },
+  delegantM365Connections: {
+    id: 'delegantM365Connections.id',
+    orgId: 'delegantM365Connections.orgId',
+    status: 'delegantM365Connections.status',
+  },
+  devices: { id: 'devices.id', orgId: 'devices.orgId', siteId: 'devices.siteId' },
+}));
+
+vi.mock('./aiAgentSystemPrompt', () => ({ AI_SYSTEM_PROMPT_BASE: 'base' }));
+vi.mock('./brainDeviceContext', () => ({ getActiveDeviceContext: vi.fn().mockResolvedValue([]) }));
+vi.mock('./llm/llmConfigResolver', () => ({
+  LlmUnavailableError: class LlmUnavailableError extends Error {},
+  resolveLlmConfigForOrg: (...args: unknown[]) => resolveLlmConfigForOrgMock(...args),
+}));
+
+import { createSession } from './aiAgent';
+
+const ORG_A = 'aaaaaaaa-1111-4222-8333-444455556666';
+const ORG_B = 'bbbbbbbb-1111-4222-8333-444455556666';
+const DEVICE_ID = 'dddddddd-1111-4222-8333-444455556666';
+
+function devSelect(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(rows) }),
+    }),
+  };
+}
+
+/** Partner-scope login: no home org, accessibleOrgIds[0] is NOT the device org. */
+function partnerAuth(overrides: Record<string, unknown> = {}): any {
+  return {
+    scope: 'partner',
+    user: { id: 'user-1' },
+    orgId: undefined,
+    accessibleOrgIds: [ORG_A, ORG_B],
+    canAccessOrg: (id: string) => id === ORG_A || id === ORG_B,
+    orgCondition: () => undefined,
+    ...overrides,
+  };
+}
+
+/** Org-scope login: one org, the classic single-tenant technician. */
+function orgAuth(overrides: Record<string, unknown> = {}): any {
+  return {
+    scope: 'organization',
+    user: { id: 'user-2' },
+    orgId: ORG_A,
+    accessibleOrgIds: [ORG_A],
+    canAccessOrg: (id: string) => id === ORG_A,
+    orgCondition: () => undefined,
+    ...overrides,
+  };
+}
+
+const devicePageContext = { type: 'device' as const, id: DEVICE_ID, hostname: 'WS-01' };
+
+function expectInsert() {
+  const valuesSpy = vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([{ id: 'sess-1' }]) });
+  insertMock.mockReturnValueOnce({ values: valuesSpy });
+  return valuesSpy;
+}
+
+describe('createSession page-context org anchoring (#5593)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resolveLlmConfigForOrgMock.mockResolvedValue({
+      source: 'platform',
+      apiKey: 'platform-key',
+      model: 'claude-sonnet-4-6',
+    });
+  });
+
+  it('anchors a partner-scoped session to the page-context device org, not accessibleOrgIds[0]', async () => {
+    // 1st select = org anchor, 2nd = device-memory authorization in the prompt.
+    selectMock
+      .mockReturnValueOnce(devSelect([{ orgId: ORG_B, siteId: null }]))
+      .mockReturnValueOnce(devSelect([{ orgId: ORG_B, siteId: null }]));
+    const valuesSpy = expectInsert();
+
+    const result = await createSession(partnerAuth(), { pageContext: devicePageContext });
+
+    expect(valuesSpy).toHaveBeenCalledWith(expect.objectContaining({ orgId: ORG_B }));
+    expect(result.orgId).toBe(ORG_B);
+    expect(resolveLlmConfigForOrgMock).toHaveBeenCalledWith(ORG_B);
+  });
+
+  it('falls back to accessibleOrgIds[0] when the page-context device is outside the caller org axis', async () => {
+    selectMock.mockReturnValue(devSelect([{ orgId: 'cccccccc-1111-4222-8333-444455556666', siteId: null }]));
+    const valuesSpy = expectInsert();
+
+    await createSession(partnerAuth(), { pageContext: devicePageContext });
+
+    expect(valuesSpy).toHaveBeenCalledWith(expect.objectContaining({ orgId: ORG_A }));
+  });
+
+  it('does not anchor to a device whose site the caller cannot reach (#1047 site axis)', async () => {
+    selectMock.mockReturnValue(devSelect([{ orgId: ORG_B, siteId: 'site-OTHER' }]));
+    const valuesSpy = expectInsert();
+
+    await createSession(
+      partnerAuth({ canAccessSite: (s: string | null) => s === 'site-ALLOWED' }),
+      { pageContext: devicePageContext },
+    );
+
+    expect(valuesSpy).toHaveBeenCalledWith(expect.objectContaining({ orgId: ORG_A }));
+  });
+
+  it('never queries devices for a malformed page-context device id', async () => {
+    const valuesSpy = expectInsert();
+
+    await createSession(partnerAuth(), {
+      pageContext: { type: 'device', id: 'not-a-uuid', hostname: 'WS-01' },
+    });
+
+    expect(selectMock).not.toHaveBeenCalled();
+    expect(valuesSpy).toHaveBeenCalledWith(expect.objectContaining({ orgId: ORG_A }));
+  });
+
+  it('leaves the org-scoped path unchanged (session stays on the login org)', async () => {
+    selectMock.mockReturnValue(devSelect([{ orgId: ORG_A, siteId: null }]));
+    const valuesSpy = expectInsert();
+
+    await createSession(orgAuth(), { pageContext: devicePageContext });
+
+    expect(valuesSpy).toHaveBeenCalledWith(expect.objectContaining({ orgId: ORG_A }));
+  });
+
+  it('leaves the device-bound path unchanged: options.deviceId still drives the org', async () => {
+    // Single device lookup (the deviceId branch); the anchor branch is skipped.
+    selectMock.mockReturnValue(devSelect([{ id: DEVICE_ID, orgId: ORG_B, siteId: null }]));
+    const valuesSpy = expectInsert();
+
+    await createSession(partnerAuth(), { deviceId: DEVICE_ID });
+
+    expect(valuesSpy).toHaveBeenCalledWith(expect.objectContaining({ orgId: ORG_B, deviceId: DEVICE_ID }));
+    expect(selectMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves an explicit options.orgId authoritative over the page context', async () => {
+    selectMock.mockReturnValue(devSelect([{ orgId: ORG_B, siteId: null }]));
+    const valuesSpy = expectInsert();
+
+    await createSession(partnerAuth(), { orgId: ORG_A, pageContext: devicePageContext });
+
+    expect(valuesSpy).toHaveBeenCalledWith(expect.objectContaining({ orgId: ORG_A }));
+  });
+
+  it('ignores a non-device page context (no device lookup, previous fallback stands)', async () => {
+    const valuesSpy = expectInsert();
+
+    await createSession(partnerAuth(), {
+      pageContext: { type: 'dashboard', orgName: 'Mountain Capital' },
+    });
+
+    expect(selectMock).not.toHaveBeenCalled();
+    expect(valuesSpy).toHaveBeenCalledWith(expect.objectContaining({ orgId: ORG_A }));
+  });
+});

--- a/apps/api/src/services/aiAgent.ts
+++ b/apps/api/src/services/aiAgent.ts
@@ -24,6 +24,52 @@ export { BREEZE_FALLBACK_MODEL, resolveDefaultModel } from './aiModel';
 // Session Management
 // ============================================
 
+/** `devices.id` is a uuid column — a malformed client-supplied id would raise 22P02. */
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Load a device row only when the caller may reach it on BOTH tenancy axes
+ * (SECURITY-CRITICAL, org axis + site axis per #1047). Returns null on a miss —
+ * "not found" and "not yours" are indistinguishable to the caller by design.
+ *
+ * Single source of truth for authorizing an attacker-controllable device id out
+ * of `pageContext`: both the device-memory load and the session org anchor
+ * (#5593) run this same predicate.
+ */
+async function loadAccessibleDeviceRow(
+  deviceId: string,
+  auth: AuthContext,
+): Promise<{ orgId: string; siteId: string | null } | null> {
+  if (!UUID_PATTERN.test(deviceId)) return null;
+
+  const rows = await db
+    .select({ orgId: devices.orgId, siteId: devices.siteId })
+    .from(devices)
+    .where(eq(devices.id, deviceId))
+    .limit(1);
+  const deviceRow = rows[0];
+  if (!deviceRow) return null;
+  if (!auth.canAccessOrg(deviceRow.orgId)) return null;
+  // `canAccessSite` is undefined for unrestricted (e.g. partner) scopes; when
+  // present it returns false for sites outside the caller's allowlist.
+  if (auth.canAccessSite && !auth.canAccessSite(deviceRow.siteId)) return null;
+  return deviceRow;
+}
+
+/**
+ * Org anchor derived from the page the chat was opened on (#5593).
+ *
+ * Returns the org of the page-context device when the caller can access it, or
+ * undefined so the caller falls back to its previous resolution chain.
+ */
+async function resolvePageContextOrgId(
+  auth: AuthContext,
+  pageContext: AiPageContext | undefined,
+): Promise<string | undefined> {
+  if (!pageContext || pageContext.type !== 'device') return undefined;
+  return (await loadAccessibleDeviceRow(pageContext.id, auth))?.orgId;
+}
+
 export async function createSession(
   auth: AuthContext,
   options: {
@@ -66,12 +112,26 @@ export async function createSession(
     deviceRow = rows[0] ?? null;
   }
 
+  // The sidebar opened from a device page sends `pageContext` but no
+  // `deviceId`/`orgId` (a deviceId is only sent for an explicit device-scoped
+  // task). Without this branch a partner-scoped caller (`auth.orgId` undefined)
+  // fell through to `accessibleOrgIds[0]` — an unrelated org — so the session's
+  // approval mode, M365 connection and tool-audit rows all resolved against the
+  // wrong tenant (#5593). Anchor to the page-context device's org instead, but
+  // only when the caller can reach that org (and site); otherwise leave the
+  // pre-existing fallback untouched.
+  const pageContextOrgId =
+    options.orgId || options.deviceId
+      ? undefined
+      : await resolvePageContextOrgId(auth, sanitizedPageContext);
+
   const orgId =
     options.orgId ??
     // Anchor to the device's org when the caller can reach it; otherwise fall
     // through so the opaque device check below rejects without leaking the
     // device's existence to callers outside its org.
     (deviceRow && auth.canAccessOrg(deviceRow.orgId) ? deviceRow.orgId : undefined) ??
+    pageContextOrgId ??
     auth.orgId ??
     auth.accessibleOrgIds?.[0] ??
     null;
@@ -539,18 +599,7 @@ export function waitForPlanApproval(
  * the caller skips loading device context rather than throwing.
  */
 async function canLoadDeviceContext(deviceId: string, auth: AuthContext): Promise<boolean> {
-  const rows = await db
-    .select({ orgId: devices.orgId, siteId: devices.siteId })
-    .from(devices)
-    .where(eq(devices.id, deviceId))
-    .limit(1);
-  const deviceRow = rows[0];
-  if (!deviceRow) return false;
-  if (!auth.canAccessOrg(deviceRow.orgId)) return false;
-  // `canAccessSite` is undefined for unrestricted (e.g. partner) scopes; when
-  // present it returns false for sites outside the caller's allowlist.
-  if (auth.canAccessSite && !auth.canAccessSite(deviceRow.siteId)) return false;
-  return true;
+  return (await loadAccessibleDeviceRow(deviceId, auth)) !== null;
 }
 
 /**

--- a/apps/api/src/services/streamingSessionManager.approvalMode.test.ts
+++ b/apps/api/src/services/streamingSessionManager.approvalMode.test.ts
@@ -152,6 +152,19 @@ describe('getOrCreate — effective approval mode (#5593)', () => {
     expect(second.approvalMode).toBe('hybrid_plan');
   });
 
+  it('does not swap the mode under a turn that is already running', async () => {
+    const first = await create(manager, 'sess-in-flight');
+    expect(first.approvalMode).toBe('per_step');
+
+    // A turn started (or starts while the lookup is outstanding): the gate the
+    // running turn began under must not change beneath it.
+    first.state = 'processing';
+    getEffectiveAiBudgetMock.mockResolvedValue(budget('auto_approve'));
+    await create(manager, 'sess-in-flight');
+
+    expect(first.approvalMode).toBe('per_step');
+  });
+
   it('falls back to per_step for an unrecognized partner override value', async () => {
     getEffectiveAiBudgetMock.mockResolvedValue(budget('yolo_approve'));
 

--- a/apps/api/src/services/streamingSessionManager.approvalMode.test.ts
+++ b/apps/api/src/services/streamingSessionManager.approvalMode.test.ts
@@ -1,0 +1,170 @@
+/**
+ * #5593 — approval mode must come from the EFFECTIVE AI budget (partner JSONB
+ * `aiBudgets.approvalMode` override → org `ai_budgets` row → `per_step`), not
+ * from a raw `ai_budgets` select on the session org, and it must be re-read
+ * when an in-memory session is reused so a settings change applies to the next
+ * message instead of only to a brand-new session.
+ *
+ * Mock harness mirrors streamingSessionManager.deviceBoundAuth.test.ts.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const { queryMock, getEffectiveAiBudgetMock } = vi.hoisted(() => ({
+  queryMock: vi.fn(),
+  getEffectiveAiBudgetMock: vi.fn(),
+}));
+
+vi.mock('@anthropic-ai/claude-agent-sdk', () => ({ query: queryMock }));
+
+const dbSelectMock = vi.fn(() => ({
+  from: vi.fn(() => ({
+    where: vi.fn(() => ({ limit: vi.fn(() => Promise.resolve([])) })),
+  })),
+}));
+
+vi.mock('../db', () => ({
+  db: {
+    select: (...args: unknown[]) => dbSelectMock(...(args as [])),
+    update: vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn(() => Promise.resolve()) })) })),
+    insert: vi.fn(() => ({ values: vi.fn(() => Promise.resolve()) })),
+  },
+  withDbAccessContext: vi.fn((_ctx: unknown, fn: () => unknown) => fn()),
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+}));
+
+vi.mock('./effectiveSettings', () => ({
+  getEffectiveAiBudget: (...args: unknown[]) => getEffectiveAiBudgetMock(...args),
+}));
+
+vi.mock('./aiCostTracker', () => ({
+  recordUsageFromSdkResult: vi.fn(() => Promise.resolve()),
+  sumInputTokens: () => 0,
+}));
+vi.mock('./aiAgent', () => ({ sanitizeErrorForClient: (e: unknown) => String(e) }));
+vi.mock('./sentry', () => ({ captureException: vi.fn(), captureMessage: vi.fn() }));
+vi.mock('./aiAgentSdkTools', () => ({
+  createBreezeMcpServer: vi.fn(() => ({ type: 'sdk' })),
+  BREEZE_MCP_TOOL_NAMES: ['mcp__breeze__query_devices'],
+}));
+vi.mock('./aiAgentSdk', () => ({
+  createSessionPreToolUse: vi.fn(() => vi.fn()),
+  createSessionPostToolUse: vi.fn(() => vi.fn()),
+  settleApprovalWaits: vi.fn(),
+}));
+vi.mock('./aiToolOutput', () => ({
+  redactAiToolOutputText: (s: string) => s,
+  redactSensitiveToolInput: (s: unknown) => s,
+}));
+vi.mock('./clientIp', () => ({ getTrustedClientIpOrUndefined: () => undefined }));
+
+import { StreamingSessionManager } from './streamingSessionManager';
+import { buildOrgAccessClosures } from '../middleware/auth';
+import type { AuthContext } from '../middleware/auth';
+
+const ORG_ID = 'aaaaaaaa-1111-4222-8333-444455556666';
+const USER_ID = 'eeeeeeee-1111-4222-8333-444455556666';
+
+const DB_SESSION = {
+  orgId: ORG_ID,
+  sdkSessionId: null,
+  model: 'claude-sonnet-4-5-20250929',
+  maxTurns: 50,
+  turnCount: 0,
+  systemPrompt: null,
+  deviceId: null,
+};
+
+const PLATFORM_CONFIG = {
+  source: 'platform' as const,
+  apiKey: 'platform-key',
+  model: 'claude-sonnet-4-6',
+};
+
+function makeAuth(): AuthContext {
+  return {
+    scope: 'organization',
+    orgId: ORG_ID,
+    partnerId: null,
+    accessibleOrgIds: [ORG_ID],
+    ...buildOrgAccessClosures([ORG_ID]),
+    user: { id: USER_ID, email: 'tech@msp.example' },
+  } as unknown as AuthContext;
+}
+
+function budget(approvalMode: string) {
+  return {
+    enabled: true,
+    monthlyBudgetCents: null,
+    dailyBudgetCents: null,
+    maxTurnsPerSession: 50,
+    messagesPerMinutePerUser: 20,
+    messagesPerHourPerOrg: 200,
+    approvalMode,
+    alertThresholdPercents: [],
+  };
+}
+
+function create(manager: StreamingSessionManager, id: string) {
+  return manager.getOrCreate(id, DB_SESSION, makeAuth(), undefined, 'PROMPT', undefined, PLATFORM_CONFIG);
+}
+
+describe('getOrCreate — effective approval mode (#5593)', () => {
+  let manager: StreamingSessionManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryMock.mockImplementation(() => ({
+      async *[Symbol.asyncIterator]() {
+        await new Promise(() => undefined);
+      },
+      interrupt: vi.fn(),
+      close: vi.fn(),
+    }));
+    getEffectiveAiBudgetMock.mockResolvedValue(budget('per_step'));
+    manager = new StreamingSessionManager();
+  });
+
+  afterEach(() => {
+    manager.shutdown();
+  });
+
+  it('honours a partner-level override when the org row says per_step', async () => {
+    // getEffectiveAiBudget merges partner JSONB over the org row; the raw
+    // ai_budgets select this replaced only ever saw the org row.
+    getEffectiveAiBudgetMock.mockResolvedValue(budget('auto_approve'));
+
+    const session = await create(manager, 'sess-partner-override');
+
+    expect(getEffectiveAiBudgetMock).toHaveBeenCalledWith(ORG_ID);
+    expect(session.approvalMode).toBe('auto_approve');
+    // No direct ai_budgets read remains on this path.
+    expect(dbSelectMock).not.toHaveBeenCalled();
+  });
+
+  it('reloads the approval mode when an in-memory session is reused', async () => {
+    const first = await create(manager, 'sess-reuse');
+    expect(first.approvalMode).toBe('per_step');
+
+    getEffectiveAiBudgetMock.mockResolvedValue(budget('hybrid_plan'));
+    const second = await create(manager, 'sess-reuse');
+
+    expect(second).toBe(first);
+    expect(second.approvalMode).toBe('hybrid_plan');
+  });
+
+  it('falls back to per_step for an unrecognized partner override value', async () => {
+    getEffectiveAiBudgetMock.mockResolvedValue(budget('yolo_approve'));
+
+    const session = await create(manager, 'sess-bogus-mode');
+
+    expect(session.approvalMode).toBe('per_step');
+  });
+
+  it('falls back to per_step (strictest) when resolution fails', async () => {
+    getEffectiveAiBudgetMock.mockRejectedValue(new Error('db down'));
+
+    const session = await create(manager, 'sess-error');
+
+    expect(session.approvalMode).toBe('per_step');
+  });
+});

--- a/apps/api/src/services/streamingSessionManager.clientLoop.test.ts
+++ b/apps/api/src/services/streamingSessionManager.clientLoop.test.ts
@@ -9,15 +9,19 @@ const { queryMock, recordUsageMock, capturedQueryArgs, settleApprovalWaitsMock }
 
 vi.mock('@anthropic-ai/claude-agent-sdk', () => ({ query: queryMock }));
 
+// Approval mode now resolves through the EFFECTIVE budget (#5593): partner
+// JSONB override -> org ai_budgets row -> per_step. Return auto_approve so the
+// approval-mode prompt injection is observable.
+vi.mock('./effectiveSettings', () => ({
+  getEffectiveAiBudget: vi.fn(() => Promise.resolve({ approvalMode: 'auto_approve' })),
+}));
+
 vi.mock('../db', () => ({
   db: {
-    // Only DB read on this path: the aiBudgets approvalMode lookup
-    // (streamingSessionManager.getOrCreate). Return auto_approve so the
-    // approval-mode prompt injection is observable.
     select: vi.fn(() => ({
       from: vi.fn(() => ({
         where: vi.fn(() => ({
-          limit: vi.fn(() => Promise.resolve([{ approvalMode: 'auto_approve' }])),
+          limit: vi.fn(() => Promise.resolve([])),
         })),
       })),
     })),

--- a/apps/api/src/services/streamingSessionManager.ts
+++ b/apps/api/src/services/streamingSessionManager.ts
@@ -795,9 +795,19 @@ export class StreamingSessionManager {
         // message rather than only to a brand-new in-memory session (#5593).
         // Skipped while a turn is in flight: the route answers a concurrent
         // message with 409, and swapping the mode mid-turn would change the
-        // gate the running turn already started under.
+        // gate the running turn already started under. The state is re-checked
+        // AFTER the await as well — a concurrent request can transition the
+        // session to `processing` while this lookup is outstanding, and the
+        // assignment must not land behind a turn that already started.
         if (reusable.state !== 'processing') {
-          reusable.approvalMode = await loadApprovalMode(dbSession.orgId);
+          const refreshedApprovalMode = await loadApprovalMode(dbSession.orgId);
+          // Re-read through the map rather than the narrowed `reusable` alias:
+          // a concurrent request may have started a turn — or evicted the
+          // session entirely — while this lookup was outstanding.
+          const stateAfterLookup = this.sessions.get(breezeSessionId)?.state;
+          if (stateAfterLookup && stateAfterLookup !== 'processing') {
+            reusable.approvalMode = refreshedApprovalMode;
+          }
         }
         reusable.lastActivityAt = Date.now();
         return reusable;

--- a/apps/api/src/services/streamingSessionManager.ts
+++ b/apps/api/src/services/streamingSessionManager.ts
@@ -16,7 +16,7 @@ import { query } from '@anthropic-ai/claude-agent-sdk';
 import type { Query, SDKResultMessage, SDKUserMessage, McpSdkServerConfigWithInstance } from '@anthropic-ai/claude-agent-sdk';
 import { db, withDbAccessContext, withSystemDbAccessContext, runOutsideDbContext } from '../db';
 import { dbWriteExpectingRows } from '../db/dbWriteExpectingRows';
-import { aiSessions, aiMessages, aiBudgets } from '../db/schema';
+import { aiSessions, aiMessages } from '../db/schema';
 import { eq, and, isNull, inArray } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import { buildOrgAccessClosures } from '../middleware/auth';
@@ -41,6 +41,7 @@ import { resolveWireModel, type ResolvedLlmEndpoint, type UsableLlmConfig } from
 import { getLlmEgressProxy } from './llm/llmEgressProxy';
 import { recordLlmEgressEvent } from './llm/llmEgressRecorder';
 import { markAiBudgetReservationIndeterminate } from './aiBudgetReservations';
+import { getEffectiveAiBudget } from './effectiveSettings';
 
 const SESSION_IDLE_TIMEOUT_MS = 2 * 60 * 60 * 1000; // 2h idle eviction (aligned with pre-flight check)
 const SESSION_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24h hard limit
@@ -565,7 +566,7 @@ export interface ActiveSession {
   approvalWaitAbort: AbortController | null;
   /** Count of approval waits currently blocked inside preToolUse. */
   pendingApprovalWaits: number;
-  /** Approval mode for this session (loaded from org's aiBudgets) */
+  /** Approval mode for this session (effective: partner override -> org row -> per_step) */
   approvalMode: AiApprovalMode;
   /** Optional MCP allowlist for restricted sessions such as helper chat. */
   allowedTools?: string[];
@@ -639,6 +640,34 @@ export function buildDeviceBoundSessionAuth(auth: AuthContext, sessionOrgId: str
 // ============================================
 // StreamingSessionManager (singleton)
 // ============================================
+
+const APPROVAL_MODES: readonly AiApprovalMode[] = ['per_step', 'action_plan', 'auto_approve', 'hybrid_plan'];
+
+/**
+ * Effective approval mode for a session's org (#5593).
+ *
+ * Resolves through `getEffectiveAiBudget` — partner JSONB `aiBudgets`
+ * override, then the org's `ai_budgets` row, then `per_step` — instead of
+ * reading the org row directly, which silently ignored a partner-wide default.
+ * The partner override is free-form JSON, so an unrecognized value is rejected
+ * rather than handed to the approval gate. Any failure keeps the previous
+ * fail-safe behaviour: the strictest mode, `per_step`.
+ */
+async function loadApprovalMode(orgId: string): Promise<AiApprovalMode> {
+  try {
+    const budget = await getEffectiveAiBudget(orgId);
+    const mode = budget.approvalMode as AiApprovalMode;
+    if (APPROVAL_MODES.includes(mode)) return mode;
+    console.warn(
+      '[StreamingSessionManager] Unrecognized approval mode, defaulting to per_step:',
+      budget.approvalMode,
+    );
+  } catch (err) {
+    captureException(err);
+    console.error('[StreamingSessionManager] Failed to load approval mode, defaulting to per_step:', err);
+  }
+  return 'per_step';
+}
 
 export class StreamingSessionManager {
   private sessions = new Map<string, ActiveSession>();
@@ -762,6 +791,14 @@ export class StreamingSessionManager {
           : auth;
         reusable.auditSnapshot = snapshot;
         reusable.allowedTools = allowedTools;
+        // Re-resolve the approval mode so a settings change applies to the NEXT
+        // message rather than only to a brand-new in-memory session (#5593).
+        // Skipped while a turn is in flight: the route answers a concurrent
+        // message with 409, and swapping the mode mid-turn would change the
+        // gate the running turn already started under.
+        if (reusable.state !== 'processing') {
+          reusable.approvalMode = await loadApprovalMode(dbSession.orgId);
+        }
         reusable.lastActivityAt = Date.now();
         return reusable;
       }
@@ -776,21 +813,7 @@ export class StreamingSessionManager {
       inputController.setSdkSessionId(dbSession.sdkSessionId);
     }
 
-    // Load org's approval mode from aiBudgets
-    let approvalMode: AiApprovalMode = 'per_step';
-    try {
-      const [budget] = await db
-        .select({ approvalMode: aiBudgets.approvalMode })
-        .from(aiBudgets)
-        .where(eq(aiBudgets.orgId, dbSession.orgId))
-        .limit(1);
-      if (budget?.approvalMode) {
-        approvalMode = budget.approvalMode as AiApprovalMode;
-      }
-    } catch (err) {
-      captureException(err);
-      console.error('[StreamingSessionManager] Failed to load approval mode, defaulting to per_step:', err);
-    }
+    const approvalMode = await loadApprovalMode(dbSession.orgId);
 
     const catalogEndpoint = catalogEndpointOf(resolved);
 


### PR DESCRIPTION
Closes #5593

## Problem

A partner-scoped user (`users.org_id IS NULL`) opening the AI sidebar on a device page gets a session bound to `auth.accessibleOrgIds[0]` — an unrelated org. The web store only sends `deviceId` for explicit device-scoped tasks; an ordinary sidebar session sends `pageContext` (which carries the device) and no `orgId`/`deviceId`, so `createSession` fell straight through to the fallback. Consequences seen on US prod (v0.111.1): the device org's approval mode never applied, `m365_query_intune_devices` consulted the wrong org's connection (`org_context_required` → `tools_disabled`), and tool audit rows landed under the wrong tenant.

Second, independent cause: `streamingSessionManager.getOrCreate` read `ai_budgets` directly by session org, so a partner-level `aiBudgets.approvalMode` default was ignored even when the org was right — and the mode was only ever loaded for a brand-new in-memory session.

## Changes

**`apps/api/src/services/aiAgent.ts`**
- New `resolvePageContextOrgId`: when there is no explicit `options.orgId` and no `options.deviceId`, anchor the session org to the sanitized page-context device's org — inserted into the chain *before* `auth.orgId` / `accessibleOrgIds[0]`.
- Access is gated on the same two axes the device-bound path already enforces: `auth.canAccessOrg` and `auth.canAccessSite` (#1047). A miss returns `undefined` and falls back to the previous behaviour, so the anchor never reveals whether a device exists and never moves a session into an org/site the caller cannot reach. Every SECURITY-CRITICAL check (cross-org M365, opaque "Invalid device", site axis) is untouched.
- Extracted `loadAccessibleDeviceRow` as the single source of truth for authorizing an attacker-controllable device id; `canLoadDeviceContext` (device-memory load) now delegates to it. It also rejects a non-uuid id before querying, so a malformed client value no longer raises 22P02 against the `uuid` column.

**`apps/api/src/services/streamingSessionManager.ts`**
- Approval mode resolves through the existing `getEffectiveAiBudget` helper (`services/effectiveSettings.ts`): partner JSONB `aiBudgets.approvalMode` → org `ai_budgets` row → `per_step`. No merge logic duplicated.
- Partner JSONB is free-form, so an unrecognized mode string is rejected (warn + `per_step`) rather than handed to the approval gate. Any resolution failure keeps the prior fail-safe: `per_step`, the strictest mode.
- The reusable-session path re-reads the mode so a settings change takes effect on the **next** message. Skipped while `state === 'processing'` — the route answers a concurrent message with 409 anyway, and swapping the gate mid-turn is not wanted.
- `services/llm/openaiSessionManager.ts` has no approval-mode path (verified by grep), so there is nothing parallel to mirror.

## Tests (red first)

New `apps/api/src/services/aiAgent.pageContextOrg.test.ts` (8 tests) — verified failing on unpatched `aiAgent.ts` (2 failures, incl. the partner anchor):
- partner auth (`orgId` undefined, `accessibleOrgIds [A, B]`) + page-context device in org B → session inserted with `orgId = B` and the LLM config resolved for B;
- device outside the caller's org axis → old fallback stands;
- device in a site the caller cannot reach → old fallback stands (#1047);
- malformed device id → no `devices` query at all;
- org-scoped user unchanged; `options.deviceId` path unchanged (still one device lookup); explicit `options.orgId` still authoritative; non-device page context ignored.

New `apps/api/src/services/streamingSessionManager.approvalMode.test.ts` (4 tests) — verified failing on unpatched `streamingSessionManager.ts` (2 failures):
- partner override `auto_approve` applies when the org row is `per_step`, and no raw `ai_budgets` select remains;
- reusing an in-memory session picks up a changed mode;
- unrecognized mode → `per_step`; resolution failure → `per_step`.

`streamingSessionManager.clientLoop.test.ts` updated to stub `getEffectiveAiBudget` instead of the removed raw select.

## Verification

- `vitest run src/services/aiAgent src/services/streamingSessionManager src/services/llm/openaiSessionManager src/services/effectiveSettings` — 98 files, 2301 tests passed.
- `vitest run src/routes/ai` — 12 files, 406 tests passed.
- `npx tsc --noEmit` in `apps/api` — clean.

## Note

`AiPageContext` carries no org id on any variant (`device` has `id`/`hostname`, `dashboard` only `orgName`), so the "pageContext org id" half of the issue has nothing to read — the device branch is the whole anchor. Related: #5592 (first save drops `approvalMode`) still needs to land for Auto mode to be end-to-end correct for partner users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eg6fDo1pYRJSgegy1LigNu