### PR TITLE
fix(bmr): re-authenticate slides the recovery download session window (#5493)

### DIFF
--- a/apps/api/src/routes/backup/bmr.test.ts
+++ b/apps/api/src/routes/backup/bmr.test.ts
@@ -810,6 +810,76 @@ describe('bmr routes', () => {
     expect(updateSetArgs).toContainEqual(expect.objectContaining({ status: 'authenticated' }));
   });
 
+  it('re-authenticating an already-authenticated token slides the download session window', async () => {
+    // KIT W04b proof (2026-09-12): a 105k-file rebuild ran past
+    // RECOVERY_DOWNLOAD_SESSION_TTL (1 h from authenticated_at). Downloads
+    // then 401'd with "Re-authenticate to continue", the console
+    // re-authenticated (200), but authenticated_at was left at its original
+    // value, so the window never moved and every later download still 401'd.
+    const staleAuthenticatedAt = new Date(Date.now() - 2 * 60 * 60 * 1000);
+    selectMock
+      .mockReturnValueOnce(chainMock([{
+        id: TOKEN_ID,
+        orgId: ORG_ID,
+        deviceId: DEVICE_ID,
+        snapshotId: SNAPSHOT_ID,
+        restoreType: 'bare_metal',
+        targetConfig: null,
+        status: 'authenticated',
+        createdAt: new Date(Date.now() - 3 * 60 * 60 * 1000),
+        expiresAt: new Date(Date.now() + 21 * 60 * 60 * 1000),
+        authenticatedAt: staleAuthenticatedAt,
+        completedAt: null,
+        usedAt: staleAuthenticatedAt,
+      }]))
+      .mockReturnValueOnce(chainMock([{
+        id: SNAPSHOT_ID,
+        orgId: ORG_ID,
+        deviceId: DEVICE_ID,
+        jobId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+        configId: null,
+        snapshotId: 'snap-ext-001',
+        label: 'Backup 2026-03-29',
+        location: 's3://breeze-backups/org-001/dev-001/2026-03-29',
+        timestamp: new Date('2026-03-29T12:34:56.000Z'),
+        size: 1234,
+        fileCount: 12,
+        metadata: { providerType: 's3', storagePrefix: 's3://breeze-backups/org-001/dev-001/2026-03-29' },
+        backupType: 'system_image',
+        isIncremental: false,
+        hardwareProfile: null,
+        systemStateManifest: null,
+      }]))
+      .mockReturnValueOnce(chainMock([]))
+      .mockReturnValueOnce(chainMock([{
+        id: DEVICE_ID,
+        hostname: 'srv-01',
+        osType: 'linux',
+      }]));
+
+    updateMock.mockReturnValueOnce(chainMock([]));
+
+    const before = Date.now();
+    const res = await app.request('/backup/bmr/recover/authenticate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token: VALID_RECOVERY_TOKEN }),
+    });
+    expect(res.status).toBe(200);
+
+    const updateSetArgs = updateMock.mock.results
+      .map((entry) => entry.value?.set?.mock?.calls?.[0]?.[0])
+      .filter(Boolean) as Array<{ authenticatedAt?: Date }>;
+    const slid = updateSetArgs.find((args) => args.authenticatedAt instanceof Date);
+    expect(slid, 'authenticated_at must be rewritten on re-authentication').toBeDefined();
+    expect(slid!.authenticatedAt!.getTime()).toBeGreaterThanOrEqual(before - 1000);
+
+    const body = await res.json() as { authenticatedAt: string; bootstrap: { download: { expiresAt: string } } };
+    expect(new Date(body.authenticatedAt).getTime()).toBeGreaterThanOrEqual(before - 1000);
+    // The returned download window must be a fresh hour, not the stale one.
+    expect(new Date(body.bootstrap.download.expiresAt).getTime()).toBeGreaterThan(before + 50 * 60 * 1000);
+  });
+
   it('rate limits public authenticate requests', async () => {
     rateLimiterMock.mockResolvedValueOnce({
       allowed: false,

--- a/apps/api/src/routes/backup/bmr.ts
+++ b/apps/api/src/routes/backup/bmr.ts
@@ -1110,20 +1110,29 @@ bmrPublicRoutes.post(
         .where(eq(devices.id, row.deviceId))
         .limit(1);
 
-      const authenticatedAt = row.authenticatedAt ?? row.usedAt ?? new Date();
+      // Every successful authenticate call (re)starts the download session
+      // window: the recovery download route only serves objects until
+      // authenticated_at + RECOVERY_DOWNLOAD_SESSION_TTL and tells the client
+      // to "Re-authenticate to continue" past that. Before this, a re-auth
+      // kept the ORIGINAL authenticated_at, so the window never moved; a
+      // 105k-file bare-metal rebuild on real hardware (W04b KIT proof,
+      // 2026-09-12) ran past the hour, every download 401'd, the console's
+      // per-file re-authenticate calls then burned BMR_AUTHENTICATE_TOKEN_LIMIT
+      // and the run was dead. Sliding is bounded by the token's own
+      // expires_at (24 h for exchange-minted tokens) and by the per-token
+      // authenticate rate limit above.
+      const authenticatedAt = new Date();
       const nextStatus = row.status === 'active' || (row.status === 'used' && !row.completedAt)
         ? 'authenticated'
         : row.status;
 
-      if (row.status !== nextStatus || !row.authenticatedAt) {
-        await db
-          .update(recoveryTokens)
-          .set({
-            status: nextStatus,
-            authenticatedAt,
-          })
-          .where(eq(recoveryTokens.id, row.id));
-      }
+      await db
+        .update(recoveryTokens)
+        .set({
+          status: nextStatus,
+          authenticatedAt,
+        })
+        .where(eq(recoveryTokens.id, row.id));
 
       const clientIp = getTrustedClientIp(c, 'unknown');
       const redis = getRedis();


### PR DESCRIPTION
## Summary

Found on the W04b KIT Hyper-V proof (#5493, 2026-09-12). A 105k-file bare-metal rebuild downloaded 47,255 objects, then at exactly `authenticated_at + 1h` every `/bmr/recover/download` returned 401 (`Recovery session has expired. Re-authenticate to continue.`). The console re-authenticated and got 200 three times, but `POST /bmr/recover/authenticate` kept the **original** `authenticated_at` for an already-authenticated token, so the window never moved. The per-file re-auth attempts then exhausted `BMR_AUTHENTICATE_TOKEN_LIMIT` (3/h) and the run was dead.

## Fix

A successful authenticate always rewrites `authenticated_at` (and therefore the returned download descriptor's `expiresAt`). The slide is bounded by the token's own `expires_at` (24 h for exchange-minted tokens) and by the existing per-token authenticate rate limit, so a leaked token gains at most token lifetime, not indefinite access.

## Tests

- Red-first `bmr.test.ts`: "re-authenticating an already-authenticated token slides the download session window".
- `bmr.test.ts` + `bmrRecoveries.test.ts`: 41/41.

## Follow-ups (agent side, separate)

- The console re-authenticates once per failed file with no cap or backoff; it should refresh proactively before `download.expiresAt` and back off on 429. Tracked with the rest of the W04b lab findings (#5629, #5623).

🤖 Generated with [Claude Code](https://claude.com/claude-code)