### PR TITLE
fix(remote): per-monitor DPI awareness so input and cursor land on secondary monitors

### DIFF
--- a/agent/internal/remote/desktop/capture_windows_nocgo.go
+++ b/agent/internal/remote/desktop/capture_windows_nocgo.go
@@ -18,10 +18,9 @@ var (
 	// user32 is already declared in input_windows.go (same package)
 	gdi32 = syscall.NewLazyDLL("gdi32.dll")
 
-	procGetDC              = user32.NewProc("GetDC")
-	procReleaseDC          = user32.NewProc("ReleaseDC")
-	procGetSystemMetrics   = user32.NewProc("GetSystemMetrics")
-	procSetProcessDPIAware = user32.NewProc("SetProcessDPIAware")
+	procGetDC            = user32.NewProc("GetDC")
+	procReleaseDC        = user32.NewProc("ReleaseDC")
+	procGetSystemMetrics = user32.NewProc("GetSystemMetrics")
 
 	procCreateDCW              = gdi32.NewProc("CreateDCW")
 	procCreateCompatibleDC     = gdi32.NewProc("CreateCompatibleDC")
@@ -122,20 +121,6 @@ type gdiCapturer struct {
 	// here is what lets StartSession tell the technician WHY the startup probe
 	// found no frame (see describeCaptureFailure).
 	lastCaptureErr error
-}
-
-func init() {
-	if procSetProcessDPIAware.Find() != nil {
-		return
-	}
-	// Not fatal, but not nothing either: without DPI awareness GetSystemMetrics
-	// reports scaled dimensions, which is the same class of capture/encoder size
-	// mismatch AlignEven exists to prevent (see ensureHandles). Worth a line in
-	// the helper log rather than nothing at all.
-	if ret, _, errno := procSetProcessDPIAware.Call(); ret == 0 {
-		slog.Debug("SetProcessDPIAware failed; capture dimensions may be DPI-scaled",
-			"error", gdiCallError("SetProcessDPIAware", errno).Error())
-	}
 }
 
 // ensureHandles creates or recreates GDI handles if needed.

--- a/agent/internal/remote/desktop/dpi.go
+++ b/agent/internal/remote/desktop/dpi.go
@@ -1,0 +1,46 @@
+package desktop
+
+// Process DPI-awareness mode names, reported once at startup so a helper log
+// shows which coordinate space Win32 input/cursor calls are operating in.
+const (
+	dpiModePerMonitorV2 = "per-monitor-v2"
+	dpiModePerMonitor   = "per-monitor"
+	dpiModeSystem       = "system"
+	dpiModeUnaware      = "unaware"
+)
+
+// processDPIMode is the awareness mode that took effect at init on Windows
+// (empty elsewhere); logged with the display offset so a helper log shows which
+// coordinate space input and cursor calls used.
+var processDPIMode string
+
+// chooseDPIAwareness elevates the process to the strongest available DPI
+// awareness and returns the mode that took effect.
+//
+// Why this matters for remote desktop: DXGI Desktop Duplication reports every
+// output's geometry in PHYSICAL pixels, and that geometry is what
+// applyDisplayOffset feeds into SetDisplayOffset. But SetCursorPos, SendInput
+// (MOUSEEVENTF_ABSOLUTE), GetCursorPos and GetSystemMetrics are DPI-virtualized
+// for any process that is not per-monitor aware: a system-DPI-aware process
+// gets physical coordinates only on monitors whose scale matches the primary.
+// On a 150% laptop panel driving a 100% external monitor, input aimed at the
+// external monitor lands ~1.5x off and the streamed cursor drifts the same way
+// — the primary works perfectly, the secondary is unusable (JONAH, 2026-09-10).
+// Per-monitor awareness (v2 preferred) makes all of those APIs physical on
+// every monitor, matching DXGI.
+//
+// Each attempt is a func so the ordering is unit-testable without Win32. The
+// first success wins: once the process mode is set, later calls fail with
+// ERROR_ACCESS_DENIED, so we must not keep trying.
+func chooseDPIAwareness(perMonitorV2, perMonitor, system func() bool) string {
+	if perMonitorV2 != nil && perMonitorV2() {
+		return dpiModePerMonitorV2
+	}
+	if perMonitor != nil && perMonitor() {
+		return dpiModePerMonitor
+	}
+	if system != nil && system() {
+		return dpiModeSystem
+	}
+	return dpiModeUnaware
+}

--- a/agent/internal/remote/desktop/dpi.go
+++ b/agent/internal/remote/desktop/dpi.go
@@ -9,10 +9,10 @@ const (
 	dpiModeUnaware      = "unaware"
 )
 
-// processDPIMode is the awareness mode that took effect at init on Windows
-// (empty elsewhere); logged with the display offset so a helper log shows which
-// coordinate space input and cursor calls used.
-var processDPIMode string
+// processDPIMode is the awareness mode that took effect at init on Windows;
+// logged with the display offset so a helper log shows which coordinate space
+// input and cursor calls used. Other platforms have no DPI virtualization.
+var processDPIMode = "n/a"
 
 // chooseDPIAwareness elevates the process to the strongest available DPI
 // awareness and returns the mode that took effect.
@@ -33,14 +33,20 @@ var processDPIMode string
 // first success wins: once the process mode is set, later calls fail with
 // ERROR_ACCESS_DENIED, so we must not keep trying.
 func chooseDPIAwareness(perMonitorV2, perMonitor, system func() bool) string {
-	if perMonitorV2 != nil && perMonitorV2() {
+	if perMonitorV2() {
 		return dpiModePerMonitorV2
 	}
-	if perMonitor != nil && perMonitor() {
+	if perMonitor() {
 		return dpiModePerMonitor
 	}
-	if system != nil && system() {
+	if system() {
 		return dpiModeSystem
 	}
 	return dpiModeUnaware
 }
+
+// hresultSucceeded reports SUCCEEDED(hr) for a 32-bit HRESULT that came back
+// through a uintptr. The sign bit lives in bit 31, so the value must be
+// narrowed to int32 first: on amd64 0x80070005 (E_ACCESSDENIED, "awareness
+// already set") is a positive int64 and would otherwise read as success.
+func hresultSucceeded(hr uintptr) bool { return int32(uint32(hr)) >= 0 }

--- a/agent/internal/remote/desktop/dpi_test.go
+++ b/agent/internal/remote/desktop/dpi_test.go
@@ -37,7 +37,25 @@ func TestChooseDPIAwareness(t *testing.T) {
 				if len(calls) != 2 {
 					t.Fatalf("expected 2 calls, got %v", calls)
 				}
+			default:
+				if len(calls) != 3 {
+					t.Fatalf("expected every tier attempted (3 calls), got %v", calls)
+				}
 			}
 		})
+	}
+}
+
+func TestHresultSucceeded(t *testing.T) {
+	cases := map[uintptr]bool{
+		0x00000000: true,  // S_OK
+		0x00000001: true,  // S_FALSE
+		0x80070005: false, // E_ACCESSDENIED — mode already set; int64(hr) >= 0 would wrongly pass
+		0x80070057: false, // E_INVALIDARG
+	}
+	for hr, want := range cases {
+		if got := hresultSucceeded(hr); got != want {
+			t.Errorf("0x%08x: got %v want %v", hr, got, want)
+		}
 	}
 }

