### PR TITLE
fix(ai): stamp the real approval method on proposal runs and promoted versions (#5645)

### DIFF
--- a/apps/api/src/__tests__/integration/scriptProposalHumanLoop.integration.test.ts
+++ b/apps/api/src/__tests__/integration/scriptProposalHumanLoop.integration.test.ts
@@ -272,6 +272,9 @@ describe('script-verify worker + promote (real rows)', () => {
         orgId: s.orgId, deviceId: s.deviceId, sourceKind: 'proposal', proposalId, scriptId: null,
         status: 'completed', exitCode: 0, stdout: 'ok', triggerType: 'manual',
         language: 'powershell', timeoutSeconds: 60, runAs: 'system', contentDigest: 'a'.repeat(64),
+        // #5645: the run's method, as the release stamps it — a lane run here,
+        // so promotion below must NOT read as four_eyes.
+        approvedBy: s.requester.id, approvalMethod: 'unattended_reviewer_gated',
         startedAt: new Date(), completedAt: new Date(),
       } as never).returning({ id: scriptExecutions.id });
     });
@@ -308,7 +311,8 @@ describe('script-verify worker + promote (real rows)', () => {
       expect(version!.proposalId).toBe(proposalId);
       expect(version!.reviewId).not.toBeNull();
       expect(version!.approvedBy).toBe(s.requester.id);
-      expect(version!.approvalMethod).toBe('four_eyes');
+      // #5645: the promoted version carries the RUN's method, not a constant.
+      expect(version!.approvalMethod).toBe('unattended_reviewer_gated');
     });
     proposal = await readProposal(proposalId);
     expect(proposal.status).toBe('promoted');

--- a/apps/api/src/__tests__/integration/scriptProposalsLifecycle.integration.test.ts
+++ b/apps/api/src/__tests__/integration/scriptProposalsLifecycle.integration.test.ts
@@ -2,16 +2,32 @@ import './setup';
 
 import { randomUUID } from 'node:crypto';
 import { eq } from 'drizzle-orm';
-import { afterEach, beforeEach, expect, it } from 'vitest';
-import { db, withSystemDbAccessContext } from '../../db';
-import { scriptProposalReviews, scriptProposals } from '../../db/schema';
-import { createOrganization, createPartner, createUser } from './db-utils';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import { db, withDbAccessContext, withSystemDbAccessContext } from '../../db';
+import { devices, scriptExecutions, scriptProposalReviews, scriptProposals } from '../../db/schema';
+import { createOrganization, createPartner, createSite, createUser } from './db-utils';
 import { cascadeDeleteOrg } from '../../services/tenantCascade';
 import { executeOrgMerge } from '../../services/orgMerge';
+import { buildOrgAccessClosures, type AuthContext } from '../../middleware/auth';
+import { __testOnly as aiToolsScriptsTestOnly } from '../../services/aiToolsScripts';
+
+// The proposal branch of run_script waits up to 60 s for the agent's result;
+// no agent is attached here, so the wait is short-circuited. `queueCommand` and
+// the rest of the module stay real — the execution row under test is written
+// by the REAL dispatch path.
+vi.mock('../../services/commandQueue', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../services/commandQueue')>()),
+  waitForCommandResult: async (id: string) => ({ id, result: { status: 'completed', exitCode: 0 } }),
+}));
+vi.mock('../../config/env', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../config/env')>()),
+  aiScriptAuthoringEnabled: () => true,
+}));
 
 /**
  * AI script authoring W01b — org erasure and org-merge fence coverage for
- * `script_proposals` / `script_proposal_reviews` (spec §5).
+ * `script_proposals` / `script_proposal_reviews` (spec §5), plus (#5645) the
+ * §4.1 provenance snapshot written by a real release.
  */
 const runDb = it.runIf(!!process.env.DATABASE_URL);
 
@@ -93,4 +109,60 @@ runDb('an org merge expires live proposals in the loser and leaves terminal ones
     db.select().from(scriptProposalReviews).where(eq(scriptProposalReviews.proposalId, liveId)));
   expect(reviews).toHaveLength(1);
   expect(reviews[0]!.orgId).toBe(loser.id);
+});
+
+// #5645 — `script_executions.approval_method` is the §4.1 provenance snapshot
+// the W06 risk dashboard ("unattended runs") and the device-activity audit row
+// derive from. It must be DERIVED from the releasing intent's decision record
+// (§4.6), and this is the only place the derived value is proven to reach a
+// real row through the real dispatch path (`buildExecutionValues` is mocked
+// everywhere else).
+runDb('a reviewer-decided (unattended) release stamps unattended_reviewer_gated on the execution row', async () => {
+  const partner = await withSystemDbAccessContext(() => createPartner());
+  const org = await withSystemDbAccessContext(() => createOrganization({ partnerId: partner.id }));
+  const user = await withSystemDbAccessContext(() => createUser({
+    partnerId: partner.id, orgId: org.id, email: `sp-method-${randomUUID().slice(0, 8)}@example.test`,
+  }));
+  const site = await withSystemDbAccessContext(() => createSite({ orgId: org.id }));
+  // Online, but its agent has no live socket: the command stays pending
+  // rather than being sent, and the mocked wait above returns at once.
+  const [device] = await withSystemDbAccessContext(() => db.insert(devices).values({
+    orgId: org.id, siteId: site.id, agentId: `sp-method-agent-${randomUUID()}`, hostname: `sp-method-${randomUUID().slice(0, 6)}`,
+    osType: 'windows', osVersion: '11', architecture: 'x86_64', agentVersion: '0.0.0-test', status: 'online',
+  }).returning({ id: devices.id }));
+  const intentId = randomUUID();
+  const [proposal] = await withSystemDbAccessContext(() => db.insert(scriptProposals).values({
+    orgId: org.id, authorKind: 'chat_session', language: 'powershell', content: 'Get-Date',
+    contentDigest: 'b'.repeat(64), timeoutSeconds: 60, runAs: 'system', goal: 'g', expectedEffect: 'e',
+    verification: { kind: 'exit_code', equals: 0 }, targetDeviceIds: [device!.id],
+    scannerVersion: '2026-09-11.1', status: 'reviewed', riskTier: 'low', intentId,
+    expiresAt: new Date(Date.now() + 3600_000),
+  }).returning());
+
+  const { orgCondition, canAccessOrg } = buildOrgAccessClosures([org.id]);
+  const auth = {
+    principal: { kind: 'user_session' },
+    user: { id: user.id, email: user.email, name: 'U', isPlatformAdmin: false },
+    partnerId: partner.id, orgId: org.id, scope: 'organization', accessibleOrgIds: [org.id], orgCondition, canAccessOrg,
+  } as AuthContext;
+
+  // Exactly the context bag both release paths build for a lane intent
+  // (jobs/intentReleaseWorker.ts, services/aiAgentSdk.ts): the id it is
+  // releasing plus that intent's decision record.
+  const out = JSON.parse(await withDbAccessContext(
+    { scope: 'organization', orgId: org.id, accessibleOrgIds: [org.id], accessiblePartnerIds: [], userId: user.id },
+    () => aiToolsScriptsTestOnly.runScriptHandler(
+      { proposalId: proposal!.id, deviceIds: [device!.id] },
+      auth,
+      { actionIntentId: intentId, releaseDecision: { approvalScope: 'supervised', decidedVia: 'script_reviewer' } },
+    ),
+  ));
+  expect(out.results[device!.id].error, JSON.stringify(out)).toBeUndefined();
+
+  const rows = await withSystemDbAccessContext(() =>
+    db.select().from(scriptExecutions).where(eq(scriptExecutions.proposalId, proposal!.id)));
+  expect(rows).toHaveLength(1);
+  expect(rows[0]!.sourceKind).toBe('proposal');
+  expect(rows[0]!.approvedBy).toBe(user.id);
+  expect(rows[0]!.approvalMethod).toBe('unattended_reviewer_gated');
 });

