### PR TITLE
fix(recovery-console): run stty against the console so the reboot countdown actually times out (#5493)

### DIFF
--- a/agent/internal/recoveryconsole/prompts.go
+++ b/agent/internal/recoveryconsole/prompts.go
@@ -68,19 +68,28 @@ func (t *termIO) ReadKeyWithTimeout(d time.Duration) (rune, bool) {
 
 // readOneKey reads at most one byte within d using stty's non-canonical
 // timed read mode. Returns ok=false on timeout or any error.
+// sttyCommand builds an stty invocation that acts on the console this
+// process is reading from. stty configures the terminal on ITS stdin, so
+// Stdin must be os.Stdin; with Stdin left nil (the original W04b code) it
+// configured /dev/null, the console stayed in canonical mode, and
+// readOneKey's os.Stdin.Read blocked until a newline — the "Rebooting in
+// 10 s" countdown on the KIT proof never fired (2026-09-12).
+func sttyCommand(args ...string) *exec.Cmd {
+	cmd := exec.Command("stty", args...)
+	cmd.Stdin = os.Stdin
+	return cmd
+}
+
 func readOneKey(d time.Duration) (rune, bool) {
 	deciseconds := int(d / (100 * time.Millisecond))
 	if deciseconds < 1 {
 		deciseconds = 1
 	}
-	cmd := exec.Command("stty", "-echo", "-icanon", "min", "0", "time", fmt.Sprintf("%d", deciseconds))
-	cmd.Stdin = nil
-	_ = cmd.Run() // best-effort; a failure here just means we won't detect a keypress
+	_ = sttyCommand("-echo", "-icanon", "min", "0", "time", fmt.Sprintf("%d", deciseconds)).Run() // best-effort; a failure here just means we won't detect a keypress
 
 	buf := make([]byte, 1)
 	n, err := os.Stdin.Read(buf)
-	restoreCmd := exec.Command("stty", "sane")
-	_ = restoreCmd.Run()
+	_ = sttyCommand("sane").Run()
 	if err != nil || n == 0 {
 		return 0, false
 	}

--- a/agent/internal/recoveryconsole/prompts_test.go
+++ b/agent/internal/recoveryconsole/prompts_test.go
@@ -1,0 +1,29 @@
+package recoveryconsole
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// KIT W04b proof (2026-09-12): after "Restored. Rebooting in 10 s (press any
+// key to stay)." the console sat there for good. readOneKey drove the
+// countdown with `stty -icanon min 0 time N` but ran stty with Stdin=nil, so
+// stty configured /dev/null instead of the console; the tty stayed canonical
+// and os.Stdin.Read blocked until a newline that never came. CI never sees
+// this path (breeze.ci=1 skips the countdown). Every stty invocation must
+// target the console, i.e. the process's own stdin.
+func TestSttyCommandTargetsConsoleStdin(t *testing.T) {
+	for _, args := range [][]string{
+		{"-echo", "-icanon", "min", "0", "time", "10"},
+		{"sane"},
+	} {
+		cmd := sttyCommand(args...)
+		if cmd.Stdin != os.Stdin {
+			t.Fatalf("stty %s: Stdin = %v, want os.Stdin (otherwise stty acts on /dev/null and the countdown never times out)", strings.Join(args, " "), cmd.Stdin)
+		}
+		if got := strings.Join(cmd.Args[1:], " "); got != strings.Join(args, " ") {
+			t.Fatalf("stty args = %q, want %q", got, strings.Join(args, " "))
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fourth finding from the W04b KIT Hyper-V proof (#5493, 2026-09-12). The rebuild completed (all seven phases, 104,914/104,914 files) and the console printed `Restored. Rebooting in 10 s (press any key to stay).`, then never rebooted: ten minutes later the VM was still on the live media at that line.

`readOneKey` puts the tty into non-canonical mode with `stty -icanon min 0 time N`, but ran `stty` with `Stdin = nil`. `stty` configures the terminal on **its** stdin, so it configured `/dev/null`; the console stayed canonical and `os.Stdin.Read` blocked until a newline that never came. The `breeze.ci=1` path skips the countdown, so the QEMU e2e cannot see this.

## Fix

All `stty` calls go through `sttyCommand`, which sets `Stdin = os.Stdin`. Red-first `TestSttyCommandTargetsConsoleStdin` asserts both invocations target the console stdin.

## Verification

`go test -race ./internal/recoveryconsole/` green; `golangci-lint --new-from-rev=origin/main` clean. On the lab the restored VM was booted by hand from the rebuilt disk and came up `running`, 0 failed units, UUIDs preserved (evidence in the campaign ledger row in the docs PR).

Sibling findings from the same proof: #5629, #5632 (merged), #5634 (merged), #5635.

🤖 Generated with [Claude Code](https://claude.com/claude-code)