--- a/agent/internal/remote/desktop/dpi_test.go
+++ b/agent/internal/remote/desktop/dpi_test.go
@@ -1,0 +1,43 @@
+package desktop
+
+import "testing"
+
+// chooseDPIAwareness must prefer per-monitor-v2 (physical coordinates on every
+// monitor, matching DXGI output geometry), then per-monitor, then the legacy
+// system-DPI call, and report which one took effect.
+func TestChooseDPIAwareness(t *testing.T) {
+	tests := []struct {
+		name           string
+		v2, pm, legacy bool
+		want           string
+	}{
+		{"v2 available", true, true, true, dpiModePerMonitorV2},
+		{"v2 missing, per-monitor available", false, true, true, dpiModePerMonitor},
+		{"only legacy", false, false, true, dpiModeSystem},
+		{"nothing works", false, false, false, dpiModeUnaware},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := []string{}
+			mk := func(name string, ok bool) func() bool {
+				return func() bool { calls = append(calls, name); return ok }
+			}
+			got := chooseDPIAwareness(mk("v2", tc.v2), mk("pm", tc.pm), mk("legacy", tc.legacy))
+			if got != tc.want {
+				t.Fatalf("got %q want %q (calls %v)", got, tc.want, calls)
+			}
+			// Must stop at the first success — later calls fail with
+			// ERROR_ACCESS_DENIED once the process mode is set.
+			switch tc.want {
+			case dpiModePerMonitorV2:
+				if len(calls) != 1 {
+					t.Fatalf("expected 1 call, got %v", calls)
+				}
+			case dpiModePerMonitor:
+				if len(calls) != 2 {
+					t.Fatalf("expected 2 calls, got %v", calls)
+				}
+			}
+		})
+	}
+}

