### PR TITLE
fix(ai): stop running a passkey ceremony for every supervised self-approve (#5600)

### DIFF
--- a/apps/web/src/components/ai/AiApprovalDialog.test.tsx
+++ b/apps/web/src/components/ai/AiApprovalDialog.test.tsx
@@ -120,7 +120,7 @@ describe('intent-backed self-approve (sole operator)', () => {
     );
     fireEvent.click(screen.getByRole('button', { name: /approve/i }));
     await waitFor(() => expect(onIntentDecided).toHaveBeenCalled());
-    expect(decideIntentApproval).toHaveBeenCalledWith('ap-1', 'approve');
+    expect(decideIntentApproval).toHaveBeenCalledWith('ap-1', 'approve', undefined, undefined);
     // Does not sit frozen on a disabled "Waiting for verification…" button if
     // the parent's pendingApproval clear lags or never lands.
     expect(screen.queryByText(/waiting for verification/i)).toBeNull();
@@ -168,7 +168,7 @@ describe('intent-backed self-approve (sole operator)', () => {
     decideIntentApproval.mockResolvedValueOnce('decided');
     fireEvent.click(screen.getByRole('button', { name: /deny/i }));
     await waitFor(() => expect(onIntentDecided).toHaveBeenCalled());
-    expect(decideIntentApproval).toHaveBeenLastCalledWith('ap-1', 'deny');
+    expect(decideIntentApproval).toHaveBeenLastCalledWith('ap-1', 'deny', undefined, undefined);
   });
 
   it('deny → terminal confirmation reads "Action denied", not "Action approved"', async () => {
@@ -329,7 +329,27 @@ describe('intent-backed self-approve (sole operator)', () => {
     );
     fireEvent.click(screen.getByRole('button', { name: /deny/i }));
     await waitFor(() => expect(onIntentDecided).toHaveBeenCalled());
-    expect(decideIntentApproval).toHaveBeenCalledWith('ap-1', 'deny');
+    expect(decideIntentApproval).toHaveBeenCalledWith('ap-1', 'deny', undefined, undefined);
+  });
+
+  // #5600 — the scope is what tells the decide helper whether a passkey
+  // ceremony is required at all. A card that forwards nothing makes every
+  // supervised self-approve pay a ceremony the server stopped asking for.
+  it('forwards approvalScope to decideIntentApproval', async () => {
+    decideIntentApproval.mockResolvedValue('decided');
+    const onIntentDecided = vi.fn();
+    render(
+      <AiApprovalDialog
+        {...selfProps}
+        intentBacked
+        selfApprovalRequestId="ap-1"
+        approvalScope="supervised"
+        onIntentDecided={onIntentDecided}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /approve/i }));
+    await waitFor(() => expect(onIntentDecided).toHaveBeenCalled());
+    expect(decideIntentApproval).toHaveBeenCalledWith('ap-1', 'approve', undefined, 'supervised');
   });
 
   it('disables both buttons while the ceremony is in flight', async () => {

--- a/apps/web/src/components/ai/AiApprovalDialog.tsx
+++ b/apps/web/src/components/ai/AiApprovalDialog.tsx
@@ -14,7 +14,7 @@ import { CeremonyError, decideIntentApproval } from "@/lib/intentApprovals";
 import { ActionError } from "@/lib/runAction";
 import { navigateTo } from "@/lib/navigation";
 import { useRunContextLabel } from "../common/RunContext";
-import type { AiScriptRunContext } from "@breeze/shared";
+import type { AiApprovalScope, AiScriptRunContext } from "@breeze/shared";
 
 // Must be <= server-side waitForApproval timeout (300s). Plan approvals use 10-min timeout.
 const AUTO_DENY_MS = 5 * 60 * 1000;
@@ -51,13 +51,24 @@ interface AiApprovalDialogProps {
    * requester is NOT an eligible approver (multi-approver org), this card
    * shows a waiting state only. When the server fanned the approval row out
    * to the requester (sole-operator branch), selfApprovalRequestId is set
-   * and the card offers an inline L3 self-approve: WebAuthn ceremony
-   * (Touch ID / Windows Hello) + proof POST — satisfying, not bypassing,
-   * the decide handler's assurance-level >= 3 gate.
+   * and the card offers an inline self-approve. Whether that runs a WebAuthn
+   * ceremony (Touch ID / Windows Hello) + proof POST depends on
+   * `approvalScope`: four_eyes always does, satisfying — not bypassing — the
+   * decide handler's assurance-level >= 3 gate; supervised does not, because
+   * that gate no longer applies to it (#5600).
    */
   intentBacked?: boolean;
   /** The viewer's own fanned-out approval row (sole-operator case). */
   selfApprovalRequestId?: string;
+  /**
+   * The intent's server-classified approval scope (#5600). `'supervised'` means
+   * this self-approve IS the whole authorization and the server no longer
+   * requires an L3 WebAuthn proof for it, so the decide helper skips the
+   * ceremony (retrying with it only if an enforcing partner policy answers
+   * `step_up_required`). `'four_eyes'` — and an absent scope, e.g. an older
+   * server — keeps the always-ceremony behaviour.
+   */
+  approvalScope?: AiApprovalScope;
   /**
    * The intent's real server-side expiry (ISO). When present, the countdown is
    * anchored to it rather than a mount-relative constant — so the card cannot
@@ -235,6 +246,7 @@ export default function AiApprovalDialog({
   onReject,
   intentBacked,
   selfApprovalRequestId,
+  approvalScope,
   intentExpiresAt,
   scriptRunContext,
   onIntentDecided,
@@ -285,7 +297,12 @@ export default function AiApprovalDialog({
     setIntentDecideState("deciding");
     setIntentError(null);
     try {
-      const outcome = await decideIntentApproval(selfApprovalRequestId, decision);
+      const outcome = await decideIntentApproval(
+        selfApprovalRequestId,
+        decision,
+        undefined,
+        approvalScope,
+      );
       if (outcome === "needs_device") {
         setIntentDecideState("needs_device");
         return;

--- a/apps/web/src/components/ai/AiChatMessages.tsx
+++ b/apps/web/src/components/ai/AiChatMessages.tsx
@@ -326,6 +326,7 @@ export default function AiChatMessages({
           onReject={() => onReject(pendingApproval.executionId)}
           intentBacked={pendingApproval.intentBacked}
           selfApprovalRequestId={pendingApproval.selfApprovalRequestId}
+          approvalScope={pendingApproval.approvalScope}
           intentExpiresAt={pendingApproval.intentExpiresAt}
           scriptRunContext={pendingApproval.scriptRunContext}
           onIntentDecided={onIntentDecided}

--- a/apps/web/src/lib/intentApprovals.test.ts
+++ b/apps/web/src/lib/intentApprovals.test.ts
@@ -204,6 +204,22 @@ describe('decideIntentApproval — supervised scope skips the ceremony (#5600)',
     expect(fetchWithAuth).toHaveBeenCalledTimes(1);
   });
 
+  it('supervised: a transport failure on the optimistic POST is toasted, not silent', async () => {
+    // The optimistic attempt runs outside runAction, which is what guarantees
+    // a toast on a thrown request everywhere else in this helper. Without its
+    // own catch the user would get inline card text only — and the POST must
+    // never be retried, since the server may well have received it.
+    fetchWithAuth.mockRejectedValue(new TypeError('Failed to fetch'));
+    const rejection = await decideIntentApproval('ap-1', 'approve', undefined, 'supervised').catch(
+      (e: unknown) => e,
+    );
+    expect(rejection).toBeInstanceOf(ActionError);
+    expect((rejection as ActionError).status).toBe(0);
+    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+    expect(fetchWithAuth).toHaveBeenCalledTimes(1);
+    expect(runAction).not.toHaveBeenCalled();
+  });
+
   it('supervised deny: unchanged — no ceremony, reason carried', async () => {
     await decideIntentApproval('ap-1', 'deny', ' too risky ', 'supervised');
     await invokeCapturedRequest();

--- a/apps/web/src/lib/intentApprovals.test.ts
+++ b/apps/web/src/lib/intentApprovals.test.ts
@@ -126,6 +126,94 @@ describe('decideIntentApproval', () => {
   });
 });
 
+describe('decideIntentApproval — supervised scope skips the ceremony (#5600)', () => {
+  it('supervised approve: no WebAuthn ceremony, no proof in the body', async () => {
+    getApprovalAssertion.mockResolvedValue(PROOF);
+    const outcome = await decideIntentApproval('ap-1', 'approve', undefined, 'supervised');
+    expect(outcome).toBe('decided');
+    expect(getApprovalAssertion).not.toHaveBeenCalled();
+
+    expect(fetchWithAuth).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchWithAuth.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('/mobile/approvals/ap-1/approve');
+    expect(JSON.parse(init.body as string)).toEqual({});
+  });
+
+  it('four_eyes approve: still runs the ceremony and POSTs the proof', async () => {
+    getApprovalAssertion.mockResolvedValue(PROOF);
+    await decideIntentApproval('ap-1', 'approve', undefined, 'four_eyes');
+    expect(getApprovalAssertion).toHaveBeenCalledWith('/mobile/approvals', 'ap-1');
+
+    await invokeCapturedRequest();
+    const [, init] = fetchWithAuth.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual({ proof: PROOF });
+  });
+
+  it('an unknown/absent scope keeps the always-ceremony behaviour', async () => {
+    getApprovalAssertion.mockResolvedValue(PROOF);
+    await decideIntentApproval('ap-1', 'approve');
+    expect(getApprovalAssertion).toHaveBeenCalledTimes(1);
+  });
+
+  it('supervised + 403 step_up_required: retries EXACTLY once with the ceremony', async () => {
+    // An enforcing partner authenticator policy still demands the step-up.
+    // The proofless attempt is the optimistic path, not a decision to bypass.
+    runAction.mockImplementation((opts: Parameters<typeof actualRunAction>[0]) => actualRunAction(opts));
+    getApprovalAssertion.mockResolvedValue(PROOF);
+    fetchWithAuth
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: 'step_up_required', requiredLevel: 3 }), { status: 403 }),
+      )
+      .mockResolvedValueOnce(new Response('{}', { status: 200 }));
+
+    const outcome = await decideIntentApproval('ap-1', 'approve', undefined, 'supervised');
+    expect(outcome).toBe('decided');
+    expect(getApprovalAssertion).toHaveBeenCalledTimes(1);
+    expect(fetchWithAuth).toHaveBeenCalledTimes(2);
+    const [, retryInit] = fetchWithAuth.mock.calls[1] as [string, RequestInit];
+    expect(JSON.parse(retryInit.body as string)).toEqual({ proof: PROOF });
+    // The first, proofless attempt is an internal retry step — the user must
+    // not be told their approval failed when it is about to succeed.
+    expect(showToast).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+  });
+
+  it('supervised + 403 step_up_required + no approver device: needs_device, no second POST', async () => {
+    runAction.mockImplementation((opts: Parameters<typeof actualRunAction>[0]) => actualRunAction(opts));
+    const err = new Error('No registered approver device');
+    err.name = 'NoApproverDeviceError';
+    getApprovalAssertion.mockRejectedValue(err);
+    fetchWithAuth.mockResolvedValue(
+      new Response(JSON.stringify({ error: 'step_up_required', requiredLevel: 3 }), { status: 403 }),
+    );
+
+    const outcome = await decideIntentApproval('ap-1', 'approve', undefined, 'supervised');
+    expect(outcome).toBe('needs_device');
+    expect(fetchWithAuth).toHaveBeenCalledTimes(1);
+  });
+
+  it('supervised + a non-step-up rejection is surfaced, not retried', async () => {
+    runAction.mockImplementation((opts: Parameters<typeof actualRunAction>[0]) => actualRunAction(opts));
+    getApprovalAssertion.mockResolvedValue(PROOF);
+    fetchWithAuth.mockResolvedValue(
+      new Response(JSON.stringify({ error: 'not_sole_approver' }), { status: 403 }),
+    );
+
+    const outcome = await decideIntentApproval('ap-1', 'approve', undefined, 'supervised');
+    expect(outcome).toBe('not_sole_approver');
+    expect(getApprovalAssertion).not.toHaveBeenCalled();
+    expect(fetchWithAuth).toHaveBeenCalledTimes(1);
+  });
+
+  it('supervised deny: unchanged — no ceremony, reason carried', async () => {
+    await decideIntentApproval('ap-1', 'deny', ' too risky ', 'supervised');
+    await invokeCapturedRequest();
+    const [url, init] = fetchWithAuth.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('/mobile/approvals/ap-1/deny');
+    expect(JSON.parse(init.body as string)).toEqual({ reason: 'too risky' });
+    expect(getApprovalAssertion).not.toHaveBeenCalled();
+  });
+});
+
 describe('decideIntentApproval server rejections', () => {
   beforeEach(() => {
     runAction.mockImplementation((opts: Parameters<typeof actualRunAction>[0]) => actualRunAction(opts));

--- a/apps/web/src/lib/intentApprovals.ts
+++ b/apps/web/src/lib/intentApprovals.ts
@@ -1,3 +1,4 @@
+import type { AiApprovalScope } from '@breeze/shared';
 import { fetchWithAuth } from '../stores/auth';
 import {
   AssertionChallengeError,
@@ -150,11 +151,23 @@ export function batchDecideErrorCopy(token: string): string | undefined {
 
 /**
  * Decide the viewer's own fanned-out approval row for a Tier-3 action intent
- * (the inline chat self-approve, sole-operator case). Approve runs the
- * WebAuthn (Touch ID / Windows Hello) ceremony first — the server's L3
- * self-approve gate refuses a proofless approve — then POSTs the proof to the
- * existing decide endpoint. Deny needs no proof, skips the ceremony, and may
- * carry the optional reason collected by the approvals inbox.
+ * (the inline chat self-approve, sole-operator case).
+ *
+ * Approve runs the WebAuthn (Touch ID / Windows Hello) ceremony first and
+ * POSTs the proof — EXCEPT when `approvalScope` is `'supervised'` (#5600). The
+ * 2026-08-05 supervised/four-eyes split moved the L3 sole-operator requirement
+ * to `four_eyes` only: `decideApprovalRequest.ts` skips the assurance ladder
+ * for a supervised self-decide under a non-enforcing partner policy, but ONLY
+ * when no proof is presented (a presented proof is always verified, never
+ * discarded). So a client that always attaches a proof makes the server always
+ * run the ladder — which is why every supervised chat approve was still paying
+ * a passkey ceremony. Supervised therefore POSTs prooflessly first; an
+ * enforcing partner policy answers 403 `step_up_required`, and that — and only
+ * that — triggers exactly ONE retry with the ceremony. `four_eyes` and any
+ * unknown/absent scope keep the always-ceremony behaviour.
+ *
+ * Deny needs no proof under any scope, skips the ceremony, and may carry the
+ * optional reason collected by the approvals inbox.
  *
  * Returns 'needs_device' when no approver device is registered (before any
  * network write) or when the server answers `step_up_required` — the caller
@@ -181,21 +194,71 @@ export async function decideIntentApproval(
   approvalRequestId: string,
   decision: 'approve' | 'deny',
   reason?: string,
+  approvalScope?: AiApprovalScope | null,
 ): Promise<IntentDecisionOutcome> {
   const body: Record<string, unknown> = {};
+  // Only an APPROVE of a supervised row may go prooflessly; deny never carries
+  // a proof anyway, and an unknown scope must fall back to the strict path.
+  const supervisedApprove = decision === 'approve' && approvalScope === 'supervised';
 
-  if (decision === 'approve') {
+  /** Runs the ceremony into `body.proof`. Returns a terminal outcome when the
+   *  viewer has no approver device; throws CeremonyError on a real failure. */
+  const collectProof = async (): Promise<'needs_device' | null> => {
     try {
       body.proof = await getApprovalAssertion('/mobile/approvals', approvalRequestId);
+      return null;
     } catch (err) {
       // No registered approver device → return the CTA signal instead of
       // POSTing. Unlike PamRespondModal, we do NOT submit without a proof:
-      // the self-approve gate requires L3.
+      // the four_eyes self-approve gate requires L3.
       if (isNoApproverDeviceError(err)) return 'needs_device';
       throw new CeremonyError(err);
     }
-  } else if (reason?.trim()) {
+  };
+
+  const post = () =>
+    fetchWithAuth(`/mobile/approvals/${approvalRequestId}/${decision}`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+      skipUnauthorizedRetry: true,
+    });
+
+  if (decision === 'approve' && !supervisedApprove) {
+    const noDevice = await collectProof();
+    if (noDevice) return noDevice;
+  } else if (decision === 'deny' && reason?.trim()) {
     body.reason = reason.trim();
+  }
+
+  // The supervised optimistic attempt runs OUTSIDE runAction so a 403
+  // `step_up_required` can be retried silently: runAction toasts every failure
+  // it sees, and telling the user "register a device" a beat before the
+  // approval succeeds would be a lie. Whatever response survives this block is
+  // handed to runAction untouched (the token is read off a clone, so the body
+  // is still unconsumed) — success toast, error toast and outcome mapping all
+  // stay in exactly one place.
+  let settledResponse: Response | undefined;
+  if (supervisedApprove) {
+    const firstAttempt = await post();
+    if (firstAttempt.status === 403) {
+      const token = await firstAttempt
+        .clone()
+        .json()
+        .then((data: unknown) =>
+          data && typeof data === 'object' ? (data as { error?: unknown }).error : undefined,
+        )
+        .catch(() => undefined);
+      if (token === 'step_up_required') {
+        // Enforcing partner authenticator policy: the step-up floor stands and
+        // the viewer can satisfy it. Exactly one retry, with the ceremony.
+        const noDevice = await collectProof();
+        if (noDevice) return noDevice;
+      } else {
+        settledResponse = firstAttempt;
+      }
+    } else {
+      settledResponse = firstAttempt;
+    }
   }
 
   try {
@@ -203,12 +266,7 @@ export async function decideIntentApproval(
       // Kept inline rather than hoisted: the no-silent-mutations guard walks
       // parents for an enclosing runAction call, so a hoisted thunk reads as an
       // unwrapped mutation even when passed straight in.
-      request: () =>
-        fetchWithAuth(`/mobile/approvals/${approvalRequestId}/${decision}`, {
-          method: 'POST',
-          body: JSON.stringify(body),
-          skipUnauthorizedRetry: true,
-        }),
+      request: () => (settledResponse ? Promise.resolve(settledResponse) : post()),
       errorFallback: i18n.t('ai:aiApprovalDialog.decideFailed'),
       // NO onUnauthorized here, deliberately. `treatUnauthorizedAsError` makes
       // runAction skip its 401 branch entirely, so the callback would be dead

--- a/apps/web/src/lib/intentApprovals.ts
+++ b/apps/web/src/lib/intentApprovals.ts
@@ -7,6 +7,7 @@ import {
 } from '../stores/authenticator';
 import { i18n } from './i18n';
 import { ActionError, runAction } from './runAction';
+import { showToast } from '../components/shared/Toast';
 
 export type IntentDecisionOutcome = 'decided' | 'needs_device' | 'not_sole_approver';
 
@@ -216,13 +217,6 @@ export async function decideIntentApproval(
     }
   };
 
-  const post = () =>
-    fetchWithAuth(`/mobile/approvals/${approvalRequestId}/${decision}`, {
-      method: 'POST',
-      body: JSON.stringify(body),
-      skipUnauthorizedRetry: true,
-    });
-
   if (decision === 'approve' && !supervisedApprove) {
     const noDevice = await collectProof();
     if (noDevice) return noDevice;
@@ -239,7 +233,29 @@ export async function decideIntentApproval(
   // stay in exactly one place.
   let settledResponse: Response | undefined;
   if (supervisedApprove) {
-    const firstAttempt = await post();
+    let firstAttempt: Response;
+    try {
+      // runaction-exempt: the optimistic proofless attempt (#5600). runAction
+      // toasts every failure it sees, and a 403 `step_up_required` here is
+      // RETRIED with the ceremony — toasting "register a device" a beat before
+      // the approval succeeds would be a lie. Nothing is swallowed: every other
+      // response is handed to the runAction call below untouched, and the catch
+      // below reproduces runAction's own transport-error toast.
+      firstAttempt = await fetchWithAuth(`/mobile/approvals/${approvalRequestId}/approve`, {
+        method: 'POST',
+        body: JSON.stringify(body),
+        skipUnauthorizedRetry: true,
+      });
+    } catch {
+      // A THROW (network failure, a lapsed refresh in fetchWithAuth) never
+      // reaches runAction on this branch, so reproduce its own transport-error
+      // shape here rather than letting the rejection escape untoasted — the
+      // one failure mode this optimistic attempt could otherwise report only
+      // as inline card text. Never retried: the POST may have been received.
+      const message = i18n.t('ai:aiApprovalDialog.decideFailed');
+      showToast({ message, type: 'error' });
+      throw new ActionError(message, 0);
+    }
     if (firstAttempt.status === 403) {
       const token = await firstAttempt
         .clone()
@@ -265,8 +281,16 @@ export async function decideIntentApproval(
     await runAction({
       // Kept inline rather than hoisted: the no-silent-mutations guard walks
       // parents for an enclosing runAction call, so a hoisted thunk reads as an
-      // unwrapped mutation even when passed straight in.
-      request: () => (settledResponse ? Promise.resolve(settledResponse) : post()),
+      // unwrapped mutation even when passed straight in. `settledResponse` is
+      // the supervised attempt above, already made and still unread.
+      request: () =>
+        settledResponse
+          ? Promise.resolve(settledResponse)
+          : fetchWithAuth(`/mobile/approvals/${approvalRequestId}/${decision}`, {
+              method: 'POST',
+              body: JSON.stringify(body),
+              skipUnauthorizedRetry: true,
+            }),
       errorFallback: i18n.t('ai:aiApprovalDialog.decideFailed'),
       // NO onUnauthorized here, deliberately. `treatUnauthorizedAsError` makes
       // runAction skip its 401 branch entirely, so the callback would be dead

--- a/apps/web/src/stores/processStreamEvent.test.ts
+++ b/apps/web/src/stores/processStreamEvent.test.ts
@@ -113,6 +113,48 @@ describe('approval_required — selfApprovalRequestId passthrough', () => {
   });
 });
 
+/**
+ * #5600 — the SSE event carries `approvalScope` ('supervised' | 'four_eyes'),
+ * and the card uses it to decide whether a self-approve needs the WebAuthn
+ * ceremony at all. Dropping it here silently forces every supervised approve
+ * through a passkey prompt the server stopped requiring.
+ */
+describe('approval_required — approvalScope passthrough (#5600)', () => {
+  it('carries approvalScope into pendingApproval', () => {
+    const state = makeState();
+    let patch: Partial<StreamableState> = {};
+    processStreamEvent(
+      {
+        type: 'approval_required', executionId: 'e1', toolName: 'file_operations',
+        input: { action: 'read' }, description: 'Read a file',
+        intentBacked: true, selfApprovalRequestId: 'ap-1', approvalScope: 'supervised',
+      },
+      (fn) => { patch = { ...patch, ...fn({ ...state, ...patch }) }; },
+      () => ({ ...state, ...patch }),
+      null,
+    );
+    expect(patch.pendingApproval).toMatchObject({ approvalScope: 'supervised' });
+  });
+
+  it('leaves approvalScope undefined when the event omits it', () => {
+    // An absent scope must never be defaulted to 'supervised': the
+    // ceremony-skip branch keys off exactly this value, and inventing one
+    // would drop the proof from a four_eyes self-approve.
+    const state = makeState();
+    let patch: Partial<StreamableState> = {};
+    processStreamEvent(
+      {
+        type: 'approval_required', executionId: 'e1', toolName: 'file_operations',
+        input: { action: 'read' }, description: 'Read a file', intentBacked: true,
+      },
+      (fn) => { patch = { ...patch, ...fn({ ...state, ...patch }) }; },
+      () => ({ ...state, ...patch }),
+      null,
+    );
+    expect(patch.pendingApproval?.approvalScope).toBeUndefined();
+  });
+});
+
 describe('plan-mode step sequencing under approval-gated ordering', () => {
   // API sequence for an approval-gated step is now:
   //   approval_required -> (possibly multi-minute wait) -> plan_step_start -> execute -> plan_step_complete

--- a/apps/web/src/stores/processStreamEvent.ts
+++ b/apps/web/src/stores/processStreamEvent.ts
@@ -1,4 +1,4 @@
-import type { AiStreamEvent, AiApprovalMode, ActionPlanStep, AiScriptRunContext } from '@breeze/shared';
+import type { AiStreamEvent, AiApprovalMode, AiApprovalScope, ActionPlanStep, AiScriptRunContext } from '@breeze/shared';
 
 export interface AiMessage {
   id: string;
@@ -38,6 +38,16 @@ export interface PendingApproval {
   intentBacked?: boolean;
   /** Set when the viewer (requester) holds the fanned-out approval row — enables inline L3 self-approve. */
   selfApprovalRequestId?: string;
+  /**
+   * The intent's approval scope as classified server-side (#5600). `'supervised'`
+   * means the viewer's self-approve IS the whole authorization, and the server
+   * no longer requires an L3 proof for it — so the card decides prooflessly and
+   * only runs the passkey ceremony if an enforcing partner policy asks for it.
+   * `'four_eyes'` (and an absent scope, on older servers) keeps the always-L3
+   * behaviour. Never defaulted here: inventing a value would drop the proof
+   * from a four_eyes self-approve.
+   */
+  approvalScope?: AiApprovalScope;
   /** The intent's real server-side expiry (ISO), so the self-approve countdown reflects actual deadline. */
   intentExpiresAt?: string;
   /**
@@ -179,6 +189,7 @@ export function processStreamEvent(
           deviceContext: event.deviceContext,
           intentBacked: event.intentBacked,
           selfApprovalRequestId: event.selfApprovalRequestId,
+          approvalScope: event.approvalScope,
           intentExpiresAt: event.intentExpiresAt,
           scriptRunContext: event.scriptRunContext ?? null,
         }


### PR DESCRIPTION
Closes #5600

## Problem

Every `action_intent.approved` audit row for AI chat approvals on US prod records `decidedVia: webauthn_platform` / `approvalMethod: supervised_self` / `decidedAssuranceLevel: 3` — a passkey ceremony for each supervised self-approve, under a partner with no enforcing authenticator policy.

The server already stopped requiring that. `decideApprovalRequest.ts`:

```ts
const skipAssuranceLadder =
  isSupervisedSelfDecide && !isPartnerEnforcingForSupervised && proof === undefined;
```

The third conjunct is deliberate — a presented proof is always verified, never silently discarded. The web client never got the other half of the split: `decideIntentApproval` attached a proof unconditionally, so the ladder always ran, and the SSE event's `approvalScope` (published by `aiAgentSdk.ts` precisely so the card can use it) was dropped on the floor by `processStreamEvent`.

## Change (web only — no API change)

1. `stores/processStreamEvent.ts` — copy `approvalScope` off the `approval_required` event into `PendingApproval`. Never defaulted: an absent scope stays `undefined` so a four_eyes self-approve can't lose its proof.
2. `components/ai/AiChatMessages.tsx` → `AiApprovalDialog.tsx` — new `approvalScope` prop, forwarded to `decideIntentApproval`. `AiChatMessages` is the single render site for the dialog, so the AI sidebar **and** workspace chat (`WorkspaceChatPanel` → `AiChatMessages`) are both covered by one wiring; `aiStore` and `workspaceStore` share `processStreamEvent`, so both stores get the field.
3. `lib/intentApprovals.ts` — `decideIntentApproval(id, decision, reason?, approvalScope?)`:
   - `approvalScope === 'supervised'` + approve → no ceremony, POST without `proof`.
   - 403 `step_up_required` on that attempt (enforcing partner policy) → run the ceremony and retry **exactly once**, with the proof.
   - `four_eyes` and any absent/unknown scope → unchanged always-ceremony path. Deny is unchanged under every scope.
   - Stale "the self-approve gate requires L3" comment corrected.

The proofless attempt deliberately runs outside `runAction`: `runAction` toasts every failure it sees, so a retried 403 would flash "register a device" a beat before the approval succeeds. The surviving `Response` is handed to `runAction` untouched (the token is read off a `clone()`), so success/error toasts, `friendly` copy and outcome mapping all stay in exactly one place.

`ApprovalsInbox` also calls `decideIntentApproval` and has `approval.approvalScope` in hand; it is deliberately left on the always-ceremony path. Its cards are usually somebody else's requests, where the server would not skip the ladder anyway, and changing that surface is outside this issue.

## Verification

- Red-first: with the supervised branch disabled, the 4 new supervised tests in `intentApprovals.test.ts` fail; restored, they pass.
- `npx vitest run src/lib/intentApprovals.test.ts src/stores/processStreamEvent.test.ts src/components/ai/AiApprovalDialog.test.tsx src/components/ai/AiChatMessages.test.tsx src/components/approvals/ApprovalsInbox.test.tsx src/stores/aiStore.test.ts src/stores/workspaceStore.test.ts` → **7 files, 183 tests passed**.
- `npx tsc --noEmit` (apps/web) clean; eslint clean on all touched files.

New coverage: supervised approve runs no ceremony and sends no `proof`; four_eyes still does; absent scope still does; supervised + 403 `step_up_required` → exactly one ceremony, one retry, no error toast; supervised + 403 with no approver device → `needs_device`, no second POST; supervised + a non-step-up 403 → surfaced, not retried; `processStreamEvent` carries the scope and never invents one; the dialog forwards it.

## Expected behaviour change

Supervised chat approvals will record L1 / `session_tap` instead of L3 / `webauthn_platform` (approved by Todd 2026-09-11). Partners with an enforcing authenticator policy are unaffected — the server still answers `step_up_required` and the client now satisfies it on the retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eg6fDo1pYRJSgegy1LigNu