--- a/apps/api/src/jobs/intentReleaseWorker.test.ts
+++ b/apps/api/src/jobs/intentReleaseWorker.test.ts
@@ -527,6 +527,7 @@ function baseIntent(overrides: Partial<ActionIntent> = {}): ActionIntent {
     decidedByUserId: 'approver-1',
     decidedAssuranceLevel: 1,
     decidedVia: 'session_tap',
+    approvalScope: 'four_eyes',
     executedAt: null,
     result: null,
     errorCode: null,
@@ -734,7 +735,7 @@ describe('releaseApprovedIntent', () => {
         // P2-5 (#4192): the durable worker ALWAYS names the intent it is
         // releasing. A handler that may only run as an approved release
         // (manage_ai_agents:authorize_supervised_key) reads it from here.
-        { context: { actionIntentId: intent.id } },
+        { context: { actionIntentId: intent.id, releaseDecision: { approvalScope: intent.approvalScope, decidedVia: intent.decidedVia } } },
       );
       expect(intentServiceMock.transitionIntent).toHaveBeenLastCalledWith(
         intent.id, 'executing', 'completed', expect.anything(),
@@ -818,7 +819,7 @@ describe('releaseApprovedIntent', () => {
         // P2-5 (#4192): the durable worker ALWAYS names the intent it is
         // releasing. A handler that may only run as an approved release
         // (manage_ai_agents:authorize_supervised_key) reads it from here.
-        { context: { actionIntentId: intent.id } },
+        { context: { actionIntentId: intent.id, releaseDecision: { approvalScope: intent.approvalScope, decidedVia: intent.decidedVia } } },
       );
     expect(intentServiceMock.transitionIntent).toHaveBeenLastCalledWith(
       intent.id,
@@ -1251,7 +1252,7 @@ describe('releaseApprovedIntent', () => {
         // P2-5 (#4192): the durable worker ALWAYS names the intent it is
         // releasing. A handler that may only run as an approved release
         // (manage_ai_agents:authorize_supervised_key) reads it from here.
-        { context: { actionIntentId: intent.id } },
+        { context: { actionIntentId: intent.id, releaseDecision: { approvalScope: intent.approvalScope, decidedVia: intent.decidedVia } } },
       );
       expect(intentServiceMock.transitionIntent).toHaveBeenLastCalledWith(
         intent.id, 'executing', 'completed', expect.anything(),
@@ -1284,7 +1285,7 @@ describe('releaseApprovedIntent', () => {
         // P2-5 (#4192): the durable worker ALWAYS names the intent it is
         // releasing. A handler that may only run as an approved release
         // (manage_ai_agents:authorize_supervised_key) reads it from here.
-        { context: { actionIntentId: intent.id } },
+        { context: { actionIntentId: intent.id, releaseDecision: { approvalScope: intent.approvalScope, decidedVia: intent.decidedVia } } },
       );
       expect(intentServiceMock.transitionIntent).toHaveBeenLastCalledWith(
         intent.id, 'executing', 'completed', expect.anything(),
@@ -1354,7 +1355,7 @@ describe('releaseApprovedIntent', () => {
         // P2-5 (#4192): the durable worker ALWAYS names the intent it is
         // releasing. A handler that may only run as an approved release
         // (manage_ai_agents:authorize_supervised_key) reads it from here.
-        { context: { actionIntentId: intent.id } },
+        { context: { actionIntentId: intent.id, releaseDecision: { approvalScope: intent.approvalScope, decidedVia: intent.decidedVia } } },
       );
       expect(intentServiceMock.transitionIntent).toHaveBeenLastCalledWith(
         intent.id,
@@ -1802,7 +1803,7 @@ describe('releaseApprovedIntent', () => {
         'manage_alerts',
         expect.objectContaining({ action: 'suppress', alertId: 'alert-1' }),
         agentAuth,
-        { context: { actionIntentId: intent.id } },
+        { context: { actionIntentId: intent.id, releaseDecision: { approvalScope: intent.approvalScope, decidedVia: intent.decidedVia } } },
       );
       expect(intentServiceMock.transitionIntent).toHaveBeenLastCalledWith(
         intent.id, 'executing', 'completed', expect.anything(),
@@ -4067,6 +4068,12 @@ describe('script lane checkpoint precondition (#5612 W04)', () => {
 
     expect(laneCheckpointMock.ensureLaneCheckpointBeforeRelease).toHaveBeenCalledWith(intent);
     expect(aiToolsMock.executeTool).toHaveBeenCalledTimes(1);
+    // #5645: the release hands the handler the intent's DECISION RECORD so the
+    // execution row's approval_method can be derived from it (§4.1 / §4.6) —
+    // a reviewer-decided lane intent must read as unattended_reviewer_gated.
+    const laneCall = aiToolsMock.executeTool.mock.calls[0]! as unknown as unknown[];
+    expect((laneCall[3] as { context: ToolExecutionContext }).context.releaseDecision)
+      .toEqual({ approvalScope: intent.approvalScope, decidedVia: 'script_reviewer' });
     const checkpointOrder = laneCheckpointMock.ensureLaneCheckpointBeforeRelease.mock.invocationCallOrder[0]!;
     const executeOrder = aiToolsMock.executeTool.mock.invocationCallOrder[0]!;
     expect(checkpointOrder).toBeLessThan(executeOrder);

--- a/apps/api/src/jobs/intentReleaseWorker.ts
+++ b/apps/api/src/jobs/intentReleaseWorker.ts
@@ -1143,9 +1143,20 @@ export async function releaseApprovedIntent(intentId: string): Promise<void> {
           // receive the execution context"). The no-verified-material case in
           // this file's suite asserts the bag's EXACT shape, so a future field
           // cannot ride along unnoticed.
+          //
+          // `releaseDecision` (#5645) rides with it on the same terms: it is
+          // the intent's own decision record (approval scope + decided_via),
+          // which `run_script`'s proposal branch turns into the execution
+          // row's spec §4.1 `approval_method` — so a reviewer-decided lane
+          // run reads as `unattended_reviewer_gated` instead of the
+          // constant it used to be stamped with.
           () =>
             executeTool(intent.actionName, intent.arguments, auth, {
-              context: { ...verifiedContext, actionIntentId: intent.id },
+              context: {
+                ...verifiedContext,
+                actionIntentId: intent.id,
+                releaseDecision: { approvalScope: intent.approvalScope, decidedVia: intent.decidedVia ?? null },
+              },
             });
       rawResult = await withToolTimeout(
         withAuthDbAccessContext(auth, invoke),

--- a/apps/api/src/services/aiAgentSdk.planMatch.test.ts
+++ b/apps/api/src/services/aiAgentSdk.planMatch.test.ts
@@ -224,7 +224,7 @@ describe('createSessionPreToolUse — approved plan step argument matching', () 
     const selectChain: Record<string, unknown> = {
       from: vi.fn(() => selectChain),
       where: vi.fn(() => selectChain),
-      limit: vi.fn(async () => [{ id: 'intent', boundArgumentDigest: 'digest' }]),
+      limit: vi.fn(async () => [{ id: 'intent', boundArgumentDigest: 'digest', approvalScope: 'four_eyes', decidedVia: 'session_tap' }]),
     };
     vi.mocked(db.select).mockReturnValue(selectChain as any);
   });
@@ -299,7 +299,11 @@ describe('createSessionPreToolUse — approved plan step argument matching', () 
     // intentId: createdIntentId }` in aiAgentSdk.ts). Pin the id explicitly
     // rather than loosening to objectContaining, so a future regression
     // that drops intentId on this path still fails here.
-    expect(result).toEqual({ allowed: true, intentId: 'intent-1' });
+    // #5645: a won inline release also carries the intent's decision record.
+    expect(result).toEqual({
+      allowed: true, intentId: 'intent-1',
+      context: { releaseDecision: { approvalScope: 'four_eyes', decidedVia: 'session_tap' } },
+    });
     // Falls through to per-step approval: inserts 'pending' and blocks on approval.
     expect(values).toHaveBeenCalledWith(expect.objectContaining({
       toolName: 'execute_command',

--- a/apps/api/src/services/aiAgentSdk.test.ts
+++ b/apps/api/src/services/aiAgentSdk.test.ts
@@ -1,4 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// #5645: every inline release hands the handler the released intent's decision
+// record (`approvalScope` + `decidedVia`) on the execution context — the same
+// bag the durable worker builds. The default mocked intent row below carries
+// this record, so the terminal return of a won release is asserted against it.
+const RELEASED_INTENT_DECISION = { approvalScope: 'four_eyes', decidedVia: 'session_tap' } as const;
+const RELEASED_CONTEXT = { releaseDecision: RELEASED_INTENT_DECISION };
 import { createSessionPostToolUse, createSessionPreToolUse, runPreFlightChecks, safeParseJson } from './aiAgentSdk';
 import { db } from '../db';
 import { checkGuardrails, checkToolPermission, checkToolRateLimit } from './aiGuardrails';
@@ -918,7 +925,7 @@ describe('createSessionPreToolUse', () => {
       const selectChain: Record<string, unknown> = {
         from: vi.fn(() => selectChain),
         where: vi.fn(() => selectChain),
-        limit: vi.fn(async () => [{ id: 'intent', boundArgumentDigest: 'digest' }]),
+        limit: vi.fn(async () => [{ id: 'intent', boundArgumentDigest: 'digest', ...RELEASED_INTENT_DECISION }]),
       };
       vi.mocked(db.select).mockReturnValue(selectChain as any);
     });
@@ -1128,7 +1135,7 @@ describe('createSessionPreToolUse', () => {
       // The tier-3 branch now threads the created intent id back on the
       // terminal return (Task 6) — this is what lets postToolUse seal
       // against the right intent without relying solely on the WeakMap.
-      expect(result).toEqual({ allowed: true, intentId: 'intent-2' });
+      expect(result).toEqual({ allowed: true, intentId: 'intent-2', context: RELEASED_CONTEXT });
       expect(mockTransitionIntent).toHaveBeenCalledWith('intent-2', 'approved', 'executing', expect.objectContaining({ executedAt: null, executionStartedAt: expect.any(Date) }), { requireNotExpired: 'release' });
       // ai_tool_executions ledger row marked executing (the inline path today's UX).
       expect(mockSet).toHaveBeenCalledWith({ status: 'executing' });
@@ -1267,7 +1274,7 @@ describe('createSessionPreToolUse', () => {
       const session = makeActiveSession({ approvalMode: 'per_step' });
 
       const preResult = await createSessionPreToolUse(session)('execute_command', {});
-      expect(preResult).toEqual({ allowed: true, intentId: 'intent-6' });
+      expect(preResult).toEqual({ allowed: true, intentId: 'intent-6', context: RELEASED_CONTEXT });
 
       mockTransitionIntent.mockClear();
       const postToolUse = createSessionPostToolUse(session);
@@ -1319,7 +1326,7 @@ describe('createSessionPreToolUse', () => {
       const session = makeActiveSession({ approvalMode: 'per_step' });
 
       const pre = await createSessionPreToolUse(session)('execute_command', {});
-      expect(pre).toEqual({ allowed: true, intentId: opts.intentId });
+      expect(pre).toEqual({ allowed: true, intentId: opts.intentId, context: RELEASED_CONTEXT });
 
       // Only the TERMINAL CAS loses.
       mockTransitionIntent.mockClear();
@@ -1428,7 +1435,7 @@ describe('createSessionPreToolUse', () => {
       const session = makeActiveSession({ approvalMode: 'per_step', auditSnapshot: {} });
 
       const pre = await createSessionPreToolUse(session)('execute_command', { deviceId: 'd-1' });
-      expect(pre).toEqual({ allowed: true, intentId: opts.intentId });
+      expect(pre).toEqual({ allowed: true, intentId: opts.intentId, context: RELEASED_CONTEXT });
 
       await createSessionPostToolUse(session)(
         'execute_command',
@@ -1524,7 +1531,7 @@ describe('createSessionPreToolUse', () => {
       const session = makeActiveSession({ approvalMode: 'per_step' });
 
       const preResult = await createSessionPreToolUse(session)('execute_command', {});
-      expect(preResult).toEqual({ allowed: true, intentId: 'intent-7' });
+      expect(preResult).toEqual({ allowed: true, intentId: 'intent-7', context: RELEASED_CONTEXT });
 
       mockTransitionIntent.mockClear();
       const postToolUse = createSessionPostToolUse(session);
@@ -2466,7 +2473,7 @@ describe('inline secret-bearing completion (Task 6)', () => {
     const selectChain: Record<string, unknown> = {
       from: vi.fn(() => selectChain),
       where: vi.fn(() => selectChain),
-      limit: vi.fn(async () => [{ id: 'intent-legacy', boundArgumentDigest: 'digest' }]),
+      limit: vi.fn(async () => [{ id: 'intent-legacy', boundArgumentDigest: 'digest', ...RELEASED_INTENT_DECISION }]),
     };
     vi.mocked(db.select).mockReturnValue(selectChain as any);
     mockInsertReturning({ id: 'exec-legacy' });
@@ -2480,7 +2487,7 @@ describe('inline secret-bearing completion (Task 6)', () => {
 
     // Proves the tier-3 branch genuinely ran (created a real intent and won
     // the release CAS) rather than being refused as an unknown tool.
-    expect(preResult).toEqual({ allowed: true, intentId: 'intent-legacy' });
+    expect(preResult).toEqual({ allowed: true, intentId: 'intent-legacy', context: RELEASED_CONTEXT });
     expect(mockCreateActionIntent).toHaveBeenCalled();
 
     mockTransitionIntent.mockClear();
@@ -2951,7 +2958,7 @@ describe('Task 2: plan index advances only once the step is authorized', () => {
     const selectChain: Record<string, unknown> = {
       from: vi.fn(() => selectChain),
       where: vi.fn(() => selectChain),
-      limit: vi.fn(async () => [{ id: 'intent', boundArgumentDigest: 'digest' }]),
+      limit: vi.fn(async () => [{ id: 'intent', boundArgumentDigest: 'digest', ...RELEASED_INTENT_DECISION }]),
     };
     vi.mocked(db.select).mockReturnValue(selectChain as any);
     vi.mocked(db.update).mockReturnValue({
@@ -2980,7 +2987,7 @@ describe('Task 2: plan index advances only once the step is authorized', () => {
 
     const result = await createSessionPreToolUse(session)('execute_command', { command: 'whoami' });
 
-    expect(result).toEqual({ allowed: true, intentId: 'intent-plan-adv' });
+    expect(result).toEqual({ allowed: true, intentId: 'intent-plan-adv', context: RELEASED_CONTEXT });
     expect(session.currentPlanStepIndex).toBe(1);
     expect(session.eventBus.publish).toHaveBeenCalledWith(expect.objectContaining({
       type: 'plan_step_start',
@@ -3419,6 +3426,8 @@ describe('Task 2: plan index advances only once the step is authorized', () => {
           actionName: 'execute_command',
           arguments: { command: 'whoami' },
           effectDigest: null,
+          approvalScope: 'supervised',
+          decidedVia: 'session_tap',
         },
       ]),
     };
@@ -3431,12 +3440,17 @@ describe('Task 2: plan index advances only once the step is authorized', () => {
 
     const result = await createSessionPreToolUse(session)('execute_command', { command: 'whoami' });
 
-    expect(result).toEqual({ allowed: true, intentId: 'intent-plan-digest-null' });
+    // #5645: the inline release, like the durable worker, ALWAYS hands the
+    // handler the released intent's decision record (approval_method is
+    // derived from it) — but nothing was verified, so no verified material.
+    expect(result).toEqual({
+      allowed: true,
+      intentId: 'intent-plan-digest-null',
+      context: { releaseDecision: { approvalScope: 'supervised', decidedVia: 'session_tap' } },
+    });
     expect(session.currentPlanStepIndex).toBe(1);
     expect(mockComputeEffectDigest).not.toHaveBeenCalled();
-    // Nothing was verified, so nothing is handed to the handler — the
-    // no-context path must stay byte-identical for every unpinned tool call.
-    expect((result as { context?: unknown }).context).toBeUndefined();
+    expect((result as { context?: { verifiedRunScript?: unknown } }).context?.verifiedRunScript).toBeUndefined();
     // No content_changed CAS — only the approved -> executing CAS ran.
     expect(mockTransitionIntent).not.toHaveBeenCalledWith(
       expect.anything(),
@@ -3474,6 +3488,8 @@ describe('Task 2: plan index advances only once the step is authorized', () => {
           actionName: 'execute_command',
           arguments: { command: 'whoami' },
           effectDigest: 'stored-digest-abc',
+          approvalScope: 'four_eyes',
+          decidedVia: 'webauthn_platform',
         },
       ]),
     };
@@ -3500,6 +3516,9 @@ describe('Task 2: plan index advances only once the step is authorized', () => {
     // resolved, so a re-read cannot masquerade as the verified one.
     expect((result as { context?: { verifiedRunScript?: unknown } }).context?.verifiedRunScript)
       .toBe(verifiedRunScript);
+    // #5645: the decision record rides ALONGSIDE the verified material.
+    expect((result as { context?: { releaseDecision?: unknown } }).context?.releaseDecision)
+      .toEqual({ approvalScope: 'four_eyes', decidedVia: 'webauthn_platform' });
   });
 
   // Regression guards restored from PR #2853. Task 1 necessarily inverted the
@@ -3531,7 +3550,7 @@ describe('Task 2: plan index advances only once the step is authorized', () => {
     // Step 0: effective tier 3 — goes through the durable intent, wins the
     // release CAS, and is authorized. The index must land on 1.
     const first = await createSessionPreToolUse(session)('execute_command', { command: 'whoami' });
-    expect(first).toEqual({ allowed: true, intentId: 'intent-plan-seq-0' });
+    expect(first).toEqual({ allowed: true, intentId: 'intent-plan-seq-0', context: RELEASED_CONTEXT });
     expect(session.currentPlanStepIndex).toBe(1);
 
     // Step 1: effective tier 2, non-secret — eligible for the plan shortcut.
@@ -3583,7 +3602,7 @@ describe('Task 2: plan index advances only once the step is authorized', () => {
     });
 
     const preResult = await createSessionPreToolUse(session)('execute_command', { command: 'whoami' });
-    expect(preResult).toEqual({ allowed: true, intentId: 'intent-plan-end' });
+    expect(preResult).toEqual({ allowed: true, intentId: 'intent-plan-end', context: RELEASED_CONTEXT });
     expect(session.currentPlanStepIndex).toBe(1);
 
     mockTransitionIntent.mockClear();
@@ -3639,7 +3658,7 @@ describe('Task 3: a plan aborts when a tier-3 step does not execute', () => {
     const selectChain: Record<string, unknown> = {
       from: vi.fn(() => selectChain),
       where: vi.fn(() => selectChain),
-      limit: vi.fn(async () => [{ id: 'intent', boundArgumentDigest: 'digest' }]),
+      limit: vi.fn(async () => [{ id: 'intent', boundArgumentDigest: 'digest', ...RELEASED_INTENT_DECISION }]),
     };
     vi.mocked(db.select).mockReturnValue(selectChain as any);
     vi.mocked(db.update).mockReturnValue({

--- a/apps/api/src/services/aiAgentSdk.ts
+++ b/apps/api/src/services/aiAgentSdk.ts
@@ -1609,6 +1609,17 @@ export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallb
             });
           }
 
+          // #5645 — the handler gets the released intent's decision record
+          // alongside the verified material, exactly as the durable worker
+          // passes it (jobs/intentReleaseWorker.ts): `run_script`'s proposal
+          // branch derives the execution row's spec §4.1 `approval_method`
+          // from it. Unconditional for the same reason `actionIntentId` is
+          // (see toolExecutionContext.ts).
+          verifiedToolContext = {
+            ...verifiedToolContext,
+            releaseDecision: { approvalScope: intentRow.approvalScope, decidedVia: intentRow.decidedVia ?? null },
+          };
+
           // Won the release: track the intent id so createSessionPostToolUse can
           // CAS it executing -> completed|failed once the inline tool call
           // actually finishes (see pendingIntentBySession above).

--- a/apps/api/src/services/aiToolsScripts.runScript.proposal.test.ts
+++ b/apps/api/src/services/aiToolsScripts.runScript.proposal.test.ts
@@ -10,7 +10,10 @@ const { flagMock, runnableMock, dispatchMock, accessMock, waitMock, transitionMo
 }));
 
 vi.mock('../config/env', () => ({ aiScriptAuthoringEnabled: flagMock }));
-vi.mock('./scriptProposals', () => ({
+vi.mock('./scriptProposals', async () => ({
+  // The derivation itself is real (approvalMethod.test.ts pins it per value);
+  // this suite proves the handler feeds it the context's decision record.
+  approvalMethodForRelease: (await import('./scriptProposals/approvalMethod')).approvalMethodForRelease,
   assertProposalRunnable: runnableMock,
   proposalDispatchSnapshot: () => ({ proposalId: 'p1', deviceIds: ['d1'] }),
   transitionProposal: transitionMock,
@@ -59,7 +62,8 @@ describe('run_script proposal branch', () => {
     expect(dispatchMock).toHaveBeenCalledTimes(1);
     const dispatchInput = (dispatchMock.mock.calls as unknown as Array<[Record<string, unknown>]>)[0]![0];
     expect((dispatchInput.source as { kind: string }).kind).toBe('proposal');
-    expect((dispatchInput.provenance as { approvalMethod: string }).approvalMethod).toBe('supervised_self');
+    // #5645: no release decision on the context → no method is invented.
+    expect((dispatchInput.provenance as { approvalMethod: string | null }).approvalMethod).toBeNull();
     expect((dispatchInput.offlinePolicy as { kind: string }).kind).toBe('reject');
     expect(out.proposalId).toBe('p1');
     expect(out.results.d1.executionId).toBe('e1');
@@ -103,5 +107,38 @@ describe('run_script proposal branch', () => {
     await __testOnly.runScriptHandler({ proposalId: 'p1', deviceIds: ['d1', 'd1'] }, auth);
     expect(dispatchMock).toHaveBeenCalledTimes(2);
     expect(transitionMock).toHaveBeenCalledTimes(1);
+  });
+
+  // #5645: `approval_method` is the spec §4.1 provenance snapshot; it is
+  // derived from the releasing intent's decision record (§4.6), never a
+  // constant. One case per method value.
+  describe('approval_method derived from the release decision', () => {
+    const proposal = { id: 'p1', language: 'powershell', runAs: 'system', timeoutSeconds: 300, contentDigest: 'a'.repeat(64), riskTier: 'low' };
+    const methodOf = () =>
+      ((dispatchMock.mock.calls as unknown as Array<[Record<string, unknown>]>)[0]![0].provenance as { approvalMethod: string | null }).approvalMethod;
+
+    it('unattended_reviewer_gated when the intent was decided by the script reviewer', async () => {
+      runnableMock.mockResolvedValueOnce({ ok: true, proposal } as never);
+      await __testOnly.runScriptHandler({ proposalId: 'p1', deviceIds: ['d1'] }, auth, {
+        actionIntentId: 'i1', releaseDecision: { approvalScope: 'supervised', decidedVia: 'script_reviewer' },
+      });
+      expect(methodOf()).toBe('unattended_reviewer_gated');
+    });
+
+    it('supervised_self when a supervised intent was decided by its requester', async () => {
+      runnableMock.mockResolvedValueOnce({ ok: true, proposal } as never);
+      await __testOnly.runScriptHandler({ proposalId: 'p1', deviceIds: ['d1'] }, auth, {
+        actionIntentId: 'i1', releaseDecision: { approvalScope: 'supervised', decidedVia: 'session_tap' },
+      });
+      expect(methodOf()).toBe('supervised_self');
+    });
+
+    it('four_eyes when a four_eyes intent was decided by a second approver', async () => {
+      runnableMock.mockResolvedValueOnce({ ok: true, proposal } as never);
+      await __testOnly.runScriptHandler({ proposalId: 'p1', deviceIds: ['d1'] }, auth, {
+        actionIntentId: 'i1', releaseDecision: { approvalScope: 'four_eyes', decidedVia: 'webauthn_platform' },
+      });
+      expect(methodOf()).toBe('four_eyes');
+    });
   });
 });

--- a/apps/api/src/services/aiToolsScripts.ts
+++ b/apps/api/src/services/aiToolsScripts.ts
@@ -35,7 +35,7 @@ import type { AiTool } from './aiTools';
 import type { CancelOutcome } from './scriptCancellation';
 import type { ToolExecutionContext, VerifiedRunScript } from './toolExecutionContext';
 import { dispatchScriptToDevice } from './scriptDispatch';
-import { assertProposalRunnable, proposalDispatchSnapshot, transitionProposal } from './scriptProposals';
+import { approvalMethodForRelease, assertProposalRunnable, proposalDispatchSnapshot, transitionProposal } from './scriptProposals';
 import { aiScriptAuthoringEnabled } from '../config/env';
 import { executeScriptSchema, AI_RUN_CONTEXT_JSON_SCHEMA_PROPERTIES } from './scriptRunRequest';
 import { loadTenantVariableScope } from './tenantVariableResolution';
@@ -242,6 +242,19 @@ const runScriptHandler: AiTool['handler'] = async (input, auth, context) => {
       return JSON.stringify({ error: `proposal_not_runnable: ${runnable.reason}`, proposalId: input.proposalId });
     }
     const snapshot = proposalDispatchSnapshot(runnable.proposal, proposalDeviceIds);
+    // #5645 — spec §4.1 `approval_method` is DERIVED from the releasing
+    // intent's decision record (§4.6), which both release paths put on the
+    // context next to `actionIntentId`. Resolved once per call, never per
+    // device, and never a constant: a call that carries no release decision
+    // has nothing to attribute the run to, so the row records null rather
+    // than a guess (the W06 "unattended runs" metric and the audit row read
+    // this column).
+    const approvalMethod = context?.releaseDecision ? approvalMethodForRelease(context.releaseDecision) : null;
+    if (approvalMethod === null) {
+      console.warn('[aiToolsScripts] run_script proposal dispatch without a release decision — approval_method left null', {
+        proposalId: input.proposalId, actionIntentId: context?.actionIntentId ?? null,
+      });
+    }
     const proposalResults: Record<string, unknown> = {};
     let markedExecuted = false;
     // Same cap and same wait as the library path below — a proposal is not a
@@ -262,7 +275,7 @@ const runScriptHandler: AiTool['handler'] = async (input, auth, context) => {
             offlinePolicy: { kind: 'reject' },
             provenance: {
               approvedBy: auth.user.id,
-              approvalMethod: 'supervised_self',
+              approvalMethod,
               reviewRiskTier: runnable.proposal.riskTier,
             },
           })));

--- a/apps/api/src/services/aiToolsScripts.ts
+++ b/apps/api/src/services/aiToolsScripts.ts
@@ -251,8 +251,15 @@ const runScriptHandler: AiTool['handler'] = async (input, auth, context) => {
     // this column).
     const approvalMethod = context?.releaseDecision ? approvalMethodForRelease(context.releaseDecision) : null;
     if (approvalMethod === null) {
+      // Unreachable while run_script stays Tier 3 (every proposal run IS an
+      // intent release, and both release paths attach the record). Reaching
+      // it means that invariant broke — reported, not just logged, because
+      // the row this leaves behind is exactly the audit gap #5645 closed.
       console.warn('[aiToolsScripts] run_script proposal dispatch without a release decision — approval_method left null', {
         proposalId: input.proposalId, actionIntentId: context?.actionIntentId ?? null,
+      });
+      captureException(new Error('run_script proposal dispatch without a release decision'), undefined, {
+        area: 'script_proposal_release_decision_missing',
       });
     }
     const proposalResults: Record<string, unknown> = {};

--- a/apps/api/src/services/scriptProposals/approvalMethod.test.ts
+++ b/apps/api/src/services/scriptProposals/approvalMethod.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { approvalMethodForRelease } from './approvalMethod';
+
+/**
+ * #5645 — the execution row's `approval_method` (spec §4.1) is DERIVED from the
+ * releasing intent's decision record (§4.6), one case per method value.
+ */
+describe('approvalMethodForRelease', () => {
+  it('a script_reviewer-decided intent is unattended_reviewer_gated, whatever its scope says', () => {
+    expect(approvalMethodForRelease({ approvalScope: 'supervised', decidedVia: 'script_reviewer' }))
+      .toBe('unattended_reviewer_gated');
+    expect(approvalMethodForRelease({ approvalScope: 'four_eyes', decidedVia: 'script_reviewer' }))
+      .toBe('unattended_reviewer_gated');
+  });
+
+  it('a supervised intent decided by a human is supervised_self', () => {
+    expect(approvalMethodForRelease({ approvalScope: 'supervised', decidedVia: 'session_tap' })).toBe('supervised_self');
+    expect(approvalMethodForRelease({ approvalScope: 'supervised', decidedVia: null })).toBe('supervised_self');
+  });
+
+  it('a four_eyes intent decided by a human is four_eyes', () => {
+    expect(approvalMethodForRelease({ approvalScope: 'four_eyes', decidedVia: 'webauthn_platform' })).toBe('four_eyes');
+    expect(approvalMethodForRelease({ approvalScope: 'four_eyes', decidedVia: null })).toBe('four_eyes');
+  });
+});

--- a/apps/api/src/services/scriptProposals/approvalMethod.ts
+++ b/apps/api/src/services/scriptProposals/approvalMethod.ts
@@ -1,0 +1,31 @@
+import type { AiApprovalScope, ScriptApprovalMethod } from '@breeze/shared';
+
+/**
+ * The part of a released `action_intents` row that determines HOW a
+ * proposal-backed run was authorised (spec §4.6 decision record). Carried to
+ * the `run_script` handler on `ToolExecutionContext.releaseDecision` by both
+ * release paths (jobs/intentReleaseWorker.ts, services/aiAgentSdk.ts).
+ */
+export interface ReleaseDecision {
+  approvalScope: AiApprovalScope;
+  decidedVia: string | null;
+}
+
+/**
+ * Spec §4.1 — the `approval_method` provenance value for a run released by
+ * `intent` (#5645). Derived, never a constant:
+ *
+ *  - `decided_via = 'script_reviewer'` → `unattended_reviewer_gated`: the lane's
+ *    reviewer decided it, whatever scope the classifier assigned (the lane only
+ *    admits supervised intents today, but the decision record is the truth);
+ *  - otherwise the intent's scope: `supervised` → `supervised_self` (the
+ *    requester decided their own intent), `four_eyes` → `four_eyes`.
+ *
+ * The W06 risk dashboard's "unattended runs" metric, the device-activity audit
+ * row and the library provenance panel all read the stored value, so a wrong
+ * constant here is a wrong audit trail — the bug this replaces.
+ */
+export function approvalMethodForRelease(intent: ReleaseDecision): ScriptApprovalMethod {
+  if (intent.decidedVia === 'script_reviewer') return 'unattended_reviewer_gated';
+  return intent.approvalScope === 'supervised' ? 'supervised_self' : 'four_eyes';
+}

--- a/apps/api/src/services/scriptProposals/index.ts
+++ b/apps/api/src/services/scriptProposals/index.ts
@@ -6,6 +6,7 @@ export * from './proposals';
 export * from './runnable';
 export * from './guardrailContext';
 export * from './dispatchSnapshot';
+export * from './approvalMethod';
 export * from './reviewQueue';
 export * from './intentLink';
 export { resolveEffectiveScriptPolicy, mergeScriptPolicies, SCRIPT_POLICY_DEFAULTS, type EffectiveScriptPolicy } from './policy';

--- a/apps/api/src/services/scriptProposals/promote.test.ts
+++ b/apps/api/src/services/scriptProposals/promote.test.ts
@@ -7,6 +7,8 @@ vi.mock('../scriptWrite', async (importOriginal) => ({
   insertScriptRow: (...a: unknown[]) => insertScriptRow(...a),
 }));
 vi.mock('./proposals', () => ({ transitionProposal: (...a: unknown[]) => transitionProposal(...a) }));
+const loadProposalRunApprovalMethod = vi.fn();
+vi.mock('./queries', () => ({ loadProposalRunApprovalMethod: (...a: unknown[]) => loadProposalRunApprovalMethod(...a) }));
 const TX = { __tx: true };
 vi.mock('../../db', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../db')>()),
@@ -37,6 +39,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   insertScriptRow.mockResolvedValue({ id: 'script-1', version: 1, headVersionId: 'ver-1' });
   transitionProposal.mockResolvedValue(true);
+  loadProposalRunApprovalMethod.mockResolvedValue('supervised_self');
 });
 
 describe('promoteProposalToLibrary', () => {
@@ -70,7 +73,7 @@ describe('promoteProposalToLibrary', () => {
         securityAcknowledgedBy: APPROVER,
         provenance: expect.objectContaining({
           origin: 'ai_proposal', proposalId: baseProposal.id, reviewId: 'r1', reviewedAt: review.createdAt,
-          approvedBy: APPROVER, approvedAt: baseProposal.decidedAt, approvalMethod: expect.any(String), createdBy: USER,
+          approvedBy: APPROVER, approvedAt: baseProposal.decidedAt, approvalMethod: 'supervised_self', createdBy: USER,
         }),
       }),
     );
@@ -122,5 +125,36 @@ describe('promoteProposalToLibrary', () => {
     expect(insertScriptRow).toHaveBeenCalledWith(
       expect.anything(), { orgId: ORG, partnerId: 'p1' }, expect.anything(), expect.anything(),
     );
+  });
+
+  // #5645: the promoted version carries the RUN's method (the execution row
+  // the verification was proved against), never a constant.
+  describe('approvalMethod is copied from the verified run', () => {
+    for (const method of ['supervised_self', 'four_eyes', 'unattended_reviewer_gated'] as const) {
+      it(`carries ${method}`, async () => {
+        loadProposalRunApprovalMethod.mockResolvedValueOnce(method);
+        await promoteProposalToLibrary({
+          auth: auth('organization'), proposal: baseProposal as never, review,
+          input: { name: 'Restart spooler', ownerScope: 'organization' },
+        });
+        expect(loadProposalRunApprovalMethod).toHaveBeenCalledWith(baseProposal.id, ORG);
+        expect(insertScriptRow).toHaveBeenCalledWith(
+          expect.anything(), expect.anything(), expect.anything(),
+          expect.objectContaining({ provenance: expect.objectContaining({ approvalMethod: method }) }),
+        );
+      });
+    }
+
+    it('stamps null — not a guess — when the run left no method behind', async () => {
+      loadProposalRunApprovalMethod.mockResolvedValueOnce(null);
+      await promoteProposalToLibrary({
+        auth: auth('organization'), proposal: baseProposal as never, review,
+        input: { name: 'Restart spooler', ownerScope: 'organization' },
+      });
+      expect(insertScriptRow).toHaveBeenCalledWith(
+        expect.anything(), expect.anything(), expect.anything(),
+        expect.objectContaining({ provenance: expect.objectContaining({ approvalMethod: null }) }),
+      );
+    });
   });
 });

--- a/apps/api/src/services/scriptProposals/promote.ts
+++ b/apps/api/src/services/scriptProposals/promote.ts
@@ -3,6 +3,7 @@ import type { AuthContext } from '../../middleware/auth';
 import type { ScriptProposalPromoteInput } from '@breeze/shared';
 import { insertScriptRow, resolveScriptCreateScope, isScriptScopeError } from '../scriptWrite';
 import { transitionProposal } from './proposals';
+import { loadProposalRunApprovalMethod } from './queries';
 
 export interface PromotableProposal {
   id: string;
@@ -63,6 +64,12 @@ export async function promoteProposalToLibrary(args: {
 
   const approver = proposal.decidedBy ?? auth.user.id;
   const approvedAt = proposal.decidedAt ?? new Date();
+  // #5645 — the version's method is the RUN's method: `verified` was proved
+  // against an execution row the release stamped (spec §4.1), so promotion
+  // copies it rather than asserting one. Read BEFORE the transaction opens:
+  // the loader takes its own system-scope connection, and holding it inside
+  // `db.transaction` would double-hold the pool.
+  const approvalMethod = await loadProposalRunApprovalMethod(proposal.id, proposal.orgId);
 
   return db.transaction(async (tx): Promise<PromoteResult> => {
     const claimed = await transitionProposal(tx, proposal.id, ['verified'], 'promoted', {});
@@ -91,10 +98,7 @@ export async function promoteProposalToLibrary(args: {
           reviewedAt: review?.createdAt ?? null,
           approvedBy: approver,
           approvedAt,
-          // Supervised-vs-four_eyes is the intent's property; the proposal-side
-          // record keeps the coarse value the version panel renders. W04 widens
-          // this to 'unattended_reviewer_gated'.
-          approvalMethod: 'four_eyes',
+          approvalMethod,
           changelog: `Promoted from AI proposal ${proposal.id}`,
           createdBy: auth.user.id,
         },

--- a/apps/api/src/services/scriptProposals/promote.ts
+++ b/apps/api/src/services/scriptProposals/promote.ts
@@ -70,6 +70,14 @@ export async function promoteProposalToLibrary(args: {
   // the loader takes its own system-scope connection, and holding it inside
   // `db.transaction` would double-hold the pool.
   const approvalMethod = await loadProposalRunApprovalMethod(proposal.id, proposal.orgId);
+  if (approvalMethod === null) {
+    // Recorded at the point the gap becomes permanent: promotion can happen
+    // long after the run, so this is the only line that ties the version's
+    // missing method back to its proposal.
+    console.warn('[scriptProposals] promoting a proposal whose run carries no approval_method', {
+      proposalId: proposal.id, orgId: proposal.orgId,
+    });
+  }
 
   return db.transaction(async (tx): Promise<PromoteResult> => {
     const claimed = await transitionProposal(tx, proposal.id, ['verified'], 'promoted', {});

--- a/apps/api/src/services/scriptProposals/queries.ts
+++ b/apps/api/src/services/scriptProposals/queries.ts
@@ -1,4 +1,5 @@
 import { and, desc, eq, inArray } from 'drizzle-orm';
+import type { ScriptApprovalMethod } from '@breeze/shared';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';
 import { scriptProposals, scriptProposalReviews, type ScriptProposalRow } from '../../db/schema/scriptProposals';
 import { scriptExecutions } from '../../db/schema/scripts';
@@ -56,6 +57,31 @@ export async function loadProposalExecutions(proposalId: string) {
         .where(eq(scriptExecutions.proposalId, proposalId))
         .orderBy(desc(scriptExecutions.startedAt)),
     ),
+  );
+}
+
+/**
+ * #5645 — the `approval_method` the release stamped on this proposal's run
+ * (spec §4.1), for `promoteProposalToLibrary` to carry onto the promoted
+ * version. Every execution of one proposal comes from the same release (the
+ * proposal is single-consumption), so the newest row is representative.
+ * `null` when no execution carries one — the caller stores that as-is rather
+ * than inventing a method.
+ */
+export async function loadProposalRunApprovalMethod(
+  proposalId: string,
+  orgId: string,
+): Promise<ScriptApprovalMethod | null> {
+  return runOutsideDbContext(() =>
+    withSystemDbAccessContext(async () => {
+      const [row] = await db
+        .select({ approvalMethod: scriptExecutions.approvalMethod })
+        .from(scriptExecutions)
+        .where(and(eq(scriptExecutions.proposalId, proposalId), eq(scriptExecutions.orgId, orgId)))
+        .orderBy(desc(scriptExecutions.createdAt))
+        .limit(1);
+      return row?.approvalMethod ?? null;
+    }),
   );
 }
 

--- a/apps/api/src/services/scriptProposals/queries.ts
+++ b/apps/api/src/services/scriptProposals/queries.ts
@@ -80,6 +80,13 @@ export async function loadProposalRunApprovalMethod(
         .where(and(eq(scriptExecutions.proposalId, proposalId), eq(scriptExecutions.orgId, orgId)))
         .orderBy(desc(scriptExecutions.createdAt))
         .limit(1);
+      if (!row) {
+        // A `verified` proposal was proved against an execution row, so no
+        // row at all is an invariant break (orphaned proposal, or an org
+        // mismatch hiding the real row) — distinct from a row whose method
+        // is genuinely null, and worth telling apart in the logs.
+        console.warn('[scriptProposals] no execution row found for a promotable proposal', { proposalId, orgId });
+      }
       return row?.approvalMethod ?? null;
     }),
   );

--- a/apps/api/src/services/toolExecutionContext.ts
+++ b/apps/api/src/services/toolExecutionContext.ts
@@ -1,3 +1,4 @@
+import type { ReleaseDecision } from './scriptProposals/approvalMethod';
 import type { scripts } from '../db/schema';
 import type { RunScriptSnapshot } from './actionIntents/runScriptSnapshot';
 import type { TenantVariableScope } from './tenantVariableResolution';
@@ -89,4 +90,17 @@ export type ToolExecutionContext = {
    * writing anything.
    */
   actionIntentId?: string;
+  /**
+   * The released intent's decision record — set by the SAME two release
+   * paths that set `actionIntentId`, from the intent row they already hold,
+   * and by nothing else (#5645). `run_script`'s proposal branch derives the
+   * execution row's `approval_method` (spec §4.1) from it via
+   * `approvalMethodForRelease`; a handler that finds it absent has no
+   * release to attribute the run to and must not invent a method.
+   *
+   * Passed alongside `actionIntentId` unconditionally for the reason that
+   * field is: structurally unobservable to every handler that does not read
+   * it, and a tool-name gate would have to be edited by the next consumer.
+   */
+  releaseDecision?: ReleaseDecision;
 };


### PR DESCRIPTION
## Root cause

`script_executions.approval_method` (spec §4.1 provenance snapshot) was a **constant** at both sites the issue names:

- `apps/api/src/services/aiToolsScripts.ts` — `run_script { proposalId }` stamped `approvalMethod: 'supervised_self'` on every proposal-backed execution, regardless of how the releasing intent was decided.
- `apps/api/src/services/scriptProposals/promote.ts` — the promoted version was stamped `approvalMethod: 'four_eyes'` unconditionally.

So four-eyes and reviewer-gated lane runs were misattributed, the W06 risk-dashboard "unattended runs" metric and the device-activity audit row read 0/wrong, and the library provenance panel showed "four-eyes" for supervised runs.

## Fix

- **`scriptProposals/approvalMethod.ts`** (new): `approvalMethodForRelease({ approvalScope, decidedVia })` — `decided_via = 'script_reviewer'` → `unattended_reviewer_gated`; else `supervised` → `supervised_self`, `four_eyes` → `four_eyes` (spec §4.1 / §4.6).
- **`ToolExecutionContext.releaseDecision`**: both release paths — the durable worker (`jobs/intentReleaseWorker.ts`) and the inline chat release (`services/aiAgentSdk.ts`) — put the released intent's decision record on the context next to `actionIntentId`, from the intent row they already hold (no re-query). Passed unconditionally for the same reason `actionIntentId` is.
- **`aiToolsScripts.ts`**: derives the method once per call from `context.releaseDecision` and threads it through dispatch `provenance` to the execution row. Without a release decision the row records `null` (with a warn log) — never a guess.
- **`promote.ts`**: copies the verified run's stored method via `loadProposalRunApprovalMethod` (newest `script_executions` row for the proposal, org-scoped), read before the transaction opens so it never double-holds the pool.
- `ProposalDispatchSnapshot` is left as-is: it is the pinned effect material (lifecycle/decision fields deliberately excluded); the method rides on `ScriptDispatchProvenance`, which is what `buildExecutionValues` already writes.

## Tests

- `approvalMethod.test.ts` — one case per method value.
- `aiToolsScripts.runScript.proposal.test.ts` — handler stamps `unattended_reviewer_gated` / `supervised_self` / `four_eyes` from the context, `null` without a decision.
- `promote.test.ts` — promoted version carries the run's method (each value), `null` when none stored.
- `intentReleaseWorker.test.ts` / `aiAgentSdk.test.ts` / `aiAgentSdk.planMatch.test.ts` — both release paths pass `releaseDecision`; lane release carries `decidedVia: 'script_reviewer'`.
- Live DB: `scriptProposalsLifecycle.integration.test.ts` — a reviewer-decided release through the real dispatch path writes `approval_method = 'unattended_reviewer_gated'`; `scriptProposalHumanLoop.integration.test.ts` — promote copies the run's method onto the version (was asserting the `four_eyes` constant).

```
cd apps/api && npx vitest run --pool=threads --maxWorkers=4
  Test Files  2139 passed | 3 skipped (2142)   Tests  40724 passed | 22 skipped (40746)
npx vitest run --config vitest.integration.config.ts src/__tests__/integration/scriptProposalsLifecycle.integration.test.ts src/__tests__/integration/scriptProposalHumanLoop.integration.test.ts   (fresh pnpm test-stack)
  Test Files  2 passed (2)   Tests  10 passed (10)
NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit   → clean
pnpm --filter @breeze/api lint                             → clean
```

Closes #5645

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KcoTnDj9bUJQxz6RqkC9yL