--- a/agent/internal/remote/desktop/dpi_windows.go
+++ b/agent/internal/remote/desktop/dpi_windows.go
@@ -9,11 +9,10 @@ import (
 )
 
 var (
-	dpiUser32                         = windows.NewLazySystemDLL("user32.dll")
 	dpiShcore                         = windows.NewLazySystemDLL("shcore.dll")
-	procSetProcessDpiAwarenessContext = dpiUser32.NewProc("SetProcessDpiAwarenessContext")
+	procSetProcessDpiAwarenessContext = user32.NewProc("SetProcessDpiAwarenessContext")
 	procSetProcessDpiAwarenessShcore  = dpiShcore.NewProc("SetProcessDpiAwareness")
-	procSetProcessDPIAwareLegacy      = dpiUser32.NewProc("SetProcessDPIAware")
+	procSetProcessDPIAwareLegacy      = user32.NewProc("SetProcessDPIAware")
 )
 
 // DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 is the pseudo-handle (HANDLE)-4.
@@ -34,8 +33,10 @@ func init() {
 	processDPIMode = chooseDPIAwareness(
 		func() bool {
 			if procSetProcessDpiAwarenessContext.Find() != nil {
-				return false // pre-1703 Windows 10
+				return false // pre-1607 Windows 10
 			}
+			// 1607 exports the API but rejects the V2 context (added in 1703);
+			// that surfaces as a FALSE return and falls through to shcore.
 			ret, _, _ := procSetProcessDpiAwarenessContext.Call(dpiAwarenessContextPerMonitorAwareV2)
 			return ret != 0
 		},
@@ -44,7 +45,7 @@ func init() {
 				return false // pre-8.1
 			}
 			hr, _, _ := procSetProcessDpiAwarenessShcore.Call(uintptr(processPerMonitorDPIAware))
-			return int32(hr) >= 0 // S_OK; E_ACCESSDENIED if already set
+			return hresultSucceeded(hr) // S_OK; E_ACCESSDENIED if already set
 		},
 		func() bool {
 			if procSetProcessDPIAwareLegacy.Find() != nil {

--- a/agent/internal/remote/desktop/dpi_windows.go
+++ b/agent/internal/remote/desktop/dpi_windows.go
@@ -1,0 +1,65 @@
+//go:build windows
+
+package desktop
+
+import (
+	"log/slog"
+
+	"golang.org/x/sys/windows"
+)
+
+var (
+	dpiUser32                         = windows.NewLazySystemDLL("user32.dll")
+	dpiShcore                         = windows.NewLazySystemDLL("shcore.dll")
+	procSetProcessDpiAwarenessContext = dpiUser32.NewProc("SetProcessDpiAwarenessContext")
+	procSetProcessDpiAwarenessShcore  = dpiShcore.NewProc("SetProcessDpiAwareness")
+	procSetProcessDPIAwareLegacy      = dpiUser32.NewProc("SetProcessDPIAware")
+)
+
+// DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 is the pseudo-handle (HANDLE)-4.
+// A negative constant cannot be converted to uintptr directly, so go through a
+// signed variable and let the two's-complement bit pattern carry over.
+var dpiAwarenessContextPerMonitorAwareV2 = func() uintptr {
+	v := int64(-4)
+	return uintptr(v)
+}()
+
+// PROCESS_PER_MONITOR_DPI_AWARE for shcore!SetProcessDpiAwareness (Win 8.1+).
+const processPerMonitorDPIAware = 2
+
+// The DPI mode must be fixed before any user32 call that depends on it
+// (GetSystemMetrics, SetCursorPos, GetCursorInfo, monitor enumeration), so it
+// runs in package init like the SetProcessDPIAware call it replaces.
+func init() {
+	processDPIMode = chooseDPIAwareness(
+		func() bool {
+			if procSetProcessDpiAwarenessContext.Find() != nil {
+				return false // pre-1703 Windows 10
+			}
+			ret, _, _ := procSetProcessDpiAwarenessContext.Call(dpiAwarenessContextPerMonitorAwareV2)
+			return ret != 0
+		},
+		func() bool {
+			if procSetProcessDpiAwarenessShcore.Find() != nil {
+				return false // pre-8.1
+			}
+			hr, _, _ := procSetProcessDpiAwarenessShcore.Call(uintptr(processPerMonitorDPIAware))
+			return int32(hr) >= 0 // S_OK; E_ACCESSDENIED if already set
+		},
+		func() bool {
+			if procSetProcessDPIAwareLegacy.Find() != nil {
+				return false
+			}
+			ret, _, _ := procSetProcessDPIAwareLegacy.Call()
+			return ret != 0
+		},
+	)
+	if processDPIMode == dpiModePerMonitorV2 || processDPIMode == dpiModePerMonitor {
+		slog.Debug("Process DPI awareness set", "mode", processDPIMode)
+		return
+	}
+	// Anything weaker means multi-monitor input/cursor coordinates will be
+	// DPI-virtualized on monitors whose scale differs from the primary.
+	slog.Warn("Process DPI awareness is not per-monitor; input on secondary monitors with a different scale factor will be misplaced",
+		"mode", processDPIMode)
+}

--- a/agent/internal/remote/desktop/session_capture.go
+++ b/agent/internal/remote/desktop/session_capture.go
@@ -1154,15 +1154,16 @@ func applyDisplayOffset(handler InputHandler, displayIndex int, cursorOffX, curs
 		return
 	}
 	for _, m := range monitors {
-		slog.Debug("applyDisplayOffset: monitor",
+		slog.Info("applyDisplayOffset: monitor",
 			"index", m.Index, "name", m.Name,
 			"x", m.X, "y", m.Y, "w", m.Width, "h", m.Height,
 			"primary", m.IsPrimary)
 	}
 	for _, m := range monitors {
 		if m.Index == displayIndex {
-			slog.Debug("applyDisplayOffset: selected",
-				"display", displayIndex, "offsetX", m.X, "offsetY", m.Y)
+			slog.Info("applyDisplayOffset: selected",
+				"display", displayIndex, "offsetX", m.X, "offsetY", m.Y,
+				"dpiMode", processDPIMode)
 			handler.SetDisplayOffset(m.X, m.Y)
 			cursorOffX.Store(int32(m.X))
 			cursorOffY.Store(int32(m.Y))


### PR DESCRIPTION
## Problem

Remote desktop on a multi-monitor Windows host works on the primary monitor but is unusable on a secondary monitor whose display scaling differs from the primary: clicks land in the wrong place, the streamed cursor doesn't track, and the view reads 0 FPS because nothing the operator does actually changes that screen.

Reported on JONAH (Dell 14 Plus 2-in-1, Win 11 25H2, agent 0.111.1) on 2026-09-10. The helper log for that session shows every `switch_monitor` to display 1 completing cleanly (DXGI init 1920x1080 rotation=1, hardware MFT re-init, GPU pipeline enabled, IDR sent within 250 ms, zero warnings) and healthy 15 fps bursts whenever display 1 did repaint, while the agent's own `captured` counter stayed flat (11 frames in 10 s, `skipped` climbing ~30/s). Capture and transport were fine; the operator's input simply wasn't reaching that monitor.

## Root cause

The desktop helper only called `SetProcessDPIAware`, which is **system**-DPI awareness. `ListMonitors` derives each monitor's offset from DXGI `DXGI_OUTPUT_DESC.DesktopCoordinates`, which is always physical pixels, and `applyDisplayOffset` feeds that into `SetDisplayOffset`. But in a system-DPI-aware process, `SetCursorPos`, `SendInput(MOUSEEVENTF_ABSOLUTE|VIRTUALDESK)`, `GetCursorPos`/`GetCursorInfo` and `GetSystemMetrics(SM_*VIRTUALSCREEN)` are DPI-virtualized on any monitor whose scale differs from the primary. Physical offset + virtualized coordinate space = input lands ~scale-factor off on the secondary monitor only. The primary is unaffected, which is exactly the reported shape.

## Fix

- `dpi_windows.go`: at package init, elevate to `DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2` via `user32!SetProcessDpiAwarenessContext`; fall back to `shcore!SetProcessDpiAwareness(PROCESS_PER_MONITOR_DPI_AWARE)` (Win 8.1), then the legacy `SetProcessDPIAware`. Per-monitor awareness makes all the above user32 calls physical on every monitor, matching DXGI. Logs the mode that took effect; warns if it is weaker than per-monitor.
- `dpi.go`: the ordering lives in a platform-neutral `chooseDPIAwareness` so it is unit-testable. First success must win — once the process mode is set, later calls fail with `ERROR_ACCESS_DENIED`.
- `capture_windows_nocgo.go`: removed the old `init()` that called `SetProcessDPIAware` (it would otherwise pin the process to system awareness before the new code runs, since init order within a package is filename-alphabetical: `capture_…` < `dpi_…`).
- `session_capture.go`: `applyDisplayOffset` geometry lines promoted from Debug to Info and now include `dpiMode`, so the next helper log answers "which monitor, what offset, which coordinate space" without a debug flag.

## Verification

- `go test -race ./internal/remote/desktop/` green (new `TestChooseDPIAwareness` was written red first: undefined symbols, then green).
- `GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build ./...` (the shipped cross-compile mode) and host/Linux builds green.
- `golangci-lint run --new-from-rev=origin/main ./...` clean for both host and Windows targets.
- **Not verified on real hardware.** I do not have a Windows box with two monitors at different scale factors. The hypothesis is derived from the JONAH helper log plus the operator's report that cursor tracking was off on monitor 2. Ask for the next release: on JONAH, confirm Settings → Display shows different scaling per monitor (expected: panel 150%, external 100%), then re-test monitor 2 after the agent updates. The helper log will now print `applyDisplayOffset: selected … dpiMode=per-monitor-v2` on each switch.

## Risk

Agent-shipped code, Windows only. Behaviour change is limited to the process DPI mode: capture dimensions already came from DXGI (physical) so they are unchanged; input/cursor coordinates on same-scale monitors are unchanged (virtualization was identity there); on mixed-scale setups they go from wrong to correct. The GDI fallback capturer reads `GetSystemMetrics(SM_CXSCREEN)`, which becomes physical for the primary under per-monitor awareness, the same value it had under system awareness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E8w2voVKWYj4V2ZsNvD4gV
