### PR TITLE
fix(partner-trust): unblock auto-promotion — billing route, IP backfill, parser, hard-deny (#5619)

### DIFF
--- a/apps/api/src/jobs/partnerTrustJobs.test.ts
+++ b/apps/api/src/jobs/partnerTrustJobs.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
   update, select, runOutside, withSystem, classify, tryAutoPromote,
-  evaluateHardDenies, setTrustState, partnerForDevice, sendEvidenceCard,
+  restrictOnHardDeny, partnerForDevice, ipClassifyProvider,
 } = vi.hoisted(() => ({
   update: vi.fn(),
   select: vi.fn(),
@@ -10,10 +10,9 @@ const {
   withSystem: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   classify: vi.fn(),
   tryAutoPromote: vi.fn(),
-  evaluateHardDenies: vi.fn(),
-  setTrustState: vi.fn(),
+  restrictOnHardDeny: vi.fn(),
   partnerForDevice: vi.fn(),
-  sendEvidenceCard: vi.fn(),
+  ipClassifyProvider: vi.fn(),
 }));
 
 vi.mock('../db', () => ({
@@ -22,22 +21,53 @@ vi.mock('../db', () => ({
   withSystemDbAccessContext: withSystem,
 }));
 vi.mock('../db/schema', () => ({
-  partners: { id: 'partners.id', trustState: 'partners.trustState' },
+  partners: {
+    id: 'partners.id',
+    trustState: 'partners.trustState',
+    signupIp: 'partners.signupIp',
+    signupIpClass: 'partners.signupIpClass',
+    signupIpClassifiedAt: 'partners.signupIpClassifiedAt',
+  },
   devices: { id: 'devices.id' },
 }));
-vi.mock('../services/ipClassify', () => ({
-  classifyIp: classify,
+vi.mock('../services/ipClassify', () => ({ classifyIp: classify }));
+vi.mock('../config/env', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../config/env')>()),
+  ipClassifyProvider,
 }));
-vi.mock('../services/partnerTrustPromotion', () => ({ tryAutoPromote, evaluateHardDenies }));
-vi.mock('../services/partnerTrust', () => ({ setTrustState }));
+vi.mock('../services/partnerTrustPromotion', () => ({ tryAutoPromote, restrictOnHardDeny }));
 vi.mock('../services/partnerTrust.repo', () => ({ partnerForDevice }));
-vi.mock('../services/partnerTrustEvidenceCard', () => ({ sendEvidenceCard }));
 
 import { processPartnerTrustJob } from './partnerTrustJobs';
+
+type ProbationRow = {
+  id: string;
+  signupIp: string | null;
+  signupIpClass: string;
+  signupIpClassifiedAt: Date | null;
+};
+
+const probationRow = (overrides: Partial<ProbationRow> = {}): ProbationRow => ({
+  id: 'partner-1',
+  signupIp: '198.51.100.7',
+  signupIpClass: 'unknown',
+  signupIpClassifiedAt: null,
+  ...overrides,
+});
 
 describe('processPartnerTrustJob', () => {
   const set = vi.fn();
   const where = vi.fn(async () => undefined);
+
+  const withBatch = (...batches: ProbationRow[][]) => {
+    const limit = vi.fn();
+    for (const batch of batches) limit.mockResolvedValueOnce(batch);
+    limit.mockResolvedValue([]);
+    select.mockReturnValue({
+      from: () => ({ where: () => ({ orderBy: () => ({ limit }) }) }),
+    });
+    return limit;
+  };
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -45,33 +75,149 @@ describe('processPartnerTrustJob', () => {
     process.env.PARTNER_TRUST_MODE = 'shadow';
     classify.mockResolvedValue({ ipClass: 'hosting', asn: 64500, provider: 'ipinfo' });
     tryAutoPromote.mockResolvedValue(false);
-    evaluateHardDenies.mockResolvedValue({ restrict: false });
-    setTrustState.mockResolvedValue(true);
+    restrictOnHardDeny.mockResolvedValue(false);
     partnerForDevice.mockResolvedValue('partner-for-device');
-    sendEvidenceCard.mockResolvedValue(undefined);
+    ipClassifyProvider.mockReturnValue('none');
     set.mockReturnValue({ where });
     update.mockReturnValue({ set });
   });
 
   it('iterates probation partners in batches and attempts promotion for each', async () => {
-    const first = Array.from({ length: 200 }, (_, i) => ({ id: `partner-${String(i).padStart(3, '0')}` }));
-    const second = [{ id: 'partner-200' }];
-    const limit = vi.fn().mockResolvedValueOnce(first).mockResolvedValueOnce(second);
-    const orderBy = vi.fn(() => ({ limit }));
-    const selectWhere = vi.fn(() => ({ orderBy }));
-    const from = vi.fn(() => ({ where: selectWhere }));
-    select.mockReturnValue({ from });
+    const first = Array.from({ length: 200 }, (_, i) => probationRow({ id: `partner-${String(i).padStart(3, '0')}` }));
+    const second = [probationRow({ id: 'partner-200' })];
+    const limit = withBatch(first, second);
     tryAutoPromote.mockImplementation(async (id: string) => id === 'partner-200');
 
     await expect(processPartnerTrustJob({ name: 'partner-trust-promote', data: {} }))
       .resolves.toEqual({ processed: 201, promoted: 1 });
 
     expect(tryAutoPromote).toHaveBeenCalledTimes(201);
-    expect(evaluateHardDenies).toHaveBeenCalledTimes(201);
     expect(tryAutoPromote).toHaveBeenLastCalledWith('partner-200');
     expect(limit).toHaveBeenCalledTimes(2);
-    expect(runOutside).toHaveBeenCalledTimes(2);
-    expect(withSystem).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips a partner whose promotion evaluation throws, without stopping the batch', async () => {
+    withBatch([probationRow({ id: 'partner-1' }), probationRow({ id: 'partner-2' })]);
+    tryAutoPromote.mockImplementation(async (id: string) => {
+      if (id === 'partner-1') throw new Error('db exploded');
+      return true;
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    await expect(processPartnerTrustJob({ name: 'partner-trust-promote', data: {} }))
+      .resolves.toEqual({ processed: 2, promoted: 1 });
+
+    expect(tryAutoPromote).toHaveBeenCalledTimes(2);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('partner-1'), expect.any(Error));
+    warnSpy.mockRestore();
+  });
+
+  it('never evaluates hard denies twice — tryAutoPromote owns that call now', async () => {
+    withBatch([probationRow()]);
+
+    await processPartnerTrustJob({ name: 'partner-trust-promote', data: {} });
+
+    expect(restrictOnHardDeny).not.toHaveBeenCalled();
+  });
+
+  describe('signup-IP backfill', () => {
+    it('classifies and persists an unclassified signup IP before promotion is attempted', async () => {
+      ipClassifyProvider.mockReturnValue('ipinfo');
+      withBatch([probationRow({ id: 'partner-1', signupIp: '198.51.100.7' })]);
+      const order: string[] = [];
+      classify.mockImplementation(async () => {
+        order.push('classify');
+        return { ipClass: 'residential', asn: 64500, provider: 'ipinfo' };
+      });
+      tryAutoPromote.mockImplementation(async () => {
+        order.push('promote');
+        return false;
+      });
+
+      await processPartnerTrustJob({ name: 'partner-trust-promote', data: {} });
+
+      expect(classify).toHaveBeenCalledWith('198.51.100.7');
+      expect(set).toHaveBeenCalledWith({
+        signupIpClass: 'residential',
+        signupIpAsn: 64500,
+        signupIpClassifiedAt: expect.any(Date),
+      });
+      expect(order).toEqual(['classify', 'promote']);
+    });
+
+    it('persists the unknown result so a provider outage does not retry every run', async () => {
+      ipClassifyProvider.mockReturnValue('ipinfo');
+      withBatch([probationRow()]);
+      classify.mockResolvedValue({ ipClass: 'unknown', asn: null, provider: 'ipinfo' });
+
+      await processPartnerTrustJob({ name: 'partner-trust-promote', data: {} });
+
+      expect(set).toHaveBeenCalledWith({
+        signupIpClass: 'unknown',
+        signupIpAsn: null,
+        signupIpClassifiedAt: expect.any(Date),
+      });
+    });
+
+    it('does not classify when no provider is configured', async () => {
+      ipClassifyProvider.mockReturnValue('none');
+      withBatch([probationRow()]);
+
+      await processPartnerTrustJob({ name: 'partner-trust-promote', data: {} });
+
+      expect(classify).not.toHaveBeenCalled();
+      expect(update).not.toHaveBeenCalled();
+    });
+
+    it('does not classify a partner with no signup IP recorded', async () => {
+      ipClassifyProvider.mockReturnValue('ipinfo');
+      withBatch([probationRow({ signupIp: null })]);
+
+      await processPartnerTrustJob({ name: 'partner-trust-promote', data: {} });
+
+      expect(classify).not.toHaveBeenCalled();
+      expect(tryAutoPromote).toHaveBeenCalledWith('partner-1');
+    });
+
+    it('does not re-classify a partner that already has a class', async () => {
+      ipClassifyProvider.mockReturnValue('ipinfo');
+      withBatch([probationRow({ signupIpClass: 'residential' })]);
+
+      await processPartnerTrustJob({ name: 'partner-trust-promote', data: {} });
+
+      expect(classify).not.toHaveBeenCalled();
+    });
+
+    it('skips a retry attempted within the last hour', async () => {
+      ipClassifyProvider.mockReturnValue('ipinfo');
+      withBatch([probationRow({ signupIpClassifiedAt: new Date(Date.now() - 30 * 60 * 1_000) })]);
+
+      await processPartnerTrustJob({ name: 'partner-trust-promote', data: {} });
+
+      expect(classify).not.toHaveBeenCalled();
+    });
+
+    it('retries once the previous attempt is older than an hour', async () => {
+      ipClassifyProvider.mockReturnValue('ipinfo');
+      withBatch([probationRow({ signupIpClassifiedAt: new Date(Date.now() - 2 * 60 * 60 * 1_000) })]);
+
+      await processPartnerTrustJob({ name: 'partner-trust-promote', data: {} });
+
+      expect(classify).toHaveBeenCalledWith('198.51.100.7');
+    });
+
+    it('still attempts promotion when the backfill lookup throws', async () => {
+      ipClassifyProvider.mockReturnValue('ipinfo');
+      withBatch([probationRow()]);
+      classify.mockRejectedValue(new Error('provider exploded'));
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      await expect(processPartnerTrustJob({ name: 'partner-trust-promote', data: {} }))
+        .resolves.toEqual({ processed: 1, promoted: 0 });
+
+      expect(tryAutoPromote).toHaveBeenCalledWith('partner-1');
+      warnSpy.mockRestore();
+    });
   });
 
   it('writes partner signup classification in a system DB context', async () => {
@@ -84,7 +230,7 @@ describe('processPartnerTrustJob', () => {
     }));
     expect(runOutside).toHaveBeenCalledTimes(1);
     expect(withSystem).toHaveBeenCalledTimes(1);
-    expect(evaluateHardDenies).toHaveBeenCalledWith('partner-1');
+    expect(restrictOnHardDeny).toHaveBeenCalledWith('partner-1');
   });
 
   it('writes device enrollment classification', async () => {
@@ -96,98 +242,11 @@ describe('processPartnerTrustJob', () => {
       enrollmentIpClass: 'hosting', enrollmentIpAsn: 64500, enrollmentIpClassifiedAt: expect.any(Date),
     }));
     expect(partnerForDevice).toHaveBeenCalledWith('device-1');
-    expect(evaluateHardDenies).toHaveBeenCalledWith('partner-for-device');
-  });
-
-  it('restricts a probation partner on hard deny and does not attempt promotion', async () => {
-    const limit = vi.fn().mockResolvedValue([{ id: 'partner-1' }]);
-    select.mockReturnValue({
-      from: () => ({ where: () => ({ orderBy: () => ({ limit }) }) }),
-    });
-    evaluateHardDenies.mockResolvedValue({
-      restrict: true,
-      reason: 'auto:tor_signup',
-      evidence: { matchedAxes: ['signup_ip_class'] },
-    });
-
-    await expect(processPartnerTrustJob({ name: 'partner-trust-promote', data: {} }))
-      .resolves.toEqual({ processed: 1, promoted: 0 });
-
-    expect(setTrustState).toHaveBeenCalledWith(
-      'partner-1', 'restricted', 'auto:tor_signup', null,
-      { matchedAxes: ['signup_ip_class'] },
-      { expectedFrom: 'probation' },
-    );
-    expect(tryAutoPromote).not.toHaveBeenCalled();
-    expect(sendEvidenceCard).toHaveBeenCalledWith('partner-1', 'restricted');
-  });
-
-  it('does not send the evidence card when the probation CAS loses to a trusted state', async () => {
-    evaluateHardDenies.mockResolvedValue({
-      restrict: true,
-      reason: 'auto:tor_signup',
-      evidence: {},
-    });
-    setTrustState.mockResolvedValue(false);
-
-    await processPartnerTrustJob({
-      name: 'ip-classify',
-      data: { kind: 'partner', partnerId: 'partner-1', ip: '198.51.100.1' },
-    });
-
-    expect(setTrustState).toHaveBeenCalledWith(
-      'partner-1', 'restricted', 'auto:tor_signup', null, {},
-      { expectedFrom: 'probation' },
-    );
-    expect(sendEvidenceCard).not.toHaveBeenCalled();
-  });
-
-  it('does not fail the job when sending the restricted evidence card throws (best-effort)', async () => {
-    const limit = vi.fn().mockResolvedValue([{ id: 'partner-1' }]);
-    select.mockReturnValue({
-      from: () => ({ where: () => ({ orderBy: () => ({ limit }) }) }),
-    });
-    evaluateHardDenies.mockResolvedValue({
-      restrict: true,
-      reason: 'auto:tor_signup',
-      evidence: { matchedAxes: ['signup_ip_class'] },
-    });
-    sendEvidenceCard.mockRejectedValue(new Error('smtp down'));
-
-    await expect(processPartnerTrustJob({ name: 'partner-trust-promote', data: {} }))
-      .resolves.toEqual({ processed: 1, promoted: 0 });
-
-    expect(sendEvidenceCard).toHaveBeenCalledWith('partner-1', 'restricted');
-  });
-
-  it('skips a partner whose hard-deny evaluation throws, without stopping the batch', async () => {
-    const limit = vi.fn().mockResolvedValue([{ id: 'partner-1' }, { id: 'partner-2' }]);
-    select.mockReturnValue({ from: () => ({ where: () => ({ orderBy: () => ({ limit }) }) }) });
-    evaluateHardDenies.mockImplementation(async (id: string) => {
-      if (id === 'partner-1') throw new Error('db exploded');
-      return { restrict: false };
-    });
-    tryAutoPromote.mockImplementation(async (id: string) => id === 'partner-2');
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
-
-    await expect(processPartnerTrustJob({ name: 'partner-trust-promote', data: {} }))
-      .resolves.toEqual({ processed: 2, promoted: 1 });
-
-    // The throwing partner is skipped entirely — not promoted just because
-    // its restrict check couldn't be confirmed — while the next partner in
-    // the batch still gets processed normally.
-    expect(tryAutoPromote).toHaveBeenCalledTimes(1);
-    expect(tryAutoPromote).toHaveBeenCalledWith('partner-2');
-    expect(tryAutoPromote).not.toHaveBeenCalledWith('partner-1');
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('partner-1'),
-      expect.any(Error),
-    );
-    warnSpy.mockRestore();
+    expect(restrictOnHardDeny).toHaveBeenCalledWith('partner-for-device');
   });
 
   it('does not throw out of the ip-classify job when hard-deny evaluation fails', async () => {
-    evaluateHardDenies.mockRejectedValue(new Error('db exploded'));
+    restrictOnHardDeny.mockRejectedValue(new Error('db exploded'));
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
 
     await expect(processPartnerTrustJob({
@@ -195,10 +254,7 @@ describe('processPartnerTrustJob', () => {
       data: { kind: 'partner', partnerId: 'partner-1', ip: '198.51.100.1' },
     })).resolves.toEqual({ ipClass: 'hosting', asn: 64500, provider: 'ipinfo' });
 
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('partner-1'),
-      expect.any(Error),
-    );
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('partner-1'), expect.any(Error));
     warnSpy.mockRestore();
   });
 

--- a/apps/api/src/jobs/partnerTrustJobs.ts
+++ b/apps/api/src/jobs/partnerTrustJobs.ts
@@ -1,41 +1,57 @@
 import type { Queue } from 'bullmq';
 import { and, asc, eq, gt } from 'drizzle-orm';
 
+import { ipClassifyProvider } from '../config/env';
 import { partnerTrustMode } from '../config/partnerTrustMode';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { devices, partners } from '../db/schema';
 import { classifyIp, type IpClassifyTarget } from '../services/ipClassify';
 import { partnerForDevice } from '../services/partnerTrust.repo';
-import { setTrustState } from '../services/partnerTrust';
-import { sendEvidenceCard } from '../services/partnerTrustEvidenceCard';
-import { evaluateHardDenies, tryAutoPromote } from '../services/partnerTrustPromotion';
+import { restrictOnHardDeny, tryAutoPromote } from '../services/partnerTrustPromotion';
 import { jobSchedule } from './scheduleRegistry';
 
 export const IP_CLASSIFY_JOB = 'ip-classify';
 export const PARTNER_TRUST_PROMOTE_JOB = 'partner-trust-promote';
 const PROMOTE_REPEAT_ID = 'partner-trust-promote-repeat';
 
-async function restrictOnHardDeny(partnerId: string): Promise<boolean> {
-  const decision = await evaluateHardDenies(partnerId);
-  if (!decision.restrict) return false;
-  const restricted = await setTrustState(
-    partnerId,
-    'restricted',
-    decision.reason,
-    null,
-    decision.evidence,
-    { expectedFrom: 'probation' },
-  );
-  if (restricted) {
-    try {
-      await sendEvidenceCard(partnerId, 'restricted');
-    } catch (error) {
-      // Best-effort: the restriction itself already landed — a notification
-      // failure must never surface as a job failure.
-      console.warn(`[partnerTrustJobs] Failed to send evidence card for restricted partner ${partnerId}`, error);
-    }
-  }
-  return restricted;
+/**
+ * Minimum gap between signup-IP classification attempts for one partner. The
+ * promote job runs every 15 minutes; without this bound a provider outage
+ * would hammer the classification API once per partner per run.
+ */
+const IP_BACKFILL_RETRY_MS = 60 * 60 * 1_000;
+
+type ProbationPartner = {
+  id: string;
+  signupIp: string | null;
+  signupIpClass: string;
+  signupIpClassifiedAt: Date | null;
+};
+
+/**
+ * Signup IPs are classified once, at email verification. A deployment that
+ * configures a provider afterwards would otherwise leave every existing
+ * partner on `signup_ip_class='unknown'` forever — which
+ * `promotionDecision` blocks as `signup_ip_unclassified`, so auto-promotion
+ * could never fire. Backfill those partners here, bounded by
+ * IP_BACKFILL_RETRY_MS. A failed lookup yields `unknown` again (preserved, not
+ * upgraded); partners with no recorded signup IP stay blocked for manual
+ * review.
+ */
+async function backfillSignupIpClass(partner: ProbationPartner): Promise<void> {
+  if (ipClassifyProvider() === 'none') return;
+  if (!partner.signupIp || partner.signupIpClass !== 'unknown') return;
+  const lastAttempt = partner.signupIpClassifiedAt?.getTime();
+  if (lastAttempt !== undefined && Date.now() - lastAttempt < IP_BACKFILL_RETRY_MS) return;
+
+  const classification = await classifyIp(partner.signupIp);
+  await runOutsideDbContext(() => withSystemDbAccessContext(() => db.update(partners).set({
+    signupIpClass: classification.ipClass,
+    signupIpAsn: classification.asn,
+    // Stamped even when the result is still `unknown`: this column is what
+    // bounds the retry cadence above.
+    signupIpClassifiedAt: new Date(),
+  }).where(eq(partners.id, partner.id)), 'partnerTrustJobs.backfillSignupIpClass'));
 }
 
 export async function runPartnerTrustPromote(): Promise<{ processed: number; promoted: number }> {
@@ -44,7 +60,12 @@ export async function runPartnerTrustPromote(): Promise<{ processed: number; pro
   let promoted = 0;
   do {
     const batch = await runOutsideDbContext(() => withSystemDbAccessContext(() => db
-      .select({ id: partners.id })
+      .select({
+        id: partners.id,
+        signupIp: partners.signupIp,
+        signupIpClass: partners.signupIpClass,
+        signupIpClassifiedAt: partners.signupIpClassifiedAt,
+      })
       .from(partners)
       .where(cursor
         ? and(eq(partners.trustState, 'probation'), gt(partners.id, cursor))
@@ -54,16 +75,24 @@ export async function runPartnerTrustPromote(): Promise<{ processed: number; pro
     for (const partner of batch) {
       processed += 1;
       try {
-        if (await restrictOnHardDeny(partner.id)) continue;
+        try {
+          await backfillSignupIpClass(partner);
+        } catch (error) {
+          // The backfill is an enhancement: on failure the partner keeps
+          // `signup_ip_class='unknown'`, which promotionDecision still blocks
+          // as `signup_ip_unclassified`. Don't skip the hard-deny evaluation
+          // that tryAutoPromote performs just because the lookup failed.
+          console.warn(`[partnerTrustJobs] signup-IP backfill failed for partner ${partner.id}`, error);
+        }
+        // tryAutoPromote evaluates hard denies itself (and restricts when one
+        // matches), so this is the single evaluation per partner — a failure
+        // anywhere in it skips this partner rather than aborting the batch,
+        // and never falls through to a promotion we couldn't justify.
+        if (await tryAutoPromote(partner.id)) promoted += 1;
       } catch (error) {
-        // A DB error evaluating one partner's hard-deny signals must not
-        // abort the rest of the batch. Skip this partner entirely — don't
-        // fall through to tryAutoPromote, since we couldn't confirm it's
-        // clear of a hard-deny match.
-        console.warn(`[partnerTrustJobs] hard-deny evaluation failed for partner ${partner.id}`, error);
+        console.warn(`[partnerTrustJobs] promotion evaluation failed for partner ${partner.id}`, error);
         continue;
       }
-      if (await tryAutoPromote(partner.id)) promoted += 1;
     }
     cursor = batch.at(-1)?.id;
     if (batch.length < 200) break;

--- a/apps/api/src/services/breezeBillingClient.test.ts
+++ b/apps/api/src/services/breezeBillingClient.test.ts
@@ -307,6 +307,25 @@ describe('breezeBillingClient', () => {
       await expect(client.getSignupRiskHold('p1')).resolves.toEqual({ status: 'none' });
     });
 
+    it.each([
+      ['empty string', ''],
+      ['whitespace', '   '],
+      ['zero', 0],
+      ['false', false],
+      ['an object', {}],
+    ])('treats a hold row whose releasedAt is %s as still open (fail closed)', async (_name, releasedAt) => {
+      const { client } = clientWith(okResponse({
+        partnerId: 'p1',
+        holds: [{ state: 'hold', releasedAt }],
+      }));
+      await expect(client.getSignupRiskHold('p1')).resolves.toEqual({ status: 'hold' });
+    });
+
+    it('treats an absent releasedAt field as still open', async () => {
+      const { client } = clientWith(okResponse({ partnerId: 'p1', holds: [{ state: 'hold' }] }));
+      await expect(client.getSignupRiskHold('p1')).resolves.toEqual({ status: 'hold' });
+    });
+
     it('reports pass when the only unreleased row is a pass', async () => {
       const { client } = clientWith(okResponse({
         partnerId: 'p1',

--- a/apps/api/src/services/breezeBillingClient.test.ts
+++ b/apps/api/src/services/breezeBillingClient.test.ts
@@ -231,4 +231,152 @@ describe('breezeBillingClient', () => {
       warn.mockRestore();
     });
   });
+
+  describe('getSignupRiskHold', () => {
+    let warn: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined) as never;
+    });
+
+    afterEach(() => {
+      warn.mockRestore();
+    });
+
+    const okResponse = (body: unknown) => ({ ok: true, status: 200, json: async () => body });
+
+    const clientWith = (response: unknown) => {
+      const fetchMock = vi.fn().mockResolvedValue(response);
+      return {
+        fetchMock,
+        client: createBreezeBillingClient({ baseUrl: 'http://billing.local', fetch: fetchMock as any }),
+      };
+    };
+
+    it('GETs the breeze-billing signup-risk holds route with the partner id encoded', async () => {
+      const { client, fetchMock } = clientWith(okResponse({ partnerId: 'p/1', holds: [], assessments: [] }));
+
+      await client.getSignupRiskHold('p/1');
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://billing.local/internal/signup-risk/holds/p%2F1',
+        expect.objectContaining({ method: 'GET' }),
+      );
+    });
+
+    it('reports none when the partner has no hold rows', async () => {
+      const { client } = clientWith(okResponse({ partnerId: 'p1', holds: [], assessments: [] }));
+      await expect(client.getSignupRiskHold('p1')).resolves.toEqual({ status: 'none' });
+    });
+
+    it('reports hold for an unreleased hold row', async () => {
+      const { client } = clientWith(okResponse({
+        partnerId: 'p1',
+        holds: [{ state: 'hold', releasedAt: null }],
+      }));
+      await expect(client.getSignupRiskHold('p1')).resolves.toEqual({ status: 'hold' });
+    });
+
+    it('reports review_pending for an unreleased review_pending row', async () => {
+      const { client } = clientWith(okResponse({
+        partnerId: 'p1',
+        holds: [{ state: 'review_pending', releasedAt: null }],
+      }));
+      await expect(client.getSignupRiskHold('p1')).resolves.toEqual({ status: 'review_pending' });
+    });
+
+    it('lets an unreleased hold win over an unreleased review_pending regardless of row order', async () => {
+      const { client } = clientWith(okResponse({
+        partnerId: 'p1',
+        holds: [
+          { state: 'review_pending', releasedAt: null },
+          { state: 'hold', releasedAt: null },
+        ],
+      }));
+      await expect(client.getSignupRiskHold('p1')).resolves.toEqual({ status: 'hold' });
+    });
+
+    it('ignores released rows', async () => {
+      const { client } = clientWith(okResponse({
+        partnerId: 'p1',
+        holds: [
+          { state: 'hold', releasedAt: '2026-09-01T00:00:00.000Z' },
+          { state: 'released', releasedAt: '2026-09-01T00:00:00.000Z' },
+        ],
+      }));
+      await expect(client.getSignupRiskHold('p1')).resolves.toEqual({ status: 'none' });
+    });
+
+    it('reports pass when the only unreleased row is a pass', async () => {
+      const { client } = clientWith(okResponse({
+        partnerId: 'p1',
+        holds: [{ state: 'pass', releasedAt: null }],
+      }));
+      await expect(client.getSignupRiskHold('p1')).resolves.toEqual({ status: 'pass' });
+    });
+
+    it('treats an unknown unreleased state as a hold (fail closed)', async () => {
+      const { client } = clientWith(okResponse({
+        partnerId: 'p1',
+        holds: [{ state: 'quarantined_pending_manual_thing', releasedAt: null }],
+      }));
+      await expect(client.getSignupRiskHold('p1')).resolves.toEqual({ status: 'hold' });
+    });
+
+    it('maps the exact domain 404 body to status none', async () => {
+      const { client } = clientWith({
+        ok: false,
+        status: 404,
+        json: async () => ({ error: 'no signup-risk records for partner' }),
+        text: async () => JSON.stringify({ error: 'no signup-risk records for partner' }),
+      });
+      await expect(client.getSignupRiskHold('p1')).resolves.toEqual({ status: 'none' });
+    });
+
+    it('returns null for a generic HTML 404 (route missing, not "no records")', async () => {
+      const { client } = clientWith({
+        ok: false,
+        status: 404,
+        json: async () => { throw new SyntaxError('Unexpected token <'); },
+        text: async () => '<!DOCTYPE html><title>Cannot GET</title>',
+      });
+      await expect(client.getSignupRiskHold('p1')).resolves.toBeNull();
+    });
+
+    it('returns null for a JSON 404 whose error text is not the domain message', async () => {
+      const { client } = clientWith({
+        ok: false,
+        status: 404,
+        json: async () => ({ error: 'Not Found' }),
+        text: async () => '{"error":"Not Found"}',
+      });
+      await expect(client.getSignupRiskHold('p1')).resolves.toBeNull();
+    });
+
+    it.each([401, 403, 500, 502])('returns null on %i without throwing', async (status) => {
+      const { client } = clientWith({ ok: false, status, json: async () => ({}), text: async () => 'nope' });
+      await expect(client.getSignupRiskHold('p1')).resolves.toBeNull();
+    });
+
+    it('returns null when the request itself fails', async () => {
+      const fetchMock = vi.fn().mockRejectedValue(new Error('network down'));
+      const client = createBreezeBillingClient({ baseUrl: 'http://billing.local', fetch: fetchMock as any });
+      await expect(client.getSignupRiskHold('p1')).resolves.toBeNull();
+    });
+
+    it.each([
+      ['holds missing', { partnerId: 'p1' }],
+      ['holds not an array', { partnerId: 'p1', holds: { state: 'hold' } }],
+      ['body not an object', 'ok'],
+      ['body null', null],
+    ])('returns null on a malformed success body (%s)', async (_name, body) => {
+      const { client } = clientWith(okResponse(body));
+      await expect(client.getSignupRiskHold('p1')).resolves.toBeNull();
+    });
+
+    it('returns null when the body is for a different partner', async () => {
+      const { client } = clientWith(okResponse({ partnerId: 'other', holds: [] }));
+      await expect(client.getSignupRiskHold('p1')).resolves.toBeNull();
+    });
+  });
 });

--- a/apps/api/src/services/breezeBillingClient.ts
+++ b/apps/api/src/services/breezeBillingClient.ts
@@ -47,8 +47,19 @@ type SignupRiskHoldRow = { state?: unknown; releasedAt?: unknown };
  * rows count. An unrecognised state is treated as a hold: a state we do not
  * know the semantics of must never read as "clear".
  */
+/**
+ * A row counts as released only on an affirmative, well-formed timestamp.
+ * `releasedAt` arrives as untrusted JSON from a separate service, so anything
+ * else — `null`, absent, `''`, `0`, `false`, an object — leaves the row OPEN.
+ * Defaulting the other way would let a serialization quirk on the billing side
+ * silently clear a real hold.
+ */
+function isReleased(value: unknown): boolean {
+  return typeof value === 'string' && value.trim() !== '';
+}
+
 export function deriveSignupRiskHoldStatus(holds: SignupRiskHoldRow[]): SignupRiskHoldStatus {
-  const open = holds.filter((row) => row.releasedAt === null || row.releasedAt === undefined);
+  const open = holds.filter((row) => !isReleased(row.releasedAt));
   if (open.length === 0) return 'none';
   const states = open.map((row) => (typeof row.state === 'string' ? row.state : ''));
   if (states.some((state) => state === 'hold' || !['review_pending', 'pass', 'released'].includes(state))) {

--- a/apps/api/src/services/breezeBillingClient.ts
+++ b/apps/api/src/services/breezeBillingClient.ts
@@ -15,8 +15,48 @@ export interface SettledCardCharge {
   refunded: boolean;
 }
 
+/**
+ * Risk-hold status for a partner, as reported by breeze-billing.
+ *
+ * - `none` — breeze-billing has records for this partner (or affirmatively has
+ *   none at all) and nothing is holding it.
+ * - `pass` — an unreleased assessment row explicitly cleared the partner.
+ * - `hold` / `review_pending` — an unreleased row is blocking.
+ *
+ * A `null` return from `getSignupRiskHold` is NOT one of these: it means the
+ * status could not be determined and callers must fail closed.
+ */
+export type SignupRiskHoldStatus = 'none' | 'hold' | 'review_pending' | 'pass';
+
 export interface SignupRiskHold {
-  status: string;
+  status: SignupRiskHoldStatus;
+}
+
+/**
+ * The one 404 body that means "breeze-billing answered, and this partner has
+ * no signup-risk records" (`routes/signupRiskInternal.ts`). Every other 404 —
+ * a missing route, a proxy's HTML error page, a generic `Not Found` — means we
+ * did not reach the endpoint and must stay fail-closed.
+ */
+const NO_RISK_RECORDS_ERROR = 'no signup-risk records for partner';
+
+type SignupRiskHoldRow = { state?: unknown; releasedAt?: unknown };
+
+/**
+ * Derives a single status from breeze-billing's hold rows. Only unreleased
+ * rows count. An unrecognised state is treated as a hold: a state we do not
+ * know the semantics of must never read as "clear".
+ */
+export function deriveSignupRiskHoldStatus(holds: SignupRiskHoldRow[]): SignupRiskHoldStatus {
+  const open = holds.filter((row) => row.releasedAt === null || row.releasedAt === undefined);
+  if (open.length === 0) return 'none';
+  const states = open.map((row) => (typeof row.state === 'string' ? row.state : ''));
+  if (states.some((state) => state === 'hold' || !['review_pending', 'pass', 'released'].includes(state))) {
+    return 'hold';
+  }
+  if (states.includes('review_pending')) return 'review_pending';
+  if (states.includes('pass')) return 'pass';
+  return 'none';
 }
 
 export interface BreezeBillingClient {
@@ -148,7 +188,44 @@ export function createBreezeBillingClient(opts: {
     },
 
     async getSignupRiskHold(partnerId) {
-      return internalGet<SignupRiskHold>(partnerId, 'signup-risk-hold');
+      // breeze-billing mounts this as GET /internal/signup-risk/holds/:partnerId
+      // (src/index.ts + routes/signupRiskInternal.ts) — NOT under
+      // /internal/partners/:id, so it cannot go through internalGet.
+      const headers: Record<string, string> = {};
+      const billingKey = process.env.BREEZE_BILLING_API_KEY;
+      if (billingKey) headers.Authorization = `Bearer ${billingKey}`;
+      const url = `${opts.baseUrl}/internal/signup-risk/holds/${encodeURIComponent(partnerId)}`;
+      const unknown = (why: string): null => {
+        console.warn(`[breezeBillingClient] signup-risk hold unknown for partner ${partnerId}: ${why}`);
+        return null;
+      };
+      try {
+        const res = await doFetch(url, { method: 'GET', headers });
+        if (res.status === 404) {
+          // Only the exact domain body means "no records". A generic or HTML
+          // 404 means the route is missing — stay fail-closed.
+          const body = await res.json().catch(() => null) as { error?: unknown } | null;
+          if (body && typeof body === 'object' && body.error === NO_RISK_RECORDS_ERROR) {
+            return { status: 'none' };
+          }
+          return unknown('404 without the no-records body');
+        }
+        if (!res.ok) return unknown(`HTTP ${res.status}`);
+        const body = await res.json().catch(() => null) as
+          { partnerId?: unknown; holds?: unknown } | null;
+        if (!body || typeof body !== 'object') return unknown('malformed body');
+        if (!Array.isArray(body.holds)) return unknown('missing holds array');
+        if (typeof body.partnerId === 'string' && body.partnerId !== partnerId) {
+          return unknown('body is for a different partner');
+        }
+        return { status: deriveSignupRiskHoldStatus(body.holds as SignupRiskHoldRow[]) };
+      } catch (error) {
+        console.warn(
+          `[breezeBillingClient] signup-risk hold request failed for partner ${partnerId}`,
+          error,
+        );
+        return null;
+      }
     },
 
     async hasFraudulentRefundMatch(partnerId) {

--- a/apps/api/src/services/ipClassify.test.ts
+++ b/apps/api/src/services/ipClassify.test.ts
@@ -87,6 +87,59 @@ describe('classifyIp', () => {
     await expect(classifyIp('198.51.104.1')).resolves.toMatchObject({ ipClass: 'residential' });
   });
 
+  it('returns unknown when ipinfo omits the privacy object entirely', async () => {
+    // A token without privacy detection returns no `privacy` key at all.
+    // Absent evidence is NOT evidence of a residential address — every
+    // hosting/VPN abuser would otherwise pass the promotion gate.
+    process.env.IP_CLASSIFY_PROVIDER = 'ipinfo';
+    process.env.IP_CLASSIFY_API_KEY = 'secret';
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ asn: { asn: 'AS64500' }, company: { type: 'business' } }),
+    })));
+
+    await expect(classifyIp('198.51.100.1')).resolves.toEqual({
+      ipClass: 'unknown', asn: 64500, provider: 'ipinfo',
+    });
+  });
+
+  it('returns unknown when the ipinfo privacy field is not an object', async () => {
+    process.env.IP_CLASSIFY_PROVIDER = 'ipinfo';
+    process.env.IP_CLASSIFY_API_KEY = 'secret';
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ privacy: null, asn: 64500 }),
+    })));
+
+    await expect(classifyIp('198.51.105.1')).resolves.toMatchObject({ ipClass: 'unknown' });
+  });
+
+  it('returns unknown when ipdata omits the threat object entirely', async () => {
+    process.env.IP_CLASSIFY_PROVIDER = 'ipdata';
+    process.env.IP_CLASSIFY_API_KEY = 'secret';
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ asn: { asn: 64501 }, company: { type: 'business' } }),
+    })));
+
+    await expect(classifyIp('203.0.113.8')).resolves.toEqual({
+      ipClass: 'unknown', asn: 64501, provider: 'ipdata',
+    });
+  });
+
+  it('still classifies when the evidence object is present but empty', async () => {
+    // Positive control for the two tests above: `privacy: {}` IS evidence —
+    // the provider looked and found no privacy flags — so residential stands.
+    process.env.IP_CLASSIFY_PROVIDER = 'ipinfo';
+    process.env.IP_CLASSIFY_API_KEY = 'secret';
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ privacy: {}, asn: 64500 }),
+    })));
+
+    await expect(classifyIp('198.51.106.1')).resolves.toMatchObject({ ipClass: 'residential' });
+  });
+
   it('maps ipdata threat fields', async () => {
     process.env.IP_CLASSIFY_PROVIDER = 'ipdata';
     process.env.IP_CLASSIFY_API_KEY = 'secret';

--- a/apps/api/src/services/ipClassify.ts
+++ b/apps/api/src/services/ipClassify.ts
@@ -67,9 +67,22 @@ function parseAsn(value: unknown): number | null {
   return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;
 }
 
+/**
+ * True only when the provider actually returned its privacy/threat evidence
+ * object. Both providers omit it entirely on plans without privacy detection —
+ * and absent evidence is not evidence of absence: treating a missing object as
+ * "no privacy flags set" classified every hosting/VPN/proxy address as
+ * `residential`, which is precisely what a signup-abuse gate must not do.
+ */
+function hasEvidence(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 function mapProviderResponse(provider: 'ipinfo' | 'ipdata', body: any): IpClassification {
+  const asn = parseAsn(body?.asn?.asn ?? body?.asn);
   if (provider === 'ipinfo') {
-    const privacy = body?.privacy ?? {};
+    const privacy = body?.privacy;
+    if (!hasEvidence(privacy)) return { ipClass: 'unknown', asn, provider };
     const ipClass: IpClass = privacy.tor === true
       ? 'tor'
       : privacy.vpn === true
@@ -79,10 +92,11 @@ function mapProviderResponse(provider: 'ipinfo' | 'ipdata', body: any): IpClassi
           : body?.company?.type === 'business'
             ? 'business'
             : 'residential';
-    return { ipClass, asn: parseAsn(body?.asn?.asn ?? body?.asn), provider };
+    return { ipClass, asn, provider };
   }
 
-  const threat = body?.threat ?? {};
+  const threat = body?.threat;
+  if (!hasEvidence(threat)) return { ipClass: 'unknown', asn, provider };
   const ipClass: IpClass = threat.is_tor === true
     ? 'tor'
     : threat.is_vpn === true || threat.is_proxy === true
@@ -92,7 +106,7 @@ function mapProviderResponse(provider: 'ipinfo' | 'ipdata', body: any): IpClassi
         : body?.company?.type === 'business'
           ? 'business'
           : 'residential';
-  return { ipClass, asn: parseAsn(body?.asn?.asn ?? body?.asn), provider };
+  return { ipClass, asn, provider };
 }
 
 function providerUrl(provider: 'ipinfo' | 'ipdata', ip: string, key: string): string {

--- a/apps/api/src/services/partnerTrustPromotion.test.ts
+++ b/apps/api/src/services/partnerTrustPromotion.test.ts
@@ -3,7 +3,7 @@ import type { IpClass } from '../db/schema/orgs';
 
 const {
   readTrust, setTrustState, getSettledCardCharge, getSignupRiskHold,
-  hasFraudulentRefundMatch, select, execute, runOutside, withSystem,
+  hasFraudulentRefundMatch, select, execute, runOutside, withSystem, sendEvidenceCard,
 } = vi.hoisted(() => ({
   readTrust: vi.fn(),
   setTrustState: vi.fn(),
@@ -14,6 +14,7 @@ const {
   execute: vi.fn(),
   runOutside: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   withSystem: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  sendEvidenceCard: vi.fn(),
 }));
 
 vi.mock('../db', () => ({
@@ -34,9 +35,11 @@ vi.mock('./breezeBillingClient', () => ({
     getSettledCardCharge, getSignupRiskHold, hasFraudulentRefundMatch,
   }),
 }));
+vi.mock('./partnerTrustEvidenceCard', () => ({ sendEvidenceCard }));
 
 import {
-  evaluateHardDenies, promotionDecision, tryAutoPromote, type PromotionFacts,
+  evaluateHardDenies, gatherPromotionFacts, promotionDecision, restrictOnHardDeny,
+  tryAutoPromote, type PromotionFacts,
 } from './partnerTrustPromotion';
 
 const now = new Date('2026-09-02T12:00:00.000Z');
@@ -196,8 +199,11 @@ describe('tryAutoPromote', () => {
     });
     // A resolved "clear" status, not null — null now means "unknown" and
     // fails closed (see the billing-hold-unknown tests below).
-    getSignupRiskHold.mockResolvedValue({ status: 'clear' });
+    getSignupRiskHold.mockResolvedValue({ status: 'none' });
     setTrustState.mockResolvedValue(true);
+    execute.mockResolvedValue([hardDenyRow()]);
+    hasFraudulentRefundMatch.mockResolvedValue(false);
+    sendEvidenceCard.mockResolvedValue(undefined);
 
     select.mockImplementation((fields: Record<string, unknown>) => {
       if ('createdAt' in fields) {
@@ -218,8 +224,9 @@ describe('tryAutoPromote', () => {
       expect.objectContaining({ settledCard: { chargeId: 'ch_1', settledAt: hoursAgo(24) } }),
       { expectedFrom: 'probation' },
     );
-    expect(runOutside).toHaveBeenCalledTimes(1);
-    expect(withSystem).toHaveBeenCalledTimes(1);
+    // One system context for the hard-deny query, one for the local facts.
+    expect(runOutside).toHaveBeenCalledTimes(2);
+    expect(withSystem).toHaveBeenCalledTimes(2);
   });
 
   it.each([
@@ -256,6 +263,76 @@ describe('tryAutoPromote', () => {
     expect(setTrustState).not.toHaveBeenCalled();
   });
 
+  it.each(['none', 'pass'] as const)('treats a %s risk-hold status as no hold', async (status) => {
+    getSignupRiskHold.mockResolvedValue({ status });
+
+    await expect(tryAutoPromote('p1')).resolves.toBe(true);
+    expect(setTrustState).toHaveBeenCalledWith(
+      'p1', 'trusted', 'auto:settled_card_24h', null,
+      expect.objectContaining({ billingHold: false, billingHoldUnknown: false }),
+      { expectedFrom: 'probation' },
+    );
+  });
+
+  it.each(['hold', 'review_pending'] as const)('does not promote on a %s risk-hold status', async (status) => {
+    getSignupRiskHold.mockResolvedValue({ status });
+
+    await expect(tryAutoPromote('p1')).resolves.toBe(false);
+    expect(setTrustState).not.toHaveBeenCalled();
+  });
+
+  describe('hard-deny evaluation is inside tryAutoPromote', () => {
+    it('restricts instead of promoting when a hard deny matches', async () => {
+      execute.mockResolvedValue([hardDenyRow({ signup_ip_class: 'tor' })]);
+
+      await expect(tryAutoPromote('p1')).resolves.toBe(false);
+
+      expect(setTrustState).toHaveBeenCalledTimes(1);
+      expect(setTrustState).toHaveBeenCalledWith(
+        'p1', 'restricted', 'auto:tor_signup', null,
+        { matchedAxes: ['signup_ip_class'], signupIpClass: 'tor' },
+        { expectedFrom: 'probation' },
+      );
+      expect(sendEvidenceCard).toHaveBeenCalledWith('p1', 'restricted');
+      // Never falls through to the promotion path.
+      expect(getSettledCardCharge).not.toHaveBeenCalled();
+    });
+
+    it('does not send the evidence card when the restrict CAS loses', async () => {
+      execute.mockResolvedValue([hardDenyRow({ signup_ip_class: 'tor' })]);
+      setTrustState.mockResolvedValue(false);
+
+      await expect(tryAutoPromote('p1')).resolves.toBe(false);
+      expect(sendEvidenceCard).not.toHaveBeenCalled();
+    });
+
+    it('does not fail when the restricted evidence card throws (best effort)', async () => {
+      execute.mockResolvedValue([hardDenyRow({ signup_ip_class: 'tor' })]);
+      sendEvidenceCard.mockRejectedValue(new Error('smtp down'));
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      await expect(tryAutoPromote('p1')).resolves.toBe(false);
+      warn.mockRestore();
+    });
+
+    it('propagates a hard-deny evaluation failure rather than promoting past it', async () => {
+      execute.mockRejectedValue(new Error('db exploded'));
+
+      await expect(tryAutoPromote('p1')).rejects.toThrow('db exploded');
+      expect(setTrustState).not.toHaveBeenCalled();
+    });
+
+    it('is exported for the ip-classify path, which restricts without promoting', async () => {
+      execute.mockResolvedValue([hardDenyRow({ signup_ip_class: 'tor' })]);
+
+      await expect(restrictOnHardDeny('p1')).resolves.toBe(true);
+      expect(setTrustState).toHaveBeenCalledWith(
+        'p1', 'restricted', 'auto:tor_signup', null,
+        expect.anything(), { expectedFrom: 'probation' },
+      );
+    });
+  });
+
   it('treats a CAS miss on the underlying write as "not promoted" with no audit/event', async () => {
     // setTrustState itself performs the atomic compare-and-swap (writeTrust
     // with expectedFrom); when it reports the row already moved out of
@@ -270,4 +347,40 @@ describe('tryAutoPromote', () => {
       { expectedFrom: 'probation' },
     );
   });
+});
+
+describe('gatherPromotionFacts billing hold mapping', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getSettledCardCharge.mockResolvedValue(null);
+    select.mockImplementation((fields: Record<string, unknown>) => {
+      if ('createdAt' in fields) {
+        return { from: () => ({ where: () => ({ limit: async () => [{ createdAt: hoursAgo(48), emailVerifiedAt: hoursAgo(47), signupIpClass: 'residential' }] }) }) };
+      }
+      if ('ipClass' in fields) {
+        return { from: () => ({ innerJoin: () => ({ where: async () => [] }) }) };
+      }
+      return { from: () => ({ where: async () => [{ count: 0 }] }) };
+    });
+  });
+
+  it.each([
+    ['none', false, false],
+    ['pass', false, false],
+    ['hold', true, false],
+    ['review_pending', true, false],
+  ] as const)('maps status %s to billingHold=%s', async (status, billingHold, billingHoldUnknown) => {
+    getSignupRiskHold.mockResolvedValue({ status });
+
+    await expect(gatherPromotionFacts('p1')).resolves.toMatchObject({ billingHold, billingHoldUnknown });
+  });
+
+  it('fails closed when the hold status is unknown', async () => {
+    getSignupRiskHold.mockResolvedValue(null);
+
+    await expect(gatherPromotionFacts('p1')).resolves.toMatchObject({
+      billingHold: true, billingHoldUnknown: true,
+    });
+  });
+
 });

--- a/apps/api/src/services/partnerTrustPromotion.ts
+++ b/apps/api/src/services/partnerTrustPromotion.ts
@@ -6,6 +6,7 @@ import type { IpClass, PartnerTrustState } from '../db/schema/orgs';
 import { getBreezeBillingClient } from './breezeBillingClient';
 import { readTrust } from './partnerTrust.repo';
 import { setTrustState } from './partnerTrust';
+import { sendEvidenceCard } from './partnerTrustEvidenceCard';
 
 const DAY_MS = 24 * 60 * 60 * 1_000;
 
@@ -357,9 +358,11 @@ export async function gatherPromotionFacts(partnerId: string): Promise<Promotion
   // status as a hold so an outage in breeze-billing can never silently
   // unblock an auto-promotion.
   const billingHoldUnknown = hold === null;
+  // 'none' (no records / nothing open) and 'pass' (an unreleased row that
+  // explicitly cleared the partner) are the only statuses that are not a hold.
   const billingHold = billingHoldUnknown
     ? true
-    : hold.status === 'hold' || hold.status === 'review_pending';
+    : hold.status !== 'none' && hold.status !== 'pass';
   return {
     ...localFacts,
     settledCard: settledCard && !settledCard.disputed && !settledCard.refunded
@@ -372,9 +375,49 @@ export async function gatherPromotionFacts(partnerId: string): Promise<Promotion
   };
 }
 
+/**
+ * Evaluates hard-deny signals and, when one matches, moves the partner to
+ * `restricted` (CAS from `probation`) and best-effort sends the evidence card.
+ * Returns whether the restriction actually landed.
+ *
+ * Lives here rather than in the job so that EVERY promotion path goes through
+ * it — `tryAutoPromote` calls it first, so no caller can promote a partner
+ * that should have been restricted. The ip-classify job still calls it
+ * directly, since that path restricts without attempting a promotion.
+ */
+export async function restrictOnHardDeny(partnerId: string): Promise<boolean> {
+  const decision = await evaluateHardDenies(partnerId);
+  if (!decision.restrict) return false;
+  const restricted = await setTrustState(
+    partnerId,
+    'restricted',
+    decision.reason,
+    null,
+    decision.evidence,
+    { expectedFrom: 'probation' },
+  );
+  if (restricted) {
+    try {
+      await sendEvidenceCard(partnerId, 'restricted');
+    } catch (error) {
+      // Best-effort: the restriction itself already landed — a notification
+      // failure must never surface as a job failure.
+      console.warn(
+        `[partnerTrustPromotion] Failed to send evidence card for restricted partner ${partnerId}`,
+        error,
+      );
+    }
+  }
+  return restricted;
+}
+
 export async function tryAutoPromote(partnerId: string): Promise<boolean> {
   const current = await readTrust(partnerId);
   if (current?.trustState !== 'probation') return false;
+  // Hard denies are evaluated here, not at the call site, so a direct caller
+  // can never promote past a signal that should restrict. A failure to
+  // evaluate them propagates rather than falling through to promotion.
+  if (await restrictOnHardDeny(partnerId)) return false;
   const facts = await gatherPromotionFacts(partnerId);
   const decision = promotionDecision(facts, new Date());
   if (!decision.promote) return false;


### PR DESCRIPTION
Closes #5619

`partner.trust.promoted` has been written **zero** times since enforce mode went live. `promotionDecision` had three permanently-true blockers, plus a fourth defect that let a direct caller promote past a hard deny. All four items from the issue are fixed here; the 3DS rule is deliberately **not** touched (tracked separately).

## 1. Billing risk-hold route mismatch → `billing_hold_unknown` (always)

`getSignupRiskHold` called `GET /internal/partners/:id/signup-risk-hold`, which breeze-billing does not mount — it serves `GET /internal/signup-risk/holds/:partnerId`. Every partner 404'd, the client mapped that to `null`, and `gatherPromotionFacts` fails closed on `null`.

- Client now calls the real route (it can't go through `internalGet`, whose URL shape is different).
- Status is derived from the hold rows: unreleased `hold` (or an **unknown** state) → `hold`; unreleased `review_pending` → `review_pending`; unreleased `pass` → `pass`; nothing unreleased → `none`. A `hold` wins over a `review_pending` regardless of row order.
- **Only** the exact domain 404 body `{error:'no signup-risk records for partner'}` maps to `{status:'none'}`. A generic/HTML 404, 401/403, 5xx, a timeout, a malformed body, a missing `holds` array, or a `partnerId` mismatch all return `null` — i.e. stay fail-closed.
- `SignupRiskHold.status` is now typed `'none' | 'hold' | 'review_pending' | 'pass'`, and `gatherPromotionFacts` treats only `none`/`pass` as no hold. `null` still means unknown → `billingHold: true`, `billingHoldUnknown: true`.

## 2. No IP classification backfill → `signup_ip_unclassified` (always)

Signup IPs are classified once, at email verification, so configuring a provider afterwards never reclassifies existing partners.

`runPartnerTrustPromote` now backfills a probation partner's signup IP when `ipClassifyProvider() !== 'none'`, `signup_ip` is set and `signup_ip_class = 'unknown'` — bounded to **one attempt per hour per partner** (`signup_ip_classified_at`), so a provider outage cannot hammer the classification API every 15 minutes. The timestamp is stamped even when the result is still `unknown`, which is what bounds the retry; a failed lookup therefore preserves `unknown` rather than upgrading it. Partners with a NULL `signup_ip` stay blocked for manual review. Device `enrollment_ip_class` needs no backfill (only `tor` blocks).

A backfill failure warns and still runs `tryAutoPromote`: the partner keeps `unknown`, which `promotionDecision` blocks anyway, so skipping would only cost the hard-deny evaluation.

## 3. `mapProviderResponse` defaulted to `residential` when evidence was absent

An absent `privacy` (ipinfo) / `threat` (ipdata) object was read as "no flags set", so on a token without privacy detection every hosting/VPN/proxy address classified as `residential`. Absent (or non-object) evidence now yields `unknown`; a present-but-empty object still classifies normally — that's a real observation. ASN parsing is unchanged in both paths.

## 4. `tryAutoPromote` skipped hard denies when called directly

`restrictOnHardDeny` moves from `jobs/partnerTrustJobs.ts` into `services/partnerTrustPromotion.ts` and runs at the top of `tryAutoPromote`, so no caller can promote a partner that should be restricted. The worker loop no longer calls it separately (one evaluation per partner, not two) and keeps its per-partner try/catch; the ip-classify path still calls the exported `restrictOnHardDeny` directly. A hard-deny evaluation failure propagates out of `tryAutoPromote` rather than falling through to promotion.

## Ops prerequisites (for the release notes)

These are **deployment** steps, not code — auto-promotion stays blocked on `signup_ip_unclassified` until they're done on both droplets:

- **`IP_CLASSIFY_PROVIDER`** — `ipinfo` or `ipdata`. Unset (or `none`) means no classification and no backfill; every partner stays `unknown` and blocked.
- **`IP_CLASSIFY_API_KEY`** — required alongside the provider; without it `ipClassifyProvider()` degrades to `none` with a single warning.
- Both must be added to `/opt/breeze/.env` **and** mapped in the `api` service's `environment:` block in `/opt/breeze/docker-compose.yml` (compose only interpolates what's listed there).
- Also outstanding from the issue, unchanged by this PR: `PARTNER_MEETING_URL`, `BREEZE_PLATFORM_ADMINS`.

Once the provider is live, the existing probation backlog reclassifies itself on the next few promote runs (one partner-hour of budget each).

## Verification

- `npx vitest run src/services/breezeBillingClient.test.ts src/jobs/partnerTrustJobs.test.ts src/services/ipClassify.test.ts src/services/partnerTrustPromotion.test.ts` — **110 passed**. Every new test was written first and watched fail (40 red before the implementation).
- `src/services/partnerTrust.test.ts` + `src/config/env.test.ts` — 61 passed (call sites of the moved function).
- `npx tsc --noEmit` on `apps/api` — clean.
- `eslint` on all eight touched files — clean.

No schema, migration or tenancy changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LVTfF92bPb8YZJYLptWr11