### PR TITLE
fix(remote): stop the desktop orphan sweeper finalizing peer-to-peer viewer sessions

### DIFF
--- a/apps/api/src/routes/desktopWs.ts
+++ b/apps/api/src/routes/desktopWs.ts
@@ -1873,6 +1873,7 @@ export function __createDesktopSharedLeasesForTest(): RemoteWsSharedLeaseManager
     releaseDesktopFinalizationIntent: async () => true,
     observeDesktopFinalization: async () => ({
       ownerPresent: false,
+      everOwned: false,
       finalizationId: null,
       canonicalPayload: null,
       consistent: true,

--- a/apps/api/src/routes/terminalWs.ts
+++ b/apps/api/src/routes/terminalWs.ts
@@ -1309,6 +1309,7 @@ export function __createTerminalSharedLeasesForTest(): RemoteWsSharedLeaseManage
     releaseDesktopFinalizationIntent: async () => true,
     observeDesktopFinalization: async () => ({
       ownerPresent: false,
+      everOwned: false,
       finalizationId: null,
       canonicalPayload: null,
       consistent: true,

--- a/apps/api/src/routes/terminalWs_multitenant.test.ts
+++ b/apps/api/src/routes/terminalWs_multitenant.test.ts
@@ -399,6 +399,7 @@ describe('terminalWs — cross-replica lease ownership', () => {
         releaseDesktopFinalizationIntent: async () => true,
         observeDesktopFinalization: async () => ({
           ownerPresent: false,
+          everOwned: false,
           finalizationId: null,
           canonicalPayload: null,
           consistent: true,
@@ -496,6 +497,7 @@ describe('terminalWs — cross-replica lease ownership', () => {
       releaseDesktopFinalizationIntent: async () => true,
       observeDesktopFinalization: async () => ({
         ownerPresent: false,
+        everOwned: false,
         finalizationId: null,
         canonicalPayload: null,
         consistent: true,

--- a/apps/api/src/services/desktopSessionFinalization.test.ts
+++ b/apps/api/src/services/desktopSessionFinalization.test.ts
@@ -148,6 +148,7 @@ describe('finalizeDesktopSessionOnce', () => {
     });
     observeDesktopFinalizationMock.mockResolvedValue({
       ownerPresent: false,
+      everOwned: true,
       finalizationId: input.finalizationId,
       canonicalPayload: JSON.stringify(input),
       consistent: true,

--- a/apps/api/src/services/desktopSessionOrphanRecovery.test.ts
+++ b/apps/api/src/services/desktopSessionOrphanRecovery.test.ts
@@ -36,6 +36,10 @@ function dependencies(): DesktopOrphanRecoveryDependencies {
     loadSession: vi.fn(async () => session),
     observeSharedState: vi.fn(async () => ({
       ownerPresent: false,
+      // Default fixture models a session that once held the desktop WS owner
+      // lease and then lost it (the genuine orphan shape). Never-owned P2P
+      // sessions are covered explicitly below.
+      everOwned: true,
       finalizationId: null,
       canonicalPayload: null,
       consistent: true,
@@ -72,18 +76,21 @@ describe('desktop orphan recovery', () => {
     for (const observed of [
       {
         ownerPresent: true,
+        everOwned: true,
         finalizationId: null,
         canonicalPayload: null,
         consistent: true,
       },
       {
         ownerPresent: false,
+        everOwned: true,
         finalizationId: '55555555-5555-4555-8555-555555555555',
         canonicalPayload: null,
         consistent: false,
       },
       {
         ownerPresent: false,
+        everOwned: true,
         finalizationId: null,
         canonicalPayload: null,
         consistent: false,
@@ -98,6 +105,106 @@ describe('desktop orphan recovery', () => {
       await expect(service.recover(session.id, 'background')).resolves.toBe('retained');
       expect(deps.claimOrphanIntent).not.toHaveBeenCalled();
     }
+  });
+
+  it('never finalizes a desktop session that never bound a WebSocket owner (P2P viewer transport)', async () => {
+    // A WebRTC peer-to-peer desktop session only polls
+    // GET /desktop-ws/:id/viewer/session; it never opens the desktop
+    // WebSocket, so `remote:ws:{desktop:<id>}:owner` is never acquired and the
+    // `:generation` key is never INCR'd. To the sweeper that looks exactly
+    // like a lost owner lease, and every P2P session was finalized with
+    // error_message='orphan_recovery' ~30-60s after going active -- the same
+    // bug class as the terminal-session reaping in #2871.
+    const deps = dependencies();
+    vi.mocked(deps.observeSharedState).mockResolvedValue({
+      ownerPresent: false,
+      everOwned: false,
+      finalizationId: null,
+      canonicalPayload: null,
+      consistent: true,
+    });
+    const service = createDesktopSessionOrphanRecoveryService(deps);
+
+    // Two passes separated by more than a full lease TTL -- the exact cadence
+    // that claims and finalizes a genuine orphan.
+    await expect(service.recover(session.id, 'background')).resolves.toBe('not_orphaned');
+    deps.setNow!(31_000);
+    await expect(service.recover(session.id, 'background')).resolves.toBe('not_orphaned');
+    deps.setNow!(120_000);
+    await expect(service.recover(session.id, 'admission')).resolves.toBe('not_orphaned');
+
+    expect(deps.claimOrphanIntent).not.toHaveBeenCalled();
+    expect(deps.finalize).not.toHaveBeenCalled();
+    expect(deps.enqueue).not.toHaveBeenCalled();
+  });
+
+  it('still finalizes a session that once held the owner lease and lost it (positive control)', async () => {
+    const deps = dependencies();
+    vi.mocked(deps.observeSharedState).mockResolvedValue({
+      ownerPresent: false,
+      everOwned: true,
+      finalizationId: null,
+      canonicalPayload: null,
+      consistent: true,
+    });
+    const service = createDesktopSessionOrphanRecoveryService(deps);
+
+    await expect(service.recover(session.id, 'background')).resolves.toBe('retained');
+    deps.setNow!(31_000);
+    await expect(service.recover(session.id, 'background')).resolves.toBe('retained');
+
+    expect(deps.claimOrphanIntent).toHaveBeenCalledTimes(1);
+    expect(deps.claimOrphanIntent).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: session.id,
+      reason: 'orphan_recovery',
+      terminalStatus: 'failed',
+    }));
+    expect(deps.finalize).toHaveBeenCalledTimes(1);
+  });
+
+  it('still drives a persisted finalization intent on a never-owned session', async () => {
+    // The never-owned guard only applies to the "no intent at all" branch. A
+    // persisted intent on a session whose generation key is absent (e.g. the
+    // key was lost, or an operator-driven intent) must still be driven to
+    // completion exactly as before.
+    const deps = dependencies();
+    const persistedInput = {
+      version: 1 as const,
+      finalizationId: '66666666-6666-4666-8666-666666666666',
+      sessionId: session.id,
+      connection: {
+        connectionId: '77777777-7777-4777-8777-777777777777',
+        generation: 4,
+        instanceId: '88888888-8888-4888-8888-888888888888',
+        leaseToken: '99999999-9999-4999-8999-999999999999',
+      },
+      orgId: session.orgId,
+      userId: session.userId,
+      deviceId: session.deviceId,
+      reason: 'socket_error' as const,
+      terminalStatus: 'failed' as const,
+      endedAt: '2026-07-25T12:01:00.000Z',
+      startedAt: '2026-07-25T12:00:00.000Z',
+      inputEvents: 4,
+      frameBytes: 128,
+    };
+    vi.mocked(deps.observeSharedState).mockResolvedValue({
+      ownerPresent: false,
+      everOwned: false,
+      finalizationId: persistedInput.finalizationId,
+      canonicalPayload: JSON.stringify(persistedInput),
+      consistent: true,
+    });
+    const service = createDesktopSessionOrphanRecoveryService(deps);
+
+    await expect(service.recover(session.id, 'background')).resolves.toBe('retained');
+
+    expect(deps.claimOrphanIntent).not.toHaveBeenCalled();
+    expect(deps.finalize).toHaveBeenCalledWith(persistedInput);
+    expect(deps.enqueue).toHaveBeenCalledWith({
+      sessionId: session.id,
+      finalizationId: persistedInput.finalizationId,
+    });
   });
 
   it('finalizes and releases only after the exact durable stop is confirmed', async () => {
@@ -205,6 +312,7 @@ describe('desktop orphan recovery', () => {
     };
     vi.mocked(deps.observeSharedState).mockResolvedValue({
       ownerPresent: false,
+      everOwned: true,
       finalizationId: persistedInput.finalizationId,
       canonicalPayload: JSON.stringify(persistedInput),
       consistent: true,
@@ -257,6 +365,7 @@ describe('desktop orphan recovery', () => {
     };
     vi.mocked(deps.observeSharedState).mockResolvedValue({
       ownerPresent: false,
+      everOwned: true,
       finalizationId: persistedInput.finalizationId,
       canonicalPayload: JSON.stringify(persistedInput),
       consistent: true,
@@ -318,6 +427,7 @@ describe('desktop orphan recovery', () => {
     };
     vi.mocked(deps.observeSharedState).mockResolvedValue({
       ownerPresent: false,
+      everOwned: true,
       finalizationId: persistedInput.finalizationId,
       canonicalPayload: JSON.stringify(persistedInput),
       consistent: true,
@@ -360,6 +470,7 @@ describe('desktop orphan recovery', () => {
     };
     vi.mocked(deps.observeSharedState).mockResolvedValue({
       ownerPresent: false,
+      everOwned: true,
       finalizationId: persistedInput.finalizationId,
       canonicalPayload: JSON.stringify(persistedInput),
       consistent: true,
@@ -421,6 +532,7 @@ describe('desktop orphan recovery', () => {
     // First episode: escalate past the threshold.
     vi.mocked(deps.observeSharedState).mockResolvedValue({
       ownerPresent: false,
+      everOwned: true,
       finalizationId: resolvedFinalizationId,
       canonicalPayload: JSON.stringify(resolvedInput),
       consistent: true,
@@ -442,6 +554,7 @@ describe('desktop orphan recovery', () => {
     );
     vi.mocked(deps.observeSharedState).mockResolvedValue({
       ownerPresent: false,
+      everOwned: true,
       finalizationId: newFinalizationId,
       canonicalPayload: JSON.stringify(newInput),
       consistent: true,
@@ -454,6 +567,7 @@ describe('desktop orphan recovery', () => {
     const deps = dependencies();
     vi.mocked(deps.observeSharedState).mockResolvedValue({
       ownerPresent: false,
+      everOwned: true,
       finalizationId: '66666666-6666-4666-8666-666666666666',
       // Not valid JSON -- exercises the JSON.parse failure branch of the
       // bare `catch { return 'retained' }` this used to be (#3945). A

--- a/apps/api/src/services/desktopSessionOrphanRecovery.ts
+++ b/apps/api/src/services/desktopSessionOrphanRecovery.ts
@@ -100,6 +100,8 @@ export interface DesktopOrphanRecoveryDependencies {
   loadSession(sessionId: string): Promise<DesktopOrphanSession | null>;
   observeSharedState(sessionId: string): Promise<{
     ownerPresent: boolean;
+    /** See DesktopFinalizationSharedState.everOwned. */
+    everOwned: boolean;
     finalizationId: string | null;
     canonicalPayload: string | null;
     consistent: boolean;
@@ -294,6 +296,25 @@ export function createDesktopSessionOrphanRecoveryService(
         }
       }
 
+      // No owner and no persisted intent. Before treating the absent owner as
+      // a LOST lease, check that the session ever held one. The only code
+      // that acquires the desktop owner lease is the desktop WebSocket
+      // upgrade (routes/desktopWs.ts), and the viewer's default WebRTC
+      // peer-to-peer transport never opens that WebSocket -- it only polls
+      // GET /desktop-ws/:id/viewer/session -- so a healthy P2P session looks
+      // permanently "absent" here and, unguarded, was finalized with
+      // error_message='orphan_recovery' one lease TTL after the agent's
+      // WebRTC answer flipped the row to `active`. Same bug class as the
+      // terminal-session reaping in #2871. P2P sessions are not governed by
+      // this sweeper at all: they end via the agent's peer-disconnect notice,
+      // the revocation lease (#5481), and the 12h session cap. Sessions that
+      // DID carry a persisted finalization intent are handled above and keep
+      // driving that intent regardless of ownership history.
+      if (!observed.everOwned) {
+        firstAbsentObservation.delete(sessionId);
+        return 'not_orphaned';
+      }
+
       const first = firstAbsentObservation.get(sessionId);
       if (first === undefined) {
         firstAbsentObservation.set(sessionId, deps.now());
@@ -383,6 +404,7 @@ function getProductionService() {
       const observed = await manager.observeDesktopFinalization(sessionId);
       return {
         ownerPresent: observed.ownerPresent,
+        everOwned: observed.everOwned,
         finalizationId: observed.finalizationId,
         canonicalPayload: observed.canonicalPayload,
         consistent: observed.consistent,

--- a/apps/api/src/services/remoteWsSharedLease.test.ts
+++ b/apps/api/src/services/remoteWsSharedLease.test.ts
@@ -113,7 +113,7 @@ class FakeRedis {
     }
 
     if (script === REMOTE_WS_SHARED_LEASE_SCRIPTS.observeDesktopFinalization) {
-      const [ownerKey, fenceKey, payloadKey] = keys;
+      const [ownerKey, fenceKey, payloadKey, generationKey] = keys;
       const owner = this.current(ownerKey!);
       const fence = this.current(fenceKey!);
       const payload = this.current(payloadKey!);
@@ -122,6 +122,7 @@ class FakeRedis {
         fence ?? '',
         payload ?? '',
         (fence === null) === (payload === null) ? '1' : '0',
+        this.current(generationKey!) === null ? '0' : '1',
       ];
     }
 
@@ -322,6 +323,7 @@ describe('remote websocket shared lease', () => {
     if (!acquired.ok) return;
     expect(await leases.observeDesktopFinalization('observed')).toEqual({
       ownerPresent: true,
+      everOwned: true,
       finalizationId: null,
       canonicalPayload: null,
       consistent: true,
@@ -334,6 +336,7 @@ describe('remote websocket shared lease', () => {
     );
     expect(await leases.observeDesktopFinalization('observed')).toEqual({
       ownerPresent: true,
+      everOwned: true,
       finalizationId: 'finalization-observed',
       canonicalPayload: payload,
       consistent: true,
@@ -343,7 +346,46 @@ describe('remote websocket shared lease', () => {
     redis.values.set(keys.finalizing!, { value: 'only-fence', expiresAt: null });
     expect(await leases.observeDesktopFinalization('incomplete')).toMatchObject({
       ownerPresent: false,
+      everOwned: false,
       consistent: false,
+    });
+  });
+
+  it('reports everOwned from the durable generation key, not the expiring owner key', async () => {
+    const redis = new FakeRedis();
+    const leases = manager(redis, '11111111-1111-4111-8111-111111111111');
+
+    // A session that never acquired the desktop lease (WebRTC P2P viewer
+    // transport) has neither key: not owned now, never owned.
+    expect(await leases.observeDesktopFinalization('never-owned')).toEqual({
+      ownerPresent: false,
+      everOwned: false,
+      finalizationId: null,
+      canonicalPayload: null,
+      consistent: true,
+    });
+
+    // Once acquired, the generation key persists with no TTL: after the owner
+    // lease expires the session reads as "not owned now, but was owned".
+    const acquired = await leases.acquire('desktop', 'lost-owner');
+    expect(acquired.ok).toBe(true);
+    redis.now += REMOTE_WS_SHARED_LEASE_TTL_MS + 1;
+    expect(await leases.observeDesktopFinalization('lost-owner')).toEqual({
+      ownerPresent: false,
+      everOwned: true,
+      finalizationId: null,
+      canonicalPayload: null,
+      consistent: true,
+    });
+
+    // An explicit release also leaves the generation key behind.
+    const released = await leases.acquire('desktop', 'released-owner');
+    expect(released.ok).toBe(true);
+    if (!released.ok) return;
+    expect(await leases.release(released.claim)).toBe(true);
+    expect(await leases.observeDesktopFinalization('released-owner')).toMatchObject({
+      ownerPresent: false,
+      everOwned: true,
     });
   });
 

--- a/apps/api/src/services/remoteWsSharedLease.ts
+++ b/apps/api/src/services/remoteWsSharedLease.ts
@@ -54,6 +54,15 @@ export interface RemoteWsRedisKeys {
 
 export interface DesktopFinalizationSharedState {
   ownerPresent: boolean;
+  /**
+   * Whether this session has EVER bound a desktop WebSocket owner lease.
+   * Derived from the `:generation` key, which `acquire` INCRs with no TTL and
+   * nothing ever deletes, so it outlives the owner key itself. A session that
+   * was never owned (the WebRTC peer-to-peer viewer transport never opens the
+   * desktop WebSocket) has no lease to lose and is therefore not a
+   * WebSocket-finalization orphan when `ownerPresent` is false.
+   */
+  everOwned: boolean;
   finalizationId: string | null;
   canonicalPayload: string | null;
   consistent: boolean;
@@ -140,11 +149,13 @@ export const REMOTE_WS_SHARED_LEASE_SCRIPTS = {
     local owner = redis.call('GET', KEYS[1])
     local fence = redis.call('GET', KEYS[2])
     local payload = redis.call('GET', KEYS[3])
+    local generation = redis.call('EXISTS', KEYS[4])
     return {
       owner and '1' or '0',
       fence or '',
       payload or '',
-      ((fence and payload) or (not fence and not payload)) and '1' or '0'
+      ((fence and payload) or (not fence and not payload)) and '1' or '0',
+      generation == 1 and '1' or '0'
     }
   `,
 } as const;
@@ -445,19 +456,21 @@ export function createRemoteWsSharedLeaseManager(input: {
       const requestStart = monotonicNow();
       const reply = await evalTimed(
         REMOTE_WS_SHARED_LEASE_SCRIPTS.observeDesktopFinalization,
-        [keys.owner, keys.finalizing!, keys.finalizationPayload!],
+        [keys.owner, keys.finalizing!, keys.finalizationPayload!, keys.generation],
         [],
         requestStart,
       );
       if (
-        reply.length !== 4
+        reply.length !== 5
         || (reply[0] !== '0' && reply[0] !== '1')
         || (reply[3] !== '0' && reply[3] !== '1')
+        || (reply[4] !== '0' && reply[4] !== '1')
       ) {
         throw new Error('remote websocket desktop intent reply was malformed');
       }
       return {
         ownerPresent: reply[0] === '1',
+        everOwned: reply[4] === '1',
         finalizationId: reply[1] === '' ? null : (reply[1] ?? null),
         canonicalPayload: reply[2] === '' ? null : (reply[2] ?? null),
         consistent: reply[3] === '1',


### PR DESCRIPTION
## Symptom

Remote desktop drops every 30–90 s and has to be restarted (reported on MCIA-XK823463BF, US, 2026-09-11). Every affected `remote_sessions` row ends `status='failed'`, `error_message='orphan_recovery'`, `ended_at` on the sweeper's 30 s tick. No desktop session in either production region has lasted 5 minutes since the week of 2026-08-03 (max 181 s). Not caused by #5481 — sessions on 0.111.x died the same way.

## Root cause

`desktopSessionOrphanRecovery.ts` infers "Redis owner key `remote:ws:{desktop:<id>}:owner` absent for one 30 s TTL ⇒ the WebSocket owner died mid-finalization ⇒ orphan" and finalizes the session. The only code that acquires that owner lease is the desktop WebSocket upgrade in `routes/desktopWs.ts`. The viewer's default WebRTC peer-to-peer transport never opens that WebSocket (it only polls `GET /desktop-ws/:id/viewer/session`), so a healthy P2P session is permanently "absent" and is finalized one lease TTL after the agent's answer flips it to `active`. US Redis holds 2 desktop `:generation` keys ever (both from the WS-relay fallback) versus 200+ terminal ones. Same bug class as #2871, where the sweeper killed terminal sessions at 60 s.

## Fix

- `observeDesktopFinalization` (Lua) also returns whether the `:generation` key exists. `acquire` INCRs it with no TTL and nothing deletes it, so it is a durable "this session once bound a WebSocket owner" marker. Reply validation widened to 5 elements, strict.
- `recover()` returns `not_orphaned` for a never-owned session that carries no persisted finalization intent. Sessions with a persisted intent (including rows the pre-fix sweeper already claimed) are still driven to completion. The `admission` trigger in `remoteWsUpgrade.ts` funnels through the same function, which also removes a spurious `409 orphan_recovery` when a P2P session fell back to the WS relay after 90 s.
- P2P sessions are governed by the agent peer-disconnect notice, the revocation lease (#5481) and the 12 h cap — unchanged.

## Tests

- Red first: never-owned `active` session, owner absent, two scans one TTL apart → asserted `not_orphaned` and no `claimOrphanIntent`/`finalize`. Failed on unfixed code (`expected 'retained' to be 'not_orphaned'`), passes now.
- Positive control: same scenario with `everOwned: true` still finalizes with `reason: 'orphan_recovery'`.
- Never-owned session with a persisted intent still drives the intent.
- Shared-lease fake-Redis test: `everOwned` false before any acquire, true after acquire, and stays true through lease expiry and explicit release.
- Scoped run (orphan recovery, shared lease, finalization, desktopWs*, terminalWs*, remoteWsUpgrade): 18 files, 256 tests green. `tsc --noEmit` clean. eslint clean on changed files.

## Review

pr-review-toolkit code-reviewer: 0 confirmed defects. Noted follow-ups (not in this PR): `active` desktop rows have no age backstop other than the 12 h cap if the generation key were ever lost (Redis is `noeviction` + AOF, so no realistic path); `:generation` keys are now load-bearing and cannot be given a TTL later; the admin `inspectDesktopFinalization` diagnostic still labels healthy P2P sessions `orphan_candidate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QxhWw4gpFuiE1SZnnU93AF